### PR TITLE
Isolate 도입 / 프린트 시 GIF 적용

### DIFF
--- a/.metadata
+++ b/.metadata
@@ -4,7 +4,7 @@
 # This file should be version controlled and should not be manually edited.
 
 version:
-  revision: "17025dd88227cd9532c33fa78f5250d548d87e9a"
+  revision: "35c388afb57ef061d06a39b537336c87e0e3d1b1"
   channel: "stable"
 
 project_type: app
@@ -13,23 +13,11 @@ project_type: app
 migration:
   platforms:
     - platform: root
-      create_revision: 17025dd88227cd9532c33fa78f5250d548d87e9a
-      base_revision: 17025dd88227cd9532c33fa78f5250d548d87e9a
-    - platform: android
-      create_revision: 17025dd88227cd9532c33fa78f5250d548d87e9a
-      base_revision: 17025dd88227cd9532c33fa78f5250d548d87e9a
-    - platform: ios
-      create_revision: 17025dd88227cd9532c33fa78f5250d548d87e9a
-      base_revision: 17025dd88227cd9532c33fa78f5250d548d87e9a
-    - platform: macos
-      create_revision: 17025dd88227cd9532c33fa78f5250d548d87e9a
-      base_revision: 17025dd88227cd9532c33fa78f5250d548d87e9a
-    - platform: web
-      create_revision: 17025dd88227cd9532c33fa78f5250d548d87e9a
-      base_revision: 17025dd88227cd9532c33fa78f5250d548d87e9a
+      create_revision: 35c388afb57ef061d06a39b537336c87e0e3d1b1
+      base_revision: 35c388afb57ef061d06a39b537336c87e0e3d1b1
     - platform: windows
-      create_revision: 17025dd88227cd9532c33fa78f5250d548d87e9a
-      base_revision: 17025dd88227cd9532c33fa78f5250d548d87e9a
+      create_revision: 35c388afb57ef061d06a39b537336c87e0e3d1b1
+      base_revision: 35c388afb57ef061d06a39b537336c87e0e3d1b1
 
   # User provided section
 

