### PR TITLE
🛠kioskMachineId가 추가된 결제 내역 API 적용

### DIFF
--- a/lib/data/datasources/remote/kiosk_api_client.dart
+++ b/lib/data/datasources/remote/kiosk_api_client.dart
@@ -35,6 +35,7 @@ abstract class KioskApiClient {
   Future<OrderListResponse> getOrders({
     @Query('pageSize') required int pageSize,
     @Query('currentPage') required int currentPage,
+    @Query('kioskMachineId') int? kioskMachineId,
   });
 
   @POST('/v1/order')

--- a/lib/data/models/request/get_orders_request.dart
+++ b/lib/data/models/request/get_orders_request.dart
@@ -8,6 +8,7 @@ class GetOrdersRequest with _$GetOrdersRequest {
   const factory GetOrdersRequest({
     required int pageSize,
     required int currentPage,
+    int? kioskMachineId,
   }) = _GetOrdersRequest;
 
   factory GetOrdersRequest.fromJson(Map<String, dynamic> json) => _$GetOrdersRequestFromJson(json);

--- a/lib/data/repositories/kiosk_repository.dart
+++ b/lib/data/repositories/kiosk_repository.dart
@@ -61,6 +61,7 @@ class _KioskRepository {
       return await _apiClient.getOrders(
         pageSize: request.pageSize,
         currentPage: request.currentPage,
+        kioskMachineId: request.kioskMachineId,
       );
     } catch (e) {
       rethrow;

--- a/lib/features/move_me/providers/payment_history_provider.dart
+++ b/lib/features/move_me/providers/payment_history_provider.dart
@@ -8,11 +8,14 @@ part 'payment_history_provider.g.dart';
 class OrdersPage extends _$OrdersPage {
   final int _pageSize = 20;
   int get kioskEventId => ref.read(kioskInfoServiceProvider)?.kioskEventId ?? 0;
+  int get kioskMachineId => ref.read(kioskInfoServiceProvider)?.kioskMachineId ?? 0;
+
   @override
   Future<OrderListResponse> build({int page = 1}) async {
     final OrderListResponse response = await ref.read(kioskRepositoryProvider).getOrders(GetOrdersRequest(
           pageSize: _pageSize,
           currentPage: page,
+          kioskMachineId: kioskMachineId,
         ));
     logger.i('response: $response');
     return response;
@@ -23,6 +26,7 @@ class OrdersPage extends _$OrdersPage {
     state = await AsyncValue.guard(() => ref.read(kioskRepositoryProvider).getOrders(GetOrdersRequest(
           pageSize: _pageSize,
           currentPage: newPage,
+          kioskMachineId: kioskMachineId,
         )));
   }
 }

--- a/lib/features/move_me/screens/payment_history_screen.dart
+++ b/lib/features/move_me/screens/payment_history_screen.dart
@@ -85,8 +85,6 @@ class _PaymentHistoryScreenState extends ConsumerState<PaymentHistoryScreen> {
                 ),
                 columns: columns,
                 rows: response.list
-                    .where((order) => order.kioskMachineId == ref.read(kioskInfoServiceProvider)?.kioskMachineId)
-                    .toList()
                     .map((order) {
                   return DataRow(
                     color: WidgetStateColor.resolveWith((states) => Colors.white),


### PR DESCRIPTION
Why:
- 기존 API는 기기와 상관없이 모든 결제 내역을 반환, 불필요한 리소스 사용 및 추가 필터링 연산 문제 발생
- 각 키오스크 기기에 맞는 결제 내역만 서버에서 받아와야 필요성 대두
- 기존 방식(클라이언트에서 전체 결제 내역 필터링)은 행 개수가 일정하지 않아 UI 일관성 문제 발생

What:
- `kioskMachineId` 필드가 추가된 API(`/v1/order/list`)를 사용하도록 변경
- 기기별로 필터링된 결제 내역을 보여줘 일관된 행 개수 유지

How:
- `kiosk_api_client`, `kiosk_repository`, `payment_history_provider` 수정
- 기존 클라이언트 측 필터링 로직 제거 (서버에서 필터링된 데이터 수신)

Tags: #api #payment #kiosk