### PR TITLE
[PHCD-14] ♻️ 단면 인쇄 테스트 복원 

### DIFF
--- a/lib/features/move_me/providers/page_print_provider.dart
+++ b/lib/features/move_me/providers/page_print_provider.dart
@@ -1,0 +1,18 @@
+import 'package:riverpod_annotation/riverpod_annotation.dart';
+
+part 'page_print_provider.g.dart';
+
+@Riverpod(keepAlive: true)
+class PagePrint extends _$PagePrint {
+  @override
+  PagePrintType build() => PagePrintType.double;
+
+  void switchType() {
+    state = state == PagePrintType.double ? PagePrintType.single : PagePrintType.double;
+  }
+}
+
+enum PagePrintType {
+  single, // 양면 인쇄
+  double // 단면 인쇄
+}

--- a/lib/features/move_me/screens/unit_test_screen.dart
+++ b/lib/features/move_me/screens/unit_test_screen.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_screenutil/flutter_screenutil.dart';
+import 'package:flutter_snaptag_kiosk/features/move_me/widgets/pager_print_type_toggle.dart';
 import 'package:flutter_snaptag_kiosk/lib.dart';
 import 'package:flutter_svg/svg.dart';
 
@@ -30,6 +31,8 @@ class _UnitTestScreenState extends ConsumerState<UnitTestScreen> {
           mainAxisAlignment: MainAxisAlignment.start,
           crossAxisAlignment: CrossAxisAlignment.start,
           children: [
+            Text('양면 / 단면 설정', style: Theme.of(context).textTheme.headlineSmall),
+            PagerPrintTypeToggle(),
             Text('프론트 이미지', style: Theme.of(context).textTheme.headlineSmall),
             FrontImagesAction(),
             Text('결제 테스트', style: Theme.of(context).textTheme.headlineSmall),

--- a/lib/features/move_me/widgets/pager_print_type_toggle.dart
+++ b/lib/features/move_me/widgets/pager_print_type_toggle.dart
@@ -1,0 +1,27 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_snaptag_kiosk/features/move_me/providers/page_print_provider.dart';
+
+class PagerPrintTypeToggle extends ConsumerWidget {
+  const PagerPrintTypeToggle({super.key});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final isDouble = ref.watch(pagePrintProvider) == PagePrintType.double;
+
+    return ToggleButtons(
+      isSelected: [isDouble, !isDouble],
+      onPressed: (_) => ref.read(pagePrintProvider.notifier).switchType(),
+      children: [
+        Padding(
+          padding: const EdgeInsets.symmetric(horizontal: 16),
+          child: Text("양면"),
+        ),
+        Padding(
+          padding: const EdgeInsets.symmetric(horizontal: 16),
+          child: Text("단면"),
+        ),
+      ],
+    );
+  }
+}


### PR DESCRIPTION
## 🔧 Changes

- 🏗 **제거된 page_print_provider.dart 복구**
    - 양면 / 단면 상태 관리 Provider

- 🏗 **제거된 page_print_type_toggle 복구**
    - 양면 / 단면 Toggle 컴포넌트
    - PagePrintProvider로 상태 관리

## 🚀 How to Test

#9 와 동일.