### PR TITLE
Feature/UI block

### DIFF
--- a/lib/features/move_me/screens/payment_history_screen.dart
+++ b/lib/features/move_me/screens/payment_history_screen.dart
@@ -5,6 +5,7 @@ import 'package:flutter_screenutil/flutter_screenutil.dart';
 import 'package:flutter_snaptag_kiosk/core/utils/sound_manager.dart';
 import 'package:flutter_snaptag_kiosk/lib.dart';
 import 'package:flutter_svg/svg.dart';
+import 'package:loader_overlay/loader_overlay.dart';
 
 class PaymentHistoryScreen extends ConsumerStatefulWidget {
   const PaymentHistoryScreen({super.key});
@@ -17,6 +18,11 @@ class _PaymentHistoryScreenState extends ConsumerState<PaymentHistoryScreen> {
   @override
   Widget build(BuildContext context) {
     ref.listen(setupRefundProcessProvider, (prev, next) {
+
+      if (context.loaderOverlay.visible) {
+        context.loaderOverlay.hide();
+      }
+
       next.whenOrNull(
         error: (error, stack) async {
           await DialogHelper.showRefundFailDialog(context);
@@ -299,6 +305,7 @@ class _PaymentHistoryScreenState extends ConsumerState<PaymentHistoryScreen> {
                   confirmButtonText: '환불 진행',
                 );
                 if (result2) {
+                  context.loaderOverlay.show();
                   await ref.read(setupRefundProcessProvider.notifier).startRefund(order);
                 }
               },
@@ -323,8 +330,6 @@ class _PaymentHistoryScreenState extends ConsumerState<PaymentHistoryScreen> {
               ),
               onPressed: () async {
                 await SoundManager().playSound();
-
-                ;
                 final result1 = await DialogHelper.showSetupDialog(
                   context,
                   title: '환불을 진행합니다.',

--- a/lib/features/move_me/screens/payment_history_screen.dart
+++ b/lib/features/move_me/screens/payment_history_screen.dart
@@ -291,6 +291,7 @@ class _PaymentHistoryScreenState extends ConsumerState<PaymentHistoryScreen> {
                 ),
               ),
               onPressed: () async {
+                context.loaderOverlay.show();
                 final result1 = await DialogHelper.showSetupDialog(
                   context,
                   title: '환불을 진행합니다.',
@@ -305,7 +306,6 @@ class _PaymentHistoryScreenState extends ConsumerState<PaymentHistoryScreen> {
                   confirmButtonText: '환불 진행',
                 );
                 if (result2) {
-                  context.loaderOverlay.show();
                   await ref.read(setupRefundProcessProvider.notifier).startRefund(order);
                 }
               },
@@ -329,6 +329,7 @@ class _PaymentHistoryScreenState extends ConsumerState<PaymentHistoryScreen> {
                 ),
               ),
               onPressed: () async {
+                context.loaderOverlay.show();
                 await SoundManager().playSound();
                 final result1 = await DialogHelper.showSetupDialog(
                   context,

--- a/lib/features/move_me/widgets/kiosk_navigator_button.dart
+++ b/lib/features/move_me/widgets/kiosk_navigator_button.dart
@@ -10,9 +10,13 @@ class KioskNavigatorButton extends ConsumerWidget {
   Widget build(BuildContext context, WidgetRef ref) {
 
     final currentPath = GoRouterState.of(context).fullPath;
+    if (currentPath == PrintProcessRouteData().location) {
+      return SizedBox.shrink();
+    }
     if (currentPath != PhotoCardUploadRouteData().location) {
       return const HomeButton();
-    } else {
+    }
+    else {
       return const LanguageSwitcher();
     }
   }


### PR DESCRIPTION
feat: 환불 진행 중 ui-block 기능 추가

why: 환불 중 동일 결제에 대해 중복 환불 요청이 발생하는 문제 방지를 위해

what: 환불 처리 중 UI 인터렉션을 차단하고 인디케이터를 통해 진행 상황임을 안내

how: loader_overlay 패키지를 활용해 환불 로직 실행 시 UI 블로킹 및 해제 처리 구현

Tags: #ui, #refund