### PR TITLE
Isolate 제외 프린트 로깅 구현

### DIFF
--- a/lib/data/datasources/cache/kiosk_info_service.dart
+++ b/lib/data/datasources/cache/kiosk_info_service.dart
@@ -28,6 +28,8 @@ class KioskInfoService extends _$KioskInfoService {
 
       ref.read(frontPhotoListProvider.notifier).fetch();
 
+      ref.read(printerServiceProvider.notifier).startPrintLog();
+
       return response;
     } catch (e) {
       ref.invalidateSelf();

--- a/lib/data/datasources/remote/kiosk_api_client.dart
+++ b/lib/data/datasources/remote/kiosk_api_client.dart
@@ -59,4 +59,9 @@ abstract class KioskApiClient {
     @Path('printedPhotoCardId') required int printedPhotoCardId,
     @Body() required Map<String, dynamic> body,
   });
+
+  @POST('/v1/machine/log')
+  Future<void> updatePrintLog({
+    @Body() required Map<String, dynamic> body,
+  });
 }

--- a/lib/data/repositories/kiosk_repository.dart
+++ b/lib/data/repositories/kiosk_repository.dart
@@ -1,5 +1,6 @@
 import 'package:flutter_snaptag_kiosk/data/datasources/remote/remote.dart';
 import 'package:flutter_snaptag_kiosk/data/models/models.dart';
+import 'package:flutter_snaptag_kiosk/features/core/printer/printer_log.dart';
 import 'package:flutter_snaptag_kiosk/flavors.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
 
@@ -106,6 +107,18 @@ class _KioskRepository {
     try {
       return await _apiClient.updatePrint(
         printedPhotoCardId: printedPhotoCardId,
+        body: request.toJson(),
+      );
+    } catch (e) {
+      rethrow;
+    }
+  }
+
+  Future<void> updatePrintLog({
+    required PrinterLog request,
+  }) async {
+    try {
+      await _apiClient.updatePrintLog(
         body: request.toJson(),
       );
     } catch (e) {

--- a/lib/features/core/printer/card_printer.dart
+++ b/lib/features/core/printer/card_printer.dart
@@ -2,8 +2,11 @@ import 'dart:ffi' as ffi; // ffi 임포트 확인
 import 'dart:io';
 
 import 'package:ffi/ffi.dart'; // Utf8 사용을 위한 임포트
-import 'package:flutter/foundation.dart';
 import 'package:flutter_snaptag_kiosk/core/utils/logger_service.dart';
+import 'package:flutter_snaptag_kiosk/data/datasources/cache/kiosk_info_service.dart';
+import 'package:flutter_snaptag_kiosk/data/datasources/remote/slack_log_service.dart';
+import 'package:flutter_snaptag_kiosk/data/repositories/kiosk_repository.dart';
+import 'package:flutter_snaptag_kiosk/features/core/printer/printer_log.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
 
 import 'printer_bindings.dart';
@@ -128,9 +131,23 @@ class PrinterService extends _$PrinterService {
 
       logger.i('7. Ejecting card...');
       _bindings.ejectCard();
+
+      startPrintLog();
     } catch (e, stack) {
       logger.i('Print error: $e\nStack: $stack');
       rethrow;
+    }
+  }
+
+  Future<void> startPrintLog() async {
+    final printerLog = getPrinterLogData(_bindings);
+    if (printerLog != null) {
+      final machineId = ref.read(kioskInfoServiceProvider)?.kioskMachineId ?? 0;
+      final log = printerLog.copyWith(kioskMachineId: machineId);
+      if (machineId != 0) {
+        await ref.read(kioskRepositoryProvider).updatePrintLog(request: log);
+        SlackLogService().sendLogToSlack('PrintState : $log');
+      }
     }
   }
 
@@ -189,6 +206,36 @@ class PrinterService extends _$PrinterService {
     } finally {
       calloc.free(strPtr);
       calloc.free(lenPtr);
+    }
+  }
+
+  PrinterLog? getPrinterLogData(PrinterBindings bindings) {
+    try {
+      final printerStatus = bindings.getPrinterStatus();
+      final ribbonStatus = bindings.getRbnAndFilmRemaining();
+      final isPrintingNow = bindings.checkCardPosition();
+      final isFeederEmpty = !bindings.checkFeederStatus();
+      // final errorMsg = printerStatus.$2 == null ? '' : bindings.getErrorInfo(printerStatus.$2 ?? 0);
+      logger.i(
+          'Printer status: $printerStatus, ribbon status: $ribbonStatus, isPrintingNow: $isPrintingNow isFeederEmpty: $isFeederEmpty');
+
+      return PrinterLog(
+          sdkMainCode: (printerStatus?.mainCode ?? 0).toString(),
+          sdkSubCode: (printerStatus?.mainCode ?? 0).toString(),
+          printerMainStatusCode: (printerStatus?.mainStatus ?? 0).toString(),
+          printerErrorStatusCode: (printerStatus?.errorStatus ?? 0).toString(),
+          printerWarningStatusCode: (printerStatus?.warningStatus ?? 0).toString(),
+          chassisTemperature: printerStatus?.chassisTemperature ?? 0,
+          printerHeadTemperature: printerStatus?.printHeadTemperature ?? 0,
+          heaterTemperature: printerStatus?.heaterTemperature ?? 0,
+          rbnRemainingRatio: ribbonStatus?.rbnRemaining ?? 0,
+          filmRemainingRatio: ribbonStatus?.filmRemaining ?? 0,
+          isPrintingNow: isPrintingNow,
+          isFeederEmpty: isFeederEmpty,
+          sdkErrorMessage: '');
+    } catch (e) {
+      logger.i(e);
+      return null;
     }
   }
 }

