### PR TITLE
🛠서버에서 받은 색상으로 QR 안내 문구 색상 변경

### DIFF
--- a/lib/features/move_me/screens/photo_card_upload_screen.dart
+++ b/lib/features/move_me/screens/photo_card_upload_screen.dart
@@ -11,6 +11,8 @@ class PhotoCardUploadScreen extends ConsumerWidget {
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
+    final kiosk = ref.watch(kioskInfoServiceProvider);
+
     return Column(
       crossAxisAlignment: CrossAxisAlignment.center,
       mainAxisAlignment: MainAxisAlignment.start,
@@ -27,7 +29,7 @@ class PhotoCardUploadScreen extends ConsumerWidget {
         SizedBox(height: 12.h),
         Text(
           LocaleKeys.main_txt_01_03.tr(),
-          style: context.typography.kioskBody2B,
+          style: context.typography.kioskBody2B.copyWith(color: Color(int.parse(kiosk?.couponTextColor.replaceFirst('#', '0xff') ?? '0xffffff'))),
         ),
         SizedBox(height: 30.h),
         Container(


### PR DESCRIPTION
 Why:
 - 기존 QR 안내 문구 (앞면은 랜덤으로 출력됩니다.)의 색상이 고정되어 변경 불가능함

 What:
 - QR 안내 문구 색상을 서버에서 받아온 값(couponTextColor)으로 동적으로 적용 가능하도록 변경

 How:
 - `photo_card_upload_screen`에서 `kioskInfoServiceProvider`의 상태를 watch하여 서버로부터 받은 `couponTextColor`값이 변경될 때 자동으로 반영되도록 수정

Tags: #ui #text-color #kiosk