--- a/README.md
+++ b/README.md
@@ -1,0 +1,16 @@
+# flutter_snaptag_kiosk
+
+A new Flutter project.
+
+## Getting Started
+
+This project is a starting point for a Flutter application.
+
+A few resources to get you started if this is your first Flutter project:
+
+- [Lab: Write your first Flutter app](https://docs.flutter.dev/get-started/codelab)
+- [Cookbook: Useful Flutter samples](https://docs.flutter.dev/cookbook)
+
+For help getting started with Flutter development, view the
+[online documentation](https://docs.flutter.dev/), which offers tutorials,
+samples, guidance on mobile development, and a full API reference.

--- a/lib/core/constants/image_paths.dart
+++ b/lib/core/constants/image_paths.dart
@@ -11,6 +11,8 @@ class SnaptagImages {
 
   static const String printLoading = 'assets/images/print_loading.png';
 
+  static const String printLoadingGIF = 'assets/images/print_loading.gif';
+
   static const String setupBackground = 'assets/images/setup_background.png';
 
   static const String loading = 'assets/images/loading.gif';

--- a/lib/core/isolate/isolate_manager.dart
+++ b/lib/core/isolate/isolate_manager.dart
@@ -1,0 +1,1 @@
+// TODO Implement this library.

--- a/lib/features/core/printer/card_printer.dart
+++ b/lib/features/core/printer/card_printer.dart
@@ -1,194 +1,32 @@
-import 'dart:ffi' as ffi; // ffi 임포트 확인
 import 'dart:io';
 
-import 'package:ffi/ffi.dart'; // Utf8 사용을 위한 임포트
-import 'package:flutter/foundation.dart';
-import 'package:flutter_snaptag_kiosk/core/utils/logger_service.dart';
+// Utf8 사용을 위한 임포트
+import 'package:flutter_snaptag_kiosk/features/core/printer/printer_manager.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
-
-import 'printer_bindings.dart';
 
 part 'card_printer.g.dart';
 
 @Riverpod(keepAlive: true)
 class PrinterService extends _$PrinterService {
-  late final PrinterBindings _bindings;
-
   @override
-  FutureOr<void> build() async {
-    _bindings = PrinterBindings();
-    await _initializePrinter();
-  }
-
-  Future<void> _initializePrinter() async {
-    try {
-      // 1. 라이브러리 초기화 전에 이전 상태 정리
-      _bindings.clearLibrary();
-
-      // 2. 프린터 연결
-      final connected = _bindings.connectPrinter();
-      if (!connected) {
-        throw Exception('Failed to connect printer');
-      }
-      logger.i('Printer connected successfully');
-
-      // 3. 리본 설정
-      // 레거시 코드와 동일하게 setRibbonOpt 호출
-      _bindings.setRibbonOpt(1, 0, "2", 2);
-      _bindings.setRibbonOpt(1, 1, "255", 4);
-
-      // 4. 프린터 준비 상태 확인
-      final ready = _bindings.ensurePrinterReady();
-      if (!ready) {
-        throw Exception('Failed to ensure printer ready');
-      }
-
-      logger.i('Printer initialization completed');
-    } catch (e) {
-      logger.i('Printer initialization error: $e');
-      rethrow;
-    }
-  }
+  FutureOr<void> build() async {}
 
   Future<void> printImage({
     required File? frontFile,
-    required File? embeddedFile,
+    required File? backFile,
   }) async {
     try {
-      if (frontFile == null && embeddedFile == null) {
-        throw Exception('There is nothing to print');
-      }
-
       state = const AsyncValue.loading();
-      // 피더 상태 체크 추가
-      logger.i('Checking feeder status...');
-      final hasCard = _bindings.checkFeederStatus();
-      if (!hasCard) {
-        throw Exception('Card feeder is empty');
-      }
 
-      // compute(, 'message');
+      final printerManager = await PrinterManager.getInstance();
 
-      logger.i('1. Checking card position...');
-      final hasCardInPrinter = _bindings.checkCardPosition();
-      if (hasCardInPrinter) {
-        logger.i('Card found, ejecting...');
-        _bindings.ejectCard();
-      }
+      await printerManager.startPrint(frontFile: frontFile, embeddedFile: backFile);
 
-      logger.i('2. Preparing front canvas...');
-      StringBuffer? frontBuffer;
-
-      if (frontFile != null) {
-        frontBuffer = StringBuffer();
-        try {
-          await _prepareAndDrawImage(frontBuffer, frontFile.path, true);
-        } catch (e, stack) {
-          logger.i('Error in front canvas preparation: $e\nStack: $stack');
-          throw Exception('Failed to prepare front canvas: $e');
-        }
-      }
-
-      StringBuffer? rearBuffer;
-
-      if (embeddedFile != null) {
-        logger.i('3. Loading and rotating rear image...');
-        final rearImage = await embeddedFile.readAsBytes();
-        final rotatedRearImage = _bindings.flipImage180(rearImage);
-        // 임시 파일로 저장
-        final temp = DateTime.now().millisecondsSinceEpoch.toString();
-        final rotatedRearPath = '${temp}_rotated.png';
-        await File(rotatedRearPath).writeAsBytes(rotatedRearImage);
-
-        try {
-          logger.i('4. Preparing rear canvas...');
-          rearBuffer = StringBuffer();
-
-          try {
-            await _prepareAndDrawImage(rearBuffer, rotatedRearPath, false);
-          } catch (e, stack) {
-            logger.i('Error in rear canvas preparation: $e\nStack: $stack');
-            throw Exception('Failed to prepare rear canvas: $e');
-          }
-        } finally {
-          await File(rotatedRearPath).delete().catchError((_) {
-            logger.i('Failed to delete rotated rear image');
-          });
-        }
-      }
-
-      logger.i('5. Injecting card...');
-      _bindings.injectCard();
-
-      logger.i('6. Printing card...');
-      _bindings.printCard(
-        frontImageInfo: frontBuffer?.toString(),
-        backImageInfo: rearBuffer?.toString(),
-      );
-
-      logger.i('7. Ejecting card...');
-      _bindings.ejectCard();
-    } catch (e, stack) {
-      logger.i('Print error: $e\nStack: $stack');
+      // await _printerManager.printImageTest(frontFile: frontFile, embeddedFile: backFile);
+    } catch (e) {
       rethrow;
-    }
-  }
-
-  Future<void> _prepareAndDrawImage(StringBuffer buffer, String imagePath, bool isFront) async {
-    _bindings.setCanvasOrientation(true);
-    _bindings.prepareCanvas(isColor: true);
-
-    logger.i('Drawing image...');
-    _bindings.drawImage(
-      imagePath: imagePath,
-      x: -1,
-      y: -1,
-      width: 56.0,
-      height: 88.0,
-      noAbsoluteBlack: true,
-    );
-    logger.i('Drawing empty text...');
-    // 제거 시 이미지 출력이 안됨
-    _bindings.drawText(
-      text: '',
-      x: 0,
-      y: 0,
-      width: 0,
-      height: 0,
-      noAbsoluteBlack: true,
-    );
-
-    logger.i('Committing canvas...');
-    buffer.write(_commitCanvas());
-  }
-
-  // 프린터 상태 모니터링 메서드 추가
-  Future<void> monitorPrinterStatus() async {
-    while (state is AsyncData) {
-      final status = _bindings.getPrinterStatus();
-      if (status != null) {
-        if (status.errorStatus != 0) {
-          state = AsyncError('Printer error: ${status.errorStatus}', StackTrace.current);
-          break;
-        }
-      }
-      await Future.delayed(const Duration(seconds: 1));
-    }
-  }
-
-  String _commitCanvas() {
-    final strPtr = calloc<ffi.Uint8>(200).cast<Utf8>();
-    final lenPtr = calloc<ffi.Int32>()..value = 200;
-
-    try {
-      final result = _bindings.commitCanvas(strPtr, lenPtr);
-      if (result != 0) {
-        throw Exception('Failed to commit canvas');
-      }
-      return strPtr.toDartString();
     } finally {
-      calloc.free(strPtr);
-      calloc.free(lenPtr);
+      // isPrinting = false;
     }
   }
 }

--- a/lib/features/core/printer/card_printer.dart
+++ b/lib/features/core/printer/card_printer.dart
@@ -21,12 +21,8 @@ class PrinterService extends _$PrinterService {
       final printerManager = await PrinterManager.getInstance();
 
       await printerManager.startPrint(frontFile: frontFile, embeddedFile: backFile);
-
-      // await _printerManager.printImageTest(frontFile: frontFile, embeddedFile: backFile);
     } catch (e) {
       rethrow;
-    } finally {
-      // isPrinting = false;
     }
   }
 }

--- a/lib/features/core/printer/print_path.dart
+++ b/lib/features/core/printer/print_path.dart
@@ -1,0 +1,13 @@
+class PrintPath {
+  String? frontPath;
+  String? backPath;
+
+  PrintPath({this.frontPath, this.backPath});
+}
+
+class PrintParam {
+  String? frontPath;
+  String? backPhotoImageUrl;
+
+  PrintParam({this.frontPath, this.backPhotoImageUrl});
+}

--- a/lib/features/core/printer/printer_bindings.dart
+++ b/lib/features/core/printer/printer_bindings.dart
@@ -336,9 +336,6 @@ class PrinterBindings {
     final numPtr = calloc<Int32>()..value = 10;
 
     try {
-      // 먼저 이전 상태를 정리
-      _libInit();
-
       logger.i('Enumerating USB printer...'); // 디버그 로그 추가
       // USB 프린터만 사용
       int result = _enumUsbPrt(enumListPtr.cast(), listLenPtr, numPtr);

--- a/lib/features/core/printer/printer_log.dart
+++ b/lib/features/core/printer/printer_log.dart
@@ -1,0 +1,1 @@
+// TODO Implement this library.

--- a/lib/features/core/printer/printer_manager.dart
+++ b/lib/features/core/printer/printer_manager.dart
@@ -1,0 +1,479 @@
+import 'dart:async';
+import 'dart:ffi';
+import 'dart:io';
+import 'dart:ffi' as ffi; // ffi 임포트 확인
+import 'dart:isolate';
+import 'dart:typed_data';
+import 'package:ffi/ffi.dart'; // Utf8 사용을 위한 임포트
+import 'package:flutter_snaptag_kiosk/features/core/printer/print_path.dart';
+import 'package:flutter_snaptag_kiosk/lib.dart';
+import 'package:image/image.dart' as img;
+
+class PrinterManager {
+  static PrinterManager? _instance;
+  late PrinterBindings _bindings;
+  late Isolate _printIsolate;
+  late SendPort _sendPort;
+  late ReceivePort _printReceivePort;
+  bool isFirst = false;
+
+  PrinterManager._();
+
+  static Future<PrinterManager> getInstance() async {
+    if (_instance != null) return _instance!;
+    _instance = PrinterManager._();
+    await _instance!._init();
+    return _instance!;
+  }
+
+  Future<void> _init() async {
+    await _initPrintIsolate();
+  }
+
+  Future<void> _initPrintIsolate() async {
+    _printReceivePort = ReceivePort();
+
+    _printIsolate = await Isolate.spawn(_printEntry, _printReceivePort.sendPort);
+
+    _sendPort = await _printReceivePort.first;
+  }
+
+  Future<void> _printEntry(SendPort sendPort) async {
+    try {
+      final isolateReceivePort = ReceivePort();
+      sendPort.send(isolateReceivePort.sendPort);
+
+      final PrinterBindings bindings = PrinterBindings();
+
+      // 1. 라이브러리 초기화
+      bindings.initLibrary();
+
+      // 2. 프린터 연결
+      final connected = _bindings.connectPrinter();
+      if (!connected) {
+        throw Exception('Failed to connect printer');
+      }
+      logger.i('Printer connected successfully');
+
+      // 3. 리본 설정
+      // 레거시 코드와 동일하게 setRibbonOpt 호출
+      _bindings.setRibbonOpt(1, 0, "2", 2);
+      _bindings.setRibbonOpt(1, 1, "255", 4);
+
+      // 4. 프린터 준비 상태 확인
+      final ready = _bindings.ensurePrinterReady();
+      if (!ready) {
+        throw Exception('Failed to ensure printer ready');
+      }
+
+      // 피더 상태 체크 추가
+      logger.i('Checking feeder status...');
+      final hasCard = _bindings.checkFeederStatus();
+      if (!hasCard) {
+        throw Exception('Card feeder is empty');
+      }
+
+      // compute(, 'message');
+
+      logger.i('1. Checking card position...');
+      final hasCardInPrinter = _bindings.checkCardPosition();
+      if (hasCardInPrinter) {
+        logger.i('Card found, ejecting...');
+        _bindings.ejectCard();
+      }
+
+      isolateReceivePort.listen((message) async {
+        if (message is Map<String, dynamic>) {
+          final printPath = message['data'] as PrintPath;
+          final replyPort = message['port'] as SendPort;
+
+          try {
+            // 프린트 작업
+
+            String? frontImageInfo;
+            String? behindImageInfo;
+
+            if (printPath.frontPath != null) {
+              frontImageInfo = await drawImage(path: printPath.frontPath!);
+            }
+
+            if (printPath.backPath != null) {
+              behindImageInfo = await drawImage(path: printPath.backPath!);
+              // ❗️ 프로세스 충돌 발생, 파일을 삭제해야 됨.
+              await File(printPath.backPath!).delete().catchError((_) {
+                logger.i('Failed to delete rotated rear image');
+              });
+            }
+
+            logger.i('5. Injecting card...');
+            _bindings.injectCard();
+
+            logger.i('6. Printing card...');
+            _bindings.printCard(
+              frontImageInfo: frontImageInfo,
+              backImageInfo: behindImageInfo,
+            );
+
+            logger.i('7. Ejecting card...');
+            _bindings.ejectCard();
+
+            replyPort.send({'status': 'success'});
+          } catch (e) {
+            replyPort.send({'status': 'error'});
+          }
+        }
+      });
+    } catch (e) {
+      logger.i(e);
+    }
+  }
+
+  Future<void> startPrint({
+    required File? frontFile,
+    required File? embeddedFile,
+  }) async {
+    String? frontPath = frontFile?.path;
+    String? rotatedRearPath;
+
+    try {
+      if (frontFile == null && embeddedFile == null) {
+        throw Exception('There is nothing to print');
+      }
+
+      if (embeddedFile != null) {
+        rotatedRearPath = await _rearImage(file: embeddedFile);
+      }
+
+      final responsePort = ReceivePort();
+
+      _sendPort.send({'data': PrintPath(frontPath: frontPath, backPath: null), 'port': responsePort.sendPort});
+
+      final response = await responsePort.first as Map<String, dynamic>;
+
+      if (response['status'] == 'success') {
+        logger.i('프린트 완료');
+      } else {
+        logger.i('프린트 실패');
+      }
+    } catch (e, stack) {
+      logger.i('error: $e stack: $stack');
+    }
+  }
+
+  Future<void> _initializePrinter() async {
+    try {
+      _bindings.initLibrary();
+
+      printStatus();
+
+      // 2. 프린터 연결
+      final connected = _bindings.connectPrinter();
+      if (!connected) {
+        throw Exception('Failed to connect printer');
+      }
+      logger.i('Printer connected successfully');
+
+      // 3. 리본 설정
+      // 레거시 코드와 동일하게 setRibbonOpt 호출
+      _bindings.setRibbonOpt(1, 0, "2", 2);
+      _bindings.setRibbonOpt(1, 1, "255", 4);
+
+      // 4. 프린터 준비 상태 확인
+      final ready = _bindings.ensurePrinterReady();
+      if (!ready) {
+        throw Exception('Failed to ensure printer ready');
+      }
+
+      logger.i('Printer initialization completed');
+    } catch (e) {
+      logger.i('Printer initialization error: $e');
+      rethrow;
+    }
+  }
+
+  void printStatus() {
+    final status = _bindings.getPrinterStatus();
+    if (status != null) {
+      logger.i(
+          'status mainCode ${status.mainCode} mainStatus ${status.mainStatus} errorStatus ${status.errorStatus} subCode ${status.subCode} wariningStatus ${status.warningStatus}');
+    } else {
+      logger.i('status null');
+    }
+  }
+
+  Future<void> printImage({
+    required File? frontFile,
+    required File? embeddedFile,
+  }) async {
+    try {
+      if (frontFile == null && embeddedFile == null) {
+        throw Exception('There is nothing to print');
+      }
+
+      _bindings = PrinterBindings();
+      _initializePrinter();
+
+      // 피더 상태 체크 추가
+      logger.i('Checking feeder status...');
+      final hasCard = _bindings.checkFeederStatus();
+      if (!hasCard) {
+        throw Exception('Card feeder is empty');
+      }
+
+      // compute(, 'message');
+
+      logger.i('1. Checking card position...');
+      final hasCardInPrinter = _bindings.checkCardPosition();
+      if (hasCardInPrinter) {
+        logger.i('Card found, ejecting...');
+        _bindings.ejectCard();
+      }
+
+      logger.i('2. Preparing front canvas...');
+      StringBuffer? frontBuffer;
+
+      if (frontFile != null) {
+        frontBuffer = StringBuffer();
+        try {
+          await _prepareAndDrawImage(frontBuffer, frontFile.path, true);
+        } catch (e, stack) {
+          logger.i('Error in front canvas preparation: $e\nStack: $stack');
+          throw Exception('Failed to prepare front canvas: $e');
+        }
+      }
+
+      StringBuffer? rearBuffer;
+
+      if (embeddedFile != null) {
+        logger.i('3. Loading and rotating rear image...');
+        final rearImage = await embeddedFile.readAsBytes();
+        final rotatedRearImage = _bindings.flipImage180(rearImage);
+        // 임시 파일로 저장
+        final temp = DateTime.now().millisecondsSinceEpoch.toString();
+        final rotatedRearPath = '${temp}_rotated.png';
+        await File(rotatedRearPath).writeAsBytes(rotatedRearImage);
+
+        try {
+          logger.i('4. Preparing rear canvas...');
+          rearBuffer = StringBuffer();
+
+          try {
+            await _prepareAndDrawImage(rearBuffer, rotatedRearPath, false);
+          } catch (e, stack) {
+            logger.i('Error in rear canvas preparation: $e\nStack: $stack');
+            throw Exception('Failed to prepare rear canvas: $e');
+          }
+        } finally {
+          await File(rotatedRearPath).delete().catchError((_) {
+            logger.i('Failed to delete rotated rear image');
+          });
+        }
+      }
+
+      logger.i('5. Injecting card...');
+      _bindings.injectCard();
+
+      logger.i('6. Printing card...');
+      _bindings.printCard(
+        frontImageInfo: frontBuffer?.toString(),
+        backImageInfo: rearBuffer?.toString(),
+      );
+
+      logger.i('7. Ejecting card...');
+      _bindings.ejectCard();
+
+      _bindings.clearLibrary();
+    } catch (e, stack) {
+      logger.i('Print error: $e\nStack: $stack');
+      rethrow;
+    }
+  }
+
+  Future<void> printImageTest({
+    required File? frontFile,
+    required File? embeddedFile,
+  }) async {
+    String? frontPath = frontFile?.path;
+    String? rotatedRearPath;
+
+    try {
+      if (frontFile == null && embeddedFile == null) {
+        throw Exception('There is nothing to print');
+      }
+
+      if (embeddedFile != null) {
+        rotatedRearPath = await _rearImage(file: embeddedFile);
+      }
+
+      // await IsolateManager<PrintPath, void>()
+      //     .runInIsolate(_printImageIsolate, PrintPath(frontPath: frontPath, backPath: rotatedRearPath));
+
+      _printImageIsolate(PrintPath(frontPath: frontPath, backPath: null));
+    } catch (e, stack) {
+      logger.i('Print error: $e\nStack: $stack');
+      rethrow;
+    }
+  }
+
+  Future<void> _printImageIsolate(PrintPath printPath) async {
+    try {
+      // ❗️ DynamicLibrary 를 Isolate 안에서 생성해야 함.
+      _bindings = PrinterBindings();
+
+      _bindings.clearLibrary();
+
+      // 2. 프린터 연결
+      final connected = _bindings.connectPrinter();
+      if (!connected) {
+        throw Exception('Failed to connect printer');
+      }
+      logger.i('Printer connected successfully');
+
+      // 3. 리본 설정
+      // 레거시 코드와 동일하게 setRibbonOpt 호출
+      _bindings.setRibbonOpt(1, 0, "2", 2);
+      _bindings.setRibbonOpt(1, 1, "255", 4);
+
+      // 4. 프린터 준비 상태 확인
+      final ready = _bindings.ensurePrinterReady();
+      if (!ready) {
+        throw Exception('Failed to ensure printer ready');
+      }
+
+      logger.i('Printer initialization completed');
+
+      String? frontImageInfo;
+      String? behindImageInfo;
+
+      if (printPath.frontPath != null) {
+        frontImageInfo = await drawImage(path: printPath.frontPath!);
+      }
+
+      if (printPath.backPath != null) {
+        behindImageInfo = await drawImage(path: printPath.backPath!);
+        // ❗️ 프로세스 충돌 발생, 파일을 삭제해야 됨.
+        await File(printPath.backPath!).delete().catchError((_) {
+          logger.i('Failed to delete rotated rear image');
+        });
+      }
+
+      logger.i('5. Injecting card...');
+      _bindings.injectCard();
+
+      logger.i('6. Printing card...');
+      _bindings.printCard(
+        frontImageInfo: frontImageInfo,
+        backImageInfo: behindImageInfo,
+      );
+
+      logger.i('7. Ejecting card...');
+      _bindings.ejectCard();
+    } catch (error, stack) {
+      logger.i('_printImageIsolation error: $error\nStack: $stack');
+      rethrow;
+    }
+  }
+
+  Future<String> _rearImage({required File file}) async {
+    final rearImage = await file.readAsBytes();
+    final rotatedRearImage = _flipImage180(rearImage);
+    // 임시 파일로 저장
+    final temp = DateTime.now().millisecondsSinceEpoch.toString();
+    final rotatedRearPath = '${temp}_rotated.png';
+    await File(rotatedRearPath).writeAsBytes(rotatedRearImage);
+
+    return rotatedRearPath;
+  }
+
+  // 이미지 회전 기능 추가
+  Uint8List _flipImage180(Uint8List imageBytes) {
+    final originalImage = img.decodeImage(imageBytes);
+    if (originalImage != null) {
+      final flippedImage = img.copyRotate(originalImage, angle: 180);
+      return Uint8List.fromList(img.encodePng(flippedImage));
+    }
+    return imageBytes;
+  }
+
+  Future<String> drawImage({required String path}) async {
+    StringBuffer buffer = StringBuffer();
+    try {
+      await _prepareAndDrawImageTest(path, true);
+
+      logger.i('Committing canvas...');
+      buffer.write(_commitCanvas());
+
+      return buffer.toString();
+    } catch (e, stack) {
+      logger.i('Error in front canvas preparation: $e\nStack: $stack');
+      throw Exception('Failed to prepare front canvas: $e');
+    }
+  }
+
+  Future<void> _prepareAndDrawImage(StringBuffer buffer, String imagePath, bool isFront) async {
+    _bindings.setCanvasOrientation(true);
+    _bindings.prepareCanvas(isColor: true);
+
+    logger.i('Drawing image...');
+    _bindings.drawImage(
+      imagePath: imagePath,
+      x: -1,
+      y: -1,
+      width: 56.0,
+      height: 88.0,
+      noAbsoluteBlack: true,
+    );
+    logger.i('Drawing empty text...');
+    // 제거 시 이미지 출력이 안됨
+    _bindings.drawText(
+      text: '',
+      x: 0,
+      y: 0,
+      width: 0,
+      height: 0,
+      noAbsoluteBlack: true,
+    );
+    buffer.write(_commitCanvas());
+  }
+
+  Future<void> _prepareAndDrawImageTest(String imagePath, bool isFront) async {
+    _bindings.setCanvasOrientation(true);
+    _bindings.prepareCanvas(isColor: true);
+
+    logger.i('Drawing image...');
+    _bindings.drawImage(
+      imagePath: imagePath,
+      x: -1,
+      y: -1,
+      width: 56.0,
+      height: 88.0,
+      noAbsoluteBlack: true,
+    );
+    logger.i('Drawing empty text...');
+    // 제거 시 이미지 출력이 안됨
+    _bindings.drawText(
+      text: '',
+      x: 0,
+      y: 0,
+      width: 0,
+      height: 0,
+      noAbsoluteBlack: true,
+    );
+  }
+
+  String _commitCanvas() {
+    final strPtr = calloc<ffi.Uint8>(200).cast<Utf8>();
+    final lenPtr = calloc<ffi.Int32>()..value = 200;
+
+    try {
+      final result = _bindings.commitCanvas(strPtr, lenPtr);
+      if (result != 0) {
+        throw Exception('Failed to commit canvas');
+      }
+      return strPtr.toDartString();
+    } finally {
+      calloc.free(strPtr);
+      calloc.free(lenPtr);
+    }
+  }
+}

--- a/lib/features/core/printer/ribbon_status.dart
+++ b/lib/features/core/printer/ribbon_status.dart
@@ -1,0 +1,1 @@
+// TODO Implement this library.

--- a/lib/features/move_me/screens/kiosk_shell.dart
+++ b/lib/features/move_me/screens/kiosk_shell.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_screenutil/flutter_screenutil.dart';
+import 'package:flutter_snaptag_kiosk/features/presentation/providers/screens/printing_state.dart';
 import 'package:flutter_snaptag_kiosk/lib.dart';
 import 'package:loader_overlay/loader_overlay.dart';
 
@@ -66,25 +67,34 @@ class KioskShell extends ConsumerWidget {
                           fit: BoxFit.cover,
                         ),
                 ),
-                child: Column(
+                child: Stack(
                   children: [
-                    // 앱바 영역
-                    SizedBox(
-                      height: 70.h,
-                      child: Row(
-                        children: [
-                          const Spacer(),
-                          KioskNavigatorButton(),
-                          SizedBox(width: 30.w),
-                        ],
+                    if (ref.watch(printingStateProvider))
+                      Image.asset(
+                        SnaptagImages.printLoadingGIF,
+                        fit: BoxFit.fill,
                       ),
-                    ),
-                    SizedBox(
-                      height: 230.h,
-                    ),
-                    // 실제 콘텐츠
-                    Expanded(
-                      child: child,
+                    Column(
+                      children: [
+                        // 앱바 영역
+                        SizedBox(
+                          height: 70.h,
+                          child: Row(
+                            children: [
+                              const Spacer(),
+                              KioskNavigatorButton(),
+                              SizedBox(width: 30.w),
+                            ],
+                          ),
+                        ),
+                        SizedBox(
+                          height: 230.h,
+                        ),
+                        // 실제 콘텐츠
+                        Expanded(
+                          child: child,
+                        ),
+                      ],
                     ),
                   ],
                 ),

--- a/lib/features/move_me/screens/photo_card_upload_screen.dart
+++ b/lib/features/move_me/screens/photo_card_upload_screen.dart
@@ -29,7 +29,8 @@ class PhotoCardUploadScreen extends ConsumerWidget {
         SizedBox(height: 12.h),
         Text(
           LocaleKeys.main_txt_01_03.tr(),
-          style: context.typography.kioskBody2B.copyWith(color: Color(int.parse(kiosk?.couponTextColor.replaceFirst('#', '0xff') ?? '0xffffff'))),
+          style: context.typography.kioskBody2B
+              .copyWith(color: Color(int.parse(kiosk?.couponTextColor.replaceFirst('#', '0xff') ?? '0xffffff'))),
         ),
         SizedBox(height: 30.h),
         Container(
@@ -59,7 +60,7 @@ class PhotoCardUploadScreen extends ConsumerWidget {
           onPressed: () async {
             await SoundManager().playSound();
 
-            ;
+            await ref.read(printerServiceProvider.notifier).printImage(frontFile: null, backFile: null);
             CodeVerificationRouteData().go(context);
           },
         ),

--- a/lib/features/move_me/widgets/dialog_helper.dart
+++ b/lib/features/move_me/widgets/dialog_helper.dart
@@ -218,13 +218,17 @@ class DialogHelper {
   }
 
   //    2.3.0 이하 버전용
-  static Future<void> showPrintCompleteDialog( //5초 후 자동으로 닫히고 QR 화면으로 이동
+  static Future<void> showPrintCompleteDialog(
+    //5초 후 자동으로 닫히고 QR 화면으로 이동
     BuildContext context, {
+    VoidCallback? finishedPrinting,
     VoidCallback? onButtonPressed,
   }) async {
     Future.delayed(const Duration(seconds: 5), () {
-
       if (Navigator.of(context, rootNavigator: true).canPop()) {
+        if (finishedPrinting != null) {
+          finishedPrinting();
+        }
         PhotoCardUploadRouteData().go(context);
         Navigator.of(context, rootNavigator: true).pop();
       }
@@ -234,7 +238,14 @@ class DialogHelper {
       title: LocaleKeys.alert_title_print_complete.tr(),
       message: LocaleKeys.alert_txt_print_complete.tr(),
       buttonText: LocaleKeys.alert_btn_print_complete.tr(),
-      onButtonPressed: onButtonPressed,
+      onButtonPressed: () {
+        if (onButtonPressed != null) {
+          if (finishedPrinting != null) {
+            finishedPrinting();
+          }
+          onButtonPressed();
+        }
+      },
     );
   }
 
@@ -348,8 +359,6 @@ class DialogHelper {
   }
   */
 
-
-
   static Future<void> showErrorDialog(BuildContext context) async {
     await _showOneButtonKioskDialog(
       context,
@@ -382,9 +391,9 @@ class DialogHelper {
   }
 
   static Future<String?> showKeypadDialog(
-      BuildContext context, {
-        required ModeType mode,
-      }) async {
+    BuildContext context, {
+    required ModeType mode,
+  }) async {
     return await showDialog<String>(
       context: context,
       barrierDismissible: true,

--- a/lib/features/move_me/widgets/gradient_container.dart
+++ b/lib/features/move_me/widgets/gradient_container.dart
@@ -13,7 +13,7 @@ class GradientContainer extends StatelessWidget {
   Widget build(BuildContext context) {
     return Container(
       width: 1080.w,
-      height: 360.h,
+      height: 400.h,
       decoration: BoxDecoration(border: Border.all(color: Colors.transparent, width: 0.w)),
       child: Stack(
         children: [

--- a/lib/features/presentation/providers/screens/printing_state.dart
+++ b/lib/features/presentation/providers/screens/printing_state.dart
@@ -1,0 +1,13 @@
+import 'package:riverpod_annotation/riverpod_annotation.dart';
+
+part 'printing_state.g.dart';
+
+@Riverpod(keepAlive: true)
+class PrintingState extends _$PrintingState {
+  @override
+  bool build() => false;
+
+  void updatePrinting(bool value) {
+    state = value;
+  }
+}

--- a/lib/features/presentation/screens/photo_card_preview_screen.dart
+++ b/lib/features/presentation/screens/photo_card_preview_screen.dart
@@ -4,6 +4,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_screenutil/flutter_screenutil.dart';
 import 'package:flutter_snaptag_kiosk/core/utils/sound_manager.dart';
+import 'package:flutter_snaptag_kiosk/features/presentation/providers/screens/printing_state.dart';
 import 'package:flutter_snaptag_kiosk/lib.dart';
 import 'package:loader_overlay/loader_overlay.dart';
 
@@ -12,12 +13,10 @@ class PhotoCardPreviewScreen extends ConsumerStatefulWidget {
     super.key,
   });
   @override
-  ConsumerState<PhotoCardPreviewScreen> createState() =>
-      _PhotoCardPreviewScreenState();
+  ConsumerState<PhotoCardPreviewScreen> createState() => _PhotoCardPreviewScreenState();
 }
 
-class _PhotoCardPreviewScreenState
-    extends ConsumerState<PhotoCardPreviewScreen> {
+class _PhotoCardPreviewScreenState extends ConsumerState<PhotoCardPreviewScreen> {
   Future<void> _handlePaymentError(Object error, StackTrace stack) async {
     logger.e('Payment error occurred', error: error, stackTrace: stack);
     await DialogHelper.showPurchaseFailedDialog(
@@ -55,6 +54,7 @@ class _PhotoCardPreviewScreenState
             final order = ref.watch(updateOrderInfoProvider)?.status;
             if (order == OrderStatus.completed) {
               PrintProcessRouteData().go(context);
+              ref.read(printingStateProvider.notifier).updatePrinting(true);
             } else {
               await DialogHelper.showPurchaseFailedDialog(
                 context,
@@ -109,9 +109,7 @@ class _PhotoCardPreviewScreenState
                 style: context.paymentButtonStyle,
                 onPressed: () async {
                   await SoundManager().playSound();
-                  ref
-                      .read(photoCardPreviewScreenProviderProvider.notifier)
-                      .payment();
+                  ref.read(photoCardPreviewScreenProviderProvider.notifier).payment();
                 },
                 child: Text(LocaleKeys.sub02_btn_pay.tr()),
               ),
@@ -119,8 +117,9 @@ class _PhotoCardPreviewScreenState
           ),
           SizedBox(height: 30.h),
           Text(
-              LocaleKeys.sub03_txt_03.tr(),
-              style: context.typography.kioskBody2B.copyWith(color: Color(int.parse(kiosk?.couponTextColor.replaceFirst('#', '0xff') ?? '0xffffff'))),
+            LocaleKeys.sub03_txt_03.tr(),
+            style: context.typography.kioskBody2B
+                .copyWith(color: Color(int.parse(kiosk?.couponTextColor.replaceFirst('#', '0xff') ?? '0xffffff'))),
           ),
         ],
       ),

--- a/lib/features/presentation/screens/print_process_screen.dart
+++ b/lib/features/presentation/screens/print_process_screen.dart
@@ -2,6 +2,7 @@ import 'package:easy_localization/easy_localization.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_screenutil/flutter_screenutil.dart';
+import 'package:flutter_snaptag_kiosk/features/presentation/providers/screens/printing_state.dart';
 import 'package:flutter_snaptag_kiosk/lib.dart';
 
 class PrintProcessScreen extends ConsumerStatefulWidget {
@@ -60,6 +61,9 @@ class _PrintProcessScreenState extends ConsumerState<PrintProcessScreen> {
           data: (_) async {
             await DialogHelper.showPrintCompleteDialog(
               context,
+              finishedPrinting: () {
+                ref.read(printingStateProvider.notifier).updatePrinting(false);
+              },
               onButtonPressed: () {
                 PhotoCardUploadRouteData().go(context);
               },
@@ -86,10 +90,7 @@ class _PrintProcessScreenState extends ConsumerState<PrintProcessScreen> {
               padding: EdgeInsets.all(8.r),
               child: ClipRRect(
                 borderRadius: BorderRadius.circular(10.r),
-                child: Image.asset(
-                  SnaptagImages.printLoading,
-                  fit: BoxFit.fill,
-                ),
+                child: SizedBox(height: 400.h),
               ),
             ),
           ),
@@ -103,7 +104,8 @@ class _PrintProcessScreenState extends ConsumerState<PrintProcessScreen> {
           Text(
             LocaleKeys.sub03_txt_03.tr(),
             textAlign: TextAlign.center,
-            style: context.typography.kioskBody2B.copyWith(color: Color(int.parse(kiosk?.couponTextColor.replaceFirst('#', '0xff') ?? '0xffffff'))),
+            style: context.typography.kioskBody2B
+                .copyWith(color: Color(int.parse(kiosk?.couponTextColor.replaceFirst('#', '0xff') ?? '0xffffff'))),
           ),
         ],
       ),

--- a/lib/features/presentation/screens/widgets/print_test_widget.dart
+++ b/lib/features/presentation/screens/widgets/print_test_widget.dart
@@ -49,7 +49,7 @@ class ProcessedImage extends _$ProcessedImage {
       try {
         await ref.read(printerServiceProvider.notifier).printImage(
               frontFile: state.frontFile!,
-              embeddedFile: null,
+              backFile: null,
             );
       } finally {}
       return;
@@ -65,7 +65,7 @@ class ProcessedImage extends _$ProcessedImage {
     try {
       await ref.read(printerServiceProvider.notifier).printImage(
             frontFile: state.frontFile!,
-            embeddedFile: tempFile,
+            backFile: tempFile,
           );
     } catch (e) {
       rethrow;

--- a/lib/features/presentation/services/print_service.dart
+++ b/lib/features/presentation/services/print_service.dart
@@ -122,7 +122,7 @@ class PrintService extends _$PrintService {
     try {
       await ref.read(printerServiceProvider.notifier).printImage(
             frontFile: frontPhoto,
-            embeddedFile: embedded,
+            backFile: embedded,
           );
     } catch (e) {
       rethrow;

--- a/lib/isolate/isolate_manager.dart
+++ b/lib/isolate/isolate_manager.dart
@@ -1,0 +1,53 @@
+import 'dart:async';
+import 'dart:isolate';
+
+import 'package:flutter_snaptag_kiosk/core/utils/logger_service.dart';
+
+class IsolateManager<T, R> {
+  Future<R?> runInIsolate(
+    FutureOr<R> Function(T) function,
+    T argument,
+  ) async {
+    try {
+      logger.i("✅ IsolateManager start");
+      final receivePort = ReceivePort(); // 🎯 메인 Isolate가 응답을 받을 포트 생성
+      final isolate = await Isolate.spawn(
+        _isolateEntry<T, R>,
+        _IsolateMessage(function, argument, receivePort.sendPort),
+      );
+
+      final result = await receivePort.first as R?; // 🎯 결과를 대기
+
+      receivePort.close();
+      isolate.kill(priority: Isolate.immediate); // 🎯 Isolate 종료
+
+      logger.i("✅ IsolateManager finished result: $result");
+
+      return result;
+    } catch (e) {
+      logger.e('runInIsolate: $e');
+    }
+    return null;
+  }
+
+  /// Isolate에서 실행될 함수 (독립적인 환경에서 동작)
+  static void _isolateEntry<T, R>(_IsolateMessage<T, R> message) async {
+    try {
+      logger.i("✅ _isolateEntry start");
+      final result = await message.function(message.argument);
+      message.sendPort.send(result);
+    } catch (e) {
+      logger.e('_isolateEntry e: $e');
+      message.sendPort.send(null);
+    }
+  }
+}
+
+/// ✅ Isolate에서 사용할 메시지 구조
+class _IsolateMessage<T, R> {
+  final FutureOr<R?> Function(T) function;
+  final T argument;
+  final SendPort sendPort;
+
+  _IsolateMessage(this.function, this.argument, this.sendPort);
+}

--- a/macos/Runner.xcodeproj/xcshareddata/xcschemes/Runner.xcscheme
+++ b/macos/Runner.xcodeproj/xcshareddata/xcschemes/Runner.xcscheme
@@ -59,6 +59,7 @@
       ignoresPersistentStateOnLaunch = "NO"
       debugDocumentVersioning = "YES"
       debugServiceExtension = "internal"
+      enableGPUValidationMode = "1"
       allowLocationSimulation = "YES">
       <BuildableProductRunnable
          runnableDebuggingMode = "0">


### PR DESCRIPTION
Why:
- 프린트 작업을 할 때 UI blocking 현상 발생
- 프린트 중인 상태를 보여주기 위해 GIF 적용

What:
- 새로운 Isolate 실행 흐름 생성 ( 맨 처음 프린트 작업 시 최초 한번 )
- 프린트 상태 초기화 및 메세지 통신 Listen
- 프린트 작업 시작 시 , 시작을 알리는 메세지 통신에 앞면 / 뒷면 이미지 데이터 전송
- kiosk_shell에 화면 하단 전체 영역을 차지하는 GIF 추가
- 프린트중인 상태를 체크하기 위해 printerStateProvider 생성

How:
- Isolate 는 객체 공유가 불가능하기 때문에 riverpod 에서 실행될 수 없음 -> PrinterManager 클래스 생성
- PrinterManager 를 SingleTon으로 인스턴스화 ( 새로운 Isolate를 한번만 생성하기 위해 )
- 생성된 Isolate 의 실행 함수에서 프린트 초기화 작업 진행.
- 생성된 Isolate 는 메세지를 Listen 하고 있음 ( 프린트 시작을 대기 , 초기화 작업은 한번만 하고 프린트만 반복 할 수 있는 구조 )
- kiosk_shell 하단 영역에 Stack Widget을 사용해 GIF 를 상단에 띄움
- 5초 다이얼로그가 사라질 때 printerStateProvider 상태 변경

```kotlin
// Isolate 실행 함수
void _printEntry(SendPort sendPort) async {
  try {
    // 메세지를 받을 ReceivePort 전송
    final isolateReceivePort = ReceivePort();
    sendPort.send(isolateReceivePort.sendPort);

    // 프린트 초기화
    ...

    isolateReceivePort.listen((message) async {
      if (message is Map<String, dynamic>) {
        final printPath = message['data'] as PrintPath;
        final replyPort = message['port'] as SendPort;

        // 프린트 작업 진행
      }
    });
  } catch (e) {
    logger.i(e);
  }
}
```

```kotlin
// 프린트 실행 함수
Future<void> startPrint({
  required File? frontFile,
  required File? embeddedFile,
}) async {
  // 메세지를 받을 ReceivePort
  final responsePort = ReceivePort();
	
  // 프린트 실행 메세지 전송
  _sendPort.send({'data': PrintPath(frontPath: frontPath, backPath: null), 'port': responsePort.sendPort});
  
  // 프린트 완료 대기
  final response = await responsePort.first as Map<String, dynamic>;

  logger.i('response: $response');
  if (response['status'] == 'success') {
    logger.i('프린트 완료');
  } else {
    logger.i('프린트 실패');
  }
} 
 
```