--- a/lib/features/core/printer/print_log.dart
+++ b/lib/features/core/printer/print_log.dart
@@ -1,0 +1,1 @@
+// TODO Implement this library.

--- a/lib/features/core/printer/printer_bindings.dart
+++ b/lib/features/core/printer/printer_bindings.dart
@@ -3,6 +3,7 @@ import 'dart:io';
 import 'dart:typed_data';
 
 import 'package:ffi/ffi.dart';
+import 'package:flutter_snaptag_kiosk/features/core/printer/ribbon_status.dart';
 import 'package:flutter_snaptag_kiosk/lib.dart';
 import 'package:image/image.dart' as img;
 
@@ -35,6 +36,7 @@ class PrinterBindings {
   late final R600SetTextIsStrong _setTextIsStrong;
   late final R600DrawImage _drawImage;
   late final R600IsFeederNoEmpty _isFeederNoEmpty;
+  late final R600GetRbnAndFilmRemaining _getRbnAndFilmRemaining;
 
   PrinterBindings() {
     // DLL 로드
@@ -64,6 +66,8 @@ class PrinterBindings {
     _setFont = _dll.lookupFunction<R600SetFontNative, R600SetFont>('R600SetFont');
     _setTextIsStrong = _dll.lookupFunction<R600SetTextIsStrongNative, R600SetTextIsStrong>('R600SetTextIsStrong');
     _isFeederNoEmpty = _dll.lookupFunction<R600IsFeederNoEmptyNative, R600IsFeederNoEmpty>('R600IsFeederNoEmpty');
+    _getRbnAndFilmRemaining =
+        _dll.lookupFunction<R600GetRbnAndFilmRemainingNative, R600GetRbnAndFilmRemaining>('R600GetRbnAndFilmRemaining');
   }
 
   int initLibrary() {
@@ -237,9 +241,11 @@ class PrinterBindings {
     final pWarningStatus = calloc<Uint32>();
     final pMainCode = calloc<Uint8>();
     final pSubCode = calloc<Uint8>();
+    PrinterStatus? printerStatus;
+    int? result;
 
     try {
-      final result = _queryPrinterStatus(
+      result = _queryPrinterStatus(
         pChassisTemp,
         pPrintheadTemp,
         pHeaterTemp,
@@ -256,7 +262,8 @@ class PrinterBindings {
         return null; // null 반환으로 변경
       }
 
-      return PrinterStatus(
+      printerStatus = PrinterStatus(
+        machineId: 0,
         mainCode: pMainCode.value,
         subCode: pSubCode.value,
         mainStatus: pMainStatus.value,
@@ -281,6 +288,35 @@ class PrinterBindings {
       calloc.free(pMainCode);
       calloc.free(pSubCode);
     }
+
+    return printerStatus;
+  }
+
+  // 리본과 필름 잔량 확인 함수
+  RibbonStatus? getRbnAndFilmRemaining() {
+    final rbnRemaining = calloc<Short>();
+    final filmRemaining = calloc<Short>();
+    RibbonStatus? ribbonStatus;
+
+    try {
+      final result = _getRbnAndFilmRemaining(rbnRemaining, filmRemaining);
+      if (result != 0) {
+        throw Exception('Failed to get ribbon and film remaining');
+      }
+      logger.i('Ribbon remaining: ${rbnRemaining.value}');
+      logger.i('Film remaining: ${filmRemaining.value}');
+      ribbonStatus = RibbonStatus(
+        rbnRemaining: rbnRemaining.value,
+        filmRemaining: filmRemaining.value,
+      );
+    } catch (e) {
+      rethrow;
+    } finally {
+      calloc.free(rbnRemaining);
+      calloc.free(filmRemaining);
+    }
+
+    return ribbonStatus;
   }
 
   // USB 초기화 메서드 추가

--- a/lib/features/core/printer/printer_bindings.typedef.dart
+++ b/lib/features/core/printer/printer_bindings.typedef.dart
@@ -111,3 +111,6 @@ typedef R600DrawImage = int Function(
 
 typedef R600IsFeederNoEmptyNative = Uint32 Function(Pointer<Int32>);
 typedef R600IsFeederNoEmpty = int Function(Pointer<Int32>);
+
+typedef R600GetRbnAndFilmRemainingNative = Uint32 Function(Pointer<Short> pRbnRemaining, Pointer<Short> pFilmRemaining);
+typedef R600GetRbnAndFilmRemaining = int Function(Pointer<Short> pRbnRemaining, Pointer<Short> pFilmRemaining);

--- a/lib/features/core/printer/printer_log.dart
+++ b/lib/features/core/printer/printer_log.dart
@@ -1,0 +1,26 @@
+import 'package:freezed_annotation/freezed_annotation.dart';
+
+part 'printer_log.freezed.dart';
+part 'printer_log.g.dart';
+
+@freezed
+class PrinterLog with _$PrinterLog {
+  const factory PrinterLog({
+    @Default(0) int kioskMachineId,
+    @Default('0') String sdkMainCode,
+    @Default('0') String sdkSubCode,
+    @Default('0') String printerMainStatusCode,
+    @Default('0') String printerErrorStatusCode,
+    @Default('0') String printerWarningStatusCode,
+    @Default(0) int chassisTemperature,
+    @Default(0) int printerHeadTemperature,
+    @Default(0) int heaterTemperature,
+    @Default(0) int rbnRemainingRatio,
+    @Default(0) int filmRemainingRatio,
+    @Default(null) bool? isPrintingNow,
+    @Default(null) bool? isFeederEmpty,
+    @Default(null) String? sdkErrorMessage,
+  }) = _PrinterLog;
+
+  factory PrinterLog.fromJson(Map<String, dynamic> json) => _$PrinterLogFromJson(json);
+}

--- a/lib/features/core/printer/printer_status.dart
+++ b/lib/features/core/printer/printer_status.dart
@@ -1,23 +1,22 @@
-class PrinterStatus {
-  final int mainCode;
-  final int subCode;
-  final int mainStatus;
-  final int errorStatus;
-  final int warningStatus;
-  final int chassisTemperature;
-  final int printHeadTemperature;
-  final int heaterTemperature;
-  final int subStatus;
+import 'package:freezed_annotation/freezed_annotation.dart';
 
-  const PrinterStatus({
-    required this.mainCode,
-    required this.subCode,
-    required this.mainStatus,
-    required this.errorStatus,
-    required this.warningStatus,
-    required this.chassisTemperature,
-    required this.printHeadTemperature,
-    required this.heaterTemperature,
-    required this.subStatus,
-  });
+part 'printer_status.freezed.dart';
+part 'printer_status.g.dart';
+
+@freezed
+class PrinterStatus with _$PrinterStatus {
+  const factory PrinterStatus({
+    required int machineId,
+    required int mainCode,
+    required int subCode,
+    required int mainStatus,
+    required int errorStatus,
+    required int warningStatus,
+    required int chassisTemperature,
+    required int printHeadTemperature,
+    required int heaterTemperature,
+    required int subStatus,
+  }) = _PrinterStatus;
+
+  factory PrinterStatus.fromJson(Map<String, dynamic> json) => _$PrinterStatusFromJson(json);
 }

--- a/lib/features/core/printer/ribbon_status.dart
+++ b/lib/features/core/printer/ribbon_status.dart
@@ -1,0 +1,11 @@
+import 'package:freezed_annotation/freezed_annotation.dart';
+
+part 'ribbon_status.freezed.dart';
+part 'ribbon_status.g.dart';
+
+@freezed
+class RibbonStatus with _$RibbonStatus {
+  const factory RibbonStatus({required int rbnRemaining, required int filmRemaining}) = _RibbonStatus;
+
+  factory RibbonStatus.fromJson(Map<String, dynamic> json) => _$RibbonStatusFromJson(json);
+}


### PR DESCRIPTION
Why:
- Isolate의 불안정성 때문에 제거 후, 프린트 로깅 기능만 추가.

What:
- 프린트 상태 ( 온도, 상태 코드, 에러 코드 등 ) , 카드 공급기 / 카드 존재 여부, 리본 / 필름 잔량 확인

How:
- 이벤트를 처음 가져올 때 프린트 상태 로깅.
- 포토카드 프린팅 후 프린트 상태 로깅.