### PR TITLE
🛠️ 프린트 완료 팝업 2초 후 사라짐으로 개선

### DIFF
--- a/lib/features/move_me/widgets/dialog_helper.dart
+++ b/lib/features/move_me/widgets/dialog_helper.dart
@@ -219,7 +219,7 @@ class DialogHelper {
     BuildContext context, {
     VoidCallback? onButtonPressed,
   }) async {
-    Future.delayed(const Duration(seconds: 3), () {
+    Future.delayed(const Duration(seconds: 2), () {
 
       if (Navigator.of(context, rootNavigator: true).canPop()) {
         PhotoCardUploadRouteData().go(context);


### PR DESCRIPTION
프린트 완료 팝업이 2초 후 자동으로 닫히면서 홈화면으로 이동하도록 개선.

Tags: #ux-improvement