### PR TITLE
[PHCD-13] ♻️ 단면 인쇄 테스트 추가

### DIFF
--- a/lib/features/core/printer/printer_bindings.dart
+++ b/lib/features/core/printer/printer_bindings.dart
@@ -168,10 +168,10 @@ class PrinterBindings {
 
   // 인쇄 함수
   void printCard({
-    required String frontImageInfo,
+    required String? frontImageInfo,
     String? backImageInfo,
   }) {
-    final frontPointer = frontImageInfo.toNativeUtf8();
+    final frontPointer = frontImageInfo?.toNativeUtf8() ?? nullptr;
     final backPointer = backImageInfo?.toNativeUtf8() ?? nullptr;
     try {
       final result = _printDraw(frontPointer, backPointer);


### PR DESCRIPTION
## 카드 방향 사진

<img width="136" alt="스크린샷 2025-02-18 오전 10 03 44" src="https://github.com/user-attachments/assets/ee6f8edc-9c75-4c33-8c18-2b57b95a074f" />

## 🔧 Changes

- 🏗 **PrinterService 프린트 함수 파라미터 Nullable 처리**
    - front, back 모두 null 일 경우 exception 발생
    - StringBuffer Nullable 처리
    - PrinterBindings 의 printer 함수 파라미터도 모두 nullable 처리

- 🏗 **양면 / 단면 상태에 따라 버튼 활성화**
    - PagePrintProvider로 양면, 단면 상태 확인
    - 단면인 경우 FrontImage만 있어도 버튼 활성화
    - 양면인 경우 FrontImage, BackImage 모두 있어야 활성화

## 🚀 How to Test

1. **주요 테스트 시나리오**
    - 위 스크린샷과 같이 카드 방향을 맞춰 프린터에 넣기
    - Unit Test 화면에서 단면 설정
    - FrontImage 가져오기
    - Print Images 버튼 클릭
2. **예상 결과**
    - 원래 뒷면과 위/아래 방향이 일치하게 프린팅 됐는지 확인