### PR TITLE
프린트 상태 로그 구현

### DIFF
--- a/lib/data/datasources/cache/kiosk_info_service.dart
+++ b/lib/data/datasources/cache/kiosk_info_service.dart
@@ -29,6 +29,17 @@ class KioskInfoService extends _$KioskInfoService {
 
       ref.read(frontPhotoListProvider.notifier).fetch();
 
+      await printerStartLog(machineId);
+
+      return response;
+    } catch (e) {
+      ref.invalidateSelf();
+      rethrow;
+    }
+  }
+
+  Future<void> printerStartLog(int machineId) async {
+    try {
       final printerManager = await PrinterManager.getInstance();
       final printerLog = await printerManager.startLog();
 
@@ -39,11 +50,10 @@ class KioskInfoService extends _$KioskInfoService {
           SlackLogService().sendLogToSlack('PrintState : $log');
         }
       }
-
-      return response;
     } catch (e) {
-      ref.invalidateSelf();
-      rethrow;
+      // TODO : 프린트 초기화 작업 중 오류 발생.
+      logger.i(e);
+      SlackLogService().sendLogToSlack('printerStartLog : $e');
     }
   }
 

--- a/lib/data/datasources/cache/kiosk_info_service.dart
+++ b/lib/data/datasources/cache/kiosk_info_service.dart
@@ -1,3 +1,4 @@
+import 'package:flutter_snaptag_kiosk/features/core/printer/printer_manager.dart';
 import 'package:flutter_snaptag_kiosk/lib.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
 
@@ -27,6 +28,17 @@ class KioskInfoService extends _$KioskInfoService {
       state = response;
 
       ref.read(frontPhotoListProvider.notifier).fetch();
+
+      final printerManager = await PrinterManager.getInstance();
+      final printerLog = await printerManager.startLog();
+
+      if (printerLog != null) {
+        final log = printerLog.copyWith(kioskMachineId: machineId);
+        if (machineId != 0) {
+          await ref.read(kioskRepositoryProvider).updatePrintLog(request: log);
+          SlackLogService().sendLogToSlack('PrintState : $log');
+        }
+      }
 
       return response;
     } catch (e) {

--- a/lib/data/datasources/remote/kiosk_api_client.dart
+++ b/lib/data/datasources/remote/kiosk_api_client.dart
@@ -59,4 +59,9 @@ abstract class KioskApiClient {
     @Path('printedPhotoCardId') required int printedPhotoCardId,
     @Body() required Map<String, dynamic> body,
   });
+
+  @POST('/v1/machine/log')
+  Future<void> updatePrintLog({
+    @Body() required Map<String, dynamic> body,
+  });
 }

--- a/lib/data/repositories/kiosk_repository.dart
+++ b/lib/data/repositories/kiosk_repository.dart
@@ -1,5 +1,6 @@
 import 'package:flutter_snaptag_kiosk/data/datasources/remote/remote.dart';
 import 'package:flutter_snaptag_kiosk/data/models/models.dart';
+import 'package:flutter_snaptag_kiosk/features/core/printer/printer_log.dart';
 import 'package:flutter_snaptag_kiosk/flavors.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
 
@@ -106,6 +107,18 @@ class _KioskRepository {
     try {
       return await _apiClient.updatePrint(
         printedPhotoCardId: printedPhotoCardId,
+        body: request.toJson(),
+      );
+    } catch (e) {
+      rethrow;
+    }
+  }
+
+  Future<void> updatePrintLog({
+    required PrinterLog request,
+  }) async {
+    try {
+      await _apiClient.updatePrintLog(
         body: request.toJson(),
       );
     } catch (e) {

--- a/lib/features/core/printer/card_printer.dart
+++ b/lib/features/core/printer/card_printer.dart
@@ -27,11 +27,10 @@ class PrinterService extends _$PrinterService {
 
       if (printerLog != null) {
         final machineId = ref.read(kioskInfoServiceProvider)?.kioskMachineId ?? 0;
+        final log = printerLog.copyWith(kioskMachineId: machineId);
         if (machineId != 0) {
-          await ref
-              .read(kioskRepositoryProvider)
-              .updatePrintLog(request: printerLog.copyWith(kioskMachineId: machineId));
-          SlackLogService().sendLogToSlack('PrintState : $printerLog');
+          await ref.read(kioskRepositoryProvider).updatePrintLog(request: log);
+          SlackLogService().sendLogToSlack('PrintState : $log');
         }
       }
     } catch (e) {

--- a/lib/features/core/printer/card_printer.dart
+++ b/lib/features/core/printer/card_printer.dart
@@ -1,6 +1,9 @@
 import 'dart:io';
 
 // Utf8 사용을 위한 임포트
+import 'package:flutter_snaptag_kiosk/data/datasources/cache/kiosk_info_service.dart';
+import 'package:flutter_snaptag_kiosk/data/datasources/remote/slack_log_service.dart';
+import 'package:flutter_snaptag_kiosk/data/repositories/kiosk_repository.dart';
 import 'package:flutter_snaptag_kiosk/features/core/printer/printer_manager.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
 
@@ -20,8 +23,19 @@ class PrinterService extends _$PrinterService {
 
       final printerManager = await PrinterManager.getInstance();
 
-      await printerManager.startPrint(frontFile: frontFile, embeddedFile: backFile);
+      final printerLog = await printerManager.startPrint(frontFile: frontFile, embeddedFile: backFile);
+
+      if (printerLog != null) {
+        final machineId = ref.read(kioskInfoServiceProvider)?.kioskMachineId ?? 0;
+        if (machineId != 0) {
+          await ref
+              .read(kioskRepositoryProvider)
+              .updatePrintLog(request: printerLog.copyWith(kioskMachineId: machineId));
+          SlackLogService().sendLogToSlack('PrintState : $printerLog');
+        }
+      }
     } catch (e) {
+      SlackLogService().sendLogToSlack('printerError: $e');
       rethrow;
     }
   }

--- a/lib/features/core/printer/print_message.dart
+++ b/lib/features/core/printer/print_message.dart
@@ -1,0 +1,11 @@
+import 'dart:isolate';
+
+import 'package:flutter_snaptag_kiosk/features/core/printer/print_path.dart';
+
+class PrintMessage {
+  bool shouldPrintLog;
+  PrintPath printPath;
+  SendPort sendPort;
+
+  PrintMessage({this.shouldPrintLog = false, required this.printPath, required this.sendPort});
+}

--- a/lib/features/core/printer/printer_bindings.dart
+++ b/lib/features/core/printer/printer_bindings.dart
@@ -3,6 +3,7 @@ import 'dart:io';
 import 'dart:typed_data';
 
 import 'package:ffi/ffi.dart';
+import 'package:flutter_snaptag_kiosk/features/core/printer/ribbon_status.dart';
 import 'package:flutter_snaptag_kiosk/lib.dart';
 import 'package:image/image.dart' as img;
 
@@ -35,6 +36,7 @@ class PrinterBindings {
   late final R600SetTextIsStrong _setTextIsStrong;
   late final R600DrawImage _drawImage;
   late final R600IsFeederNoEmpty _isFeederNoEmpty;
+  late final R600GetRbnAndFilmRemaining _getRbnAndFilmRemaining;
 
   PrinterBindings() {
     // DLL 로드
@@ -64,6 +66,8 @@ class PrinterBindings {
     _setFont = _dll.lookupFunction<R600SetFontNative, R600SetFont>('R600SetFont');
     _setTextIsStrong = _dll.lookupFunction<R600SetTextIsStrongNative, R600SetTextIsStrong>('R600SetTextIsStrong');
     _isFeederNoEmpty = _dll.lookupFunction<R600IsFeederNoEmptyNative, R600IsFeederNoEmpty>('R600IsFeederNoEmpty');
+    _getRbnAndFilmRemaining =
+        _dll.lookupFunction<R600GetRbnAndFilmRemainingNative, R600GetRbnAndFilmRemaining>('R600GetRbnAndFilmRemaining');
   }
 
   int initLibrary() {
@@ -166,6 +170,33 @@ class PrinterBindings {
     }
   }
 
+  // 리본과 필름 잔량 확인 함수
+  RibbonStatus? getRbnAndFilmRemaining() {
+    final rbnRemaining = calloc<Short>();
+    final filmRemaining = calloc<Short>();
+    RibbonStatus? ribbonStatus;
+
+    try {
+      final result = _getRbnAndFilmRemaining(rbnRemaining, filmRemaining);
+      if (result != 0) {
+        throw Exception('Failed to get ribbon and film remaining');
+      }
+      logger.i('Ribbon remaining: ${rbnRemaining.value}');
+      logger.i('Film remaining: ${filmRemaining.value}');
+      ribbonStatus = RibbonStatus(
+        rbnRemaining: rbnRemaining.value,
+        filmRemaining: filmRemaining.value,
+      );
+    } catch (e) {
+      rethrow;
+    } finally {
+      calloc.free(rbnRemaining);
+      calloc.free(filmRemaining);
+    }
+
+    return ribbonStatus;
+  }
+
   // 인쇄 함수
   void printCard({
     required String? frontImageInfo,
@@ -227,7 +258,7 @@ class PrinterBindings {
   }
 
   // getPrinterStatus 메서드 추가
-  PrinterStatus? getPrinterStatus() {
+  PrinterStatus? getPrinterStatus(int machineId) {
     final pChassisTemp = calloc<Int16>();
     final pPrintheadTemp = calloc<Int16>();
     final pHeaterTemp = calloc<Int16>();
@@ -237,9 +268,11 @@ class PrinterBindings {
     final pWarningStatus = calloc<Uint32>();
     final pMainCode = calloc<Uint8>();
     final pSubCode = calloc<Uint8>();
+    PrinterStatus? printerStatus;
+    int? result;
 
     try {
-      final result = _queryPrinterStatus(
+      result = _queryPrinterStatus(
         pChassisTemp,
         pPrintheadTemp,
         pHeaterTemp,
@@ -256,7 +289,8 @@ class PrinterBindings {
         return null; // null 반환으로 변경
       }
 
-      return PrinterStatus(
+      printerStatus = PrinterStatus(
+        machineId: 0,
         mainCode: pMainCode.value,
         subCode: pSubCode.value,
         mainStatus: pMainStatus.value,
@@ -281,6 +315,8 @@ class PrinterBindings {
       calloc.free(pMainCode);
       calloc.free(pSubCode);
     }
+
+    return printerStatus;
   }
 
   // USB 초기화 메서드 추가

--- a/lib/features/core/printer/printer_bindings.dart
+++ b/lib/features/core/printer/printer_bindings.dart
@@ -134,8 +134,7 @@ class PrinterBindings {
       final result = _drawImage(x, y, width, height, pathPointer.cast(), noAbsoluteBlack ? 1 : 0);
       logger.i('DrawImage result: $result'); // 결과 코드 확인
       if (result != 0) {
-        final error = getErrorInfo(result);
-        throw Exception('Failed to draw image: $error (code: $result)');
+        throw Exception('Failed to draw image: $result');
       }
     } finally {
       calloc.free(pathPointer);
@@ -166,7 +165,7 @@ class PrinterBindings {
   void injectCard() {
     final result = _cardInject(0); // 0: 기본 위치
     if (result != 0) {
-      throw Exception('Failed to inject card');
+      throw Exception('Failed to inject card : $result');
     }
   }
 
@@ -207,7 +206,7 @@ class PrinterBindings {
     try {
       final result = _printDraw(frontPointer, backPointer);
       if (result != 0) {
-        throw Exception('Failed to print card');
+        throw Exception('Failed to print card : $result');
       }
     } finally {
       calloc.free(frontPointer);
@@ -221,7 +220,7 @@ class PrinterBindings {
   void ejectCard() {
     final result = _cardEject(0); // 0: 왼쪽으로 배출
     if (result != 0) {
-      throw Exception('Failed to eject card');
+      throw Exception('Failed to eject card $result');
     }
   }
 
@@ -258,7 +257,7 @@ class PrinterBindings {
   }
 
   // getPrinterStatus 메서드 추가
-  PrinterStatus? getPrinterStatus(int machineId) {
+  PrinterStatus? getPrinterStatus() {
     final pChassisTemp = calloc<Int16>();
     final pPrintheadTemp = calloc<Int16>();
     final pHeaterTemp = calloc<Int16>();

--- a/lib/features/core/printer/printer_bindings.typedef.dart
+++ b/lib/features/core/printer/printer_bindings.typedef.dart
@@ -111,3 +111,6 @@ typedef R600DrawImage = int Function(
 
 typedef R600IsFeederNoEmptyNative = Uint32 Function(Pointer<Int32>);
 typedef R600IsFeederNoEmpty = int Function(Pointer<Int32>);
+
+typedef R600GetRbnAndFilmRemainingNative = Uint32 Function(Pointer<Short> pRbnRemaining, Pointer<Short> pFilmRemaining);
+typedef R600GetRbnAndFilmRemaining = int Function(Pointer<Short> pRbnRemaining, Pointer<Short> pFilmRemaining);

--- a/lib/features/core/printer/printer_log.dart
+++ b/lib/features/core/printer/printer_log.dart
@@ -1,1 +1,26 @@
-// TODO Implement this library.
+import 'package:freezed_annotation/freezed_annotation.dart';
+
+part 'printer_log.freezed.dart';
+part 'printer_log.g.dart';
+
+@freezed
+class PrinterLog with _$PrinterLog {
+  const factory PrinterLog({
+    @Default(0) int kioskMachineId,
+    @Default('0') String sdkMainCode,
+    @Default('0') String sdkSubCode,
+    @Default('0') String printerMainStatusCode,
+    @Default('0') String printerErrorStatusCode,
+    @Default('0') String printerWarningStatusCode,
+    @Default(0) int chassisTemperature,
+    @Default(0) int printerHeadTemperature,
+    @Default(0) int heaterTemperature,
+    @Default(0) int rbnRemainingRatio,
+    @Default(0) int filmRemainingRatio,
+    @Default(null) bool? isPrintingNow,
+    @Default(null) bool? isFeederEmpty,
+    @Default(null) String? sdkErrorMessage,
+  }) = _PrinterLog;
+
+  factory PrinterLog.fromJson(Map<String, dynamic> json) => _$PrinterLogFromJson(json);
+}

--- a/lib/features/core/printer/printer_manager.dart
+++ b/lib/features/core/printer/printer_manager.dart
@@ -6,6 +6,7 @@ import 'dart:isolate';
 import 'dart:typed_data';
 import 'package:ffi/ffi.dart'; // Utf8 사용을 위한 임포트
 import 'package:flutter_snaptag_kiosk/features/core/printer/print_path.dart';
+import 'package:flutter_snaptag_kiosk/features/core/printer/printer_log.dart';
 import 'package:flutter_snaptag_kiosk/lib.dart';
 import 'package:image/image.dart' as img;
 
@@ -81,10 +82,12 @@ class PrinterManager {
               backImageInfo: behindImageInfo,
             );
 
+            final printerLog = getPrinterLogData(bindings);
+
             logger.i('7. Ejecting card...');
             bindings.ejectCard();
 
-            replyPort.send({'status': 'success'});
+            replyPort.send({'printStatus': printerLog});
           } catch (e) {
             logger.i('isolateReceivePort: $e');
             replyPort.send({'status': 'error'});
@@ -96,7 +99,7 @@ class PrinterManager {
     }
   }
 
-  Future<void> startPrint({
+  Future<PrinterLog?> startPrint({
     required File? frontFile,
     required File? embeddedFile,
   }) async {
@@ -116,16 +119,17 @@ class PrinterManager {
 
       _sendPort.send({'data': PrintPath(frontPath: frontPath, backPath: null), 'port': responsePort.sendPort});
 
-      final response = await responsePort.first as Map<String, dynamic>;
-
-      logger.i('response: $response');
-      if (response['status'] == 'success') {
-        logger.i('프린트 완료');
-      } else {
-        logger.i('프린트 실패');
+      try {
+        final response = await responsePort.first as Map<String, dynamic>;
+        return response['printStatus'] as PrinterLog;
+      } catch (e) {
+        logger.i('error: $e');
       }
+
+      return null;
     } catch (e, stack) {
       logger.i('error: $e stack: $stack');
+      rethrow;
     }
   }
 
@@ -179,8 +183,37 @@ class PrinterManager {
     }
   }
 
+  PrinterLog getPrinterLogData(PrinterBindings bindings) {
+    try {
+      final printerStatus = bindings.getPrinterStatus(0);
+      final ribbonStatus = bindings.getRbnAndFilmRemaining();
+      final isPrintingNow = bindings.checkCardPosition();
+      final isFeederEmpty = !bindings.checkFeederStatus();
+      // final errorMsg = printerStatus.$2 == null ? '' : bindings.getErrorInfo(printerStatus.$2 ?? 0);
+      logger.i(
+          'Printer status: $printerStatus, ribbon status: $ribbonStatus, isPrintingNow: $isPrintingNow isFeederEmpty: $isFeederEmpty');
+
+      return PrinterLog(
+          sdkMainCode: (printerStatus?.mainCode ?? 0).toString(),
+          sdkSubCode: (printerStatus?.mainCode ?? 0).toString(),
+          printerMainStatusCode: (printerStatus?.mainStatus ?? 0).toString(),
+          printerErrorStatusCode: (printerStatus?.errorStatus ?? 0).toString(),
+          printerWarningStatusCode: (printerStatus?.warningStatus ?? 0).toString(),
+          chassisTemperature: printerStatus?.chassisTemperature ?? 0,
+          printerHeadTemperature: printerStatus?.printHeadTemperature ?? 0,
+          heaterTemperature: printerStatus?.heaterTemperature ?? 0,
+          rbnRemainingRatio: ribbonStatus?.rbnRemaining ?? 0,
+          filmRemainingRatio: ribbonStatus?.filmRemaining ?? 0,
+          isPrintingNow: isPrintingNow,
+          isFeederEmpty: isFeederEmpty,
+          sdkErrorMessage: '');
+    } catch (e) {
+      rethrow;
+    }
+  }
+
   void printStatus(PrinterBindings bindings) {
-    final status = bindings.getPrinterStatus();
+    final status = bindings.getPrinterStatus(0);
     if (status != null) {
       logger.i(
           'status mainCode ${status.mainCode} mainStatus ${status.mainStatus} errorStatus ${status.errorStatus} subCode ${status.subCode} wariningStatus ${status.warningStatus}');

--- a/lib/features/core/printer/printer_status.dart
+++ b/lib/features/core/printer/printer_status.dart
@@ -1,23 +1,22 @@
-class PrinterStatus {
-  final int mainCode;
-  final int subCode;
-  final int mainStatus;
-  final int errorStatus;
-  final int warningStatus;
-  final int chassisTemperature;
-  final int printHeadTemperature;
-  final int heaterTemperature;
-  final int subStatus;
+import 'package:freezed_annotation/freezed_annotation.dart';
 
-  const PrinterStatus({
-    required this.mainCode,
-    required this.subCode,
-    required this.mainStatus,
-    required this.errorStatus,
-    required this.warningStatus,
-    required this.chassisTemperature,
-    required this.printHeadTemperature,
-    required this.heaterTemperature,
-    required this.subStatus,
-  });
+part 'printer_status.freezed.dart';
+part 'printer_status.g.dart';
+
+@freezed
+class PrinterStatus with _$PrinterStatus {
+  const factory PrinterStatus({
+    required int machineId,
+    required int mainCode,
+    required int subCode,
+    required int mainStatus,
+    required int errorStatus,
+    required int warningStatus,
+    required int chassisTemperature,
+    required int printHeadTemperature,
+    required int heaterTemperature,
+    required int subStatus,
+  }) = _PrinterStatus;
+
+  factory PrinterStatus.fromJson(Map<String, dynamic> json) => _$PrinterStatusFromJson(json);
 }

--- a/lib/features/core/printer/ribbon_status.dart
+++ b/lib/features/core/printer/ribbon_status.dart
@@ -1,1 +1,11 @@
-// TODO Implement this library.
+import 'package:freezed_annotation/freezed_annotation.dart';
+
+part 'ribbon_status.freezed.dart';
+part 'ribbon_status.g.dart';
+
+@freezed
+class RibbonStatus with _$RibbonStatus {
+  const factory RibbonStatus({required int rbnRemaining, required int filmRemaining}) = _RibbonStatus;
+
+  factory RibbonStatus.fromJson(Map<String, dynamic> json) => _$RibbonStatusFromJson(json);
+}

--- a/lib/features/move_me/screens/photo_card_upload_screen.dart
+++ b/lib/features/move_me/screens/photo_card_upload_screen.dart
@@ -59,8 +59,6 @@ class PhotoCardUploadScreen extends ConsumerWidget {
           ),
           onPressed: () async {
             await SoundManager().playSound();
-
-            await ref.read(printerServiceProvider.notifier).printImage(frontFile: null, backFile: null);
             CodeVerificationRouteData().go(context);
           },
         ),

--- a/lib/features/presentation/screens/print_process_screen.dart
+++ b/lib/features/presentation/screens/print_process_screen.dart
@@ -53,6 +53,7 @@ class _PrintProcessScreenState extends ConsumerState<PrintProcessScreen> {
             await DialogHelper.showPrintErrorDialog(
               context,
               onButtonPressed: () {
+                ref.read(printingStateProvider.notifier).updatePrinting(false);
                 PhotoCardUploadRouteData().go(context);
               },
             );


### PR DESCRIPTION
Why:
- 프린트 상태를 DB에 저장하고 관리자 페이지에서 확인하기 위해 구현.
- 슬랙으로도 프린트 상태를 표시함.

What:
- 프린트 상태 ( 온도, 상태 코드, 에러 코드 등 ) , 카드 공급기 / 카드 존재 여부, 리본 / 필름 잔량 확인

How:
- 이벤트를 처음 가져올 때 프린트 상태 로깅.
- 포토카드 프린팅 후 프린트 상태 로깅.

```kotlin
void _printEntry(SendPort sendPort) async {
    try {
      //...

      isolateReceivePort.listen((message) async {
        SendPort? replyPort;
        try {
          if (message is PrintMessage) {
            //...
	          
		        // 프린트 로깅이 필요한 경우, 상태 확인 후 바로 종료.
            if (shouldPrintLog) {
              final printerLog = getPrinterLogData(bindings);
              replyPort.send({'printStatus': printerLog});
              return;
            }
            
            //..

            logger.i('6. Printing card...');
            bindings.printCard(
              frontImageInfo: frontImageInfo,
              backImageInfo: behindImageInfo,
            );
	
            final printerLog = getPrinterLogData(bindings);   // 프린트 후 상태 로깅
            
            logger.i('7. Ejecting card...');
            bindings.ejectCard();

            replyPort.send({'printStatus': printerLog, 'error': ''});
          }
        }
```