### PR TITLE
결제 실패 에러 슬랙 로깅 추가 / 프린트 상태 로깅 제거

### DIFF
--- a/lib/data/datasources/cache/kiosk_info_service.dart
+++ b/lib/data/datasources/cache/kiosk_info_service.dart
@@ -28,7 +28,8 @@ class KioskInfoService extends _$KioskInfoService {
 
       ref.read(frontPhotoListProvider.notifier).fetch();
 
-      ref.read(printerServiceProvider.notifier).startPrintLog();
+      // ❗️ 주석 처리된 부분은 나중에 필요할 때 활성화
+      // ref.read(printerServiceProvider.notifier).startPrintLog();
 
       return response;
     } catch (e) {

--- a/lib/data/datasources/remote/slack_log_service.dart
+++ b/lib/data/datasources/remote/slack_log_service.dart
@@ -9,6 +9,9 @@ class SlackLogService {
   factory SlackLogService() => _instance;
 
   final slackWebhookUrl = dotenv.env['SLACK_WEBHOOK_URL'];
+
+  final slackWebhookErrorUrl = dotenv.env['SLACK_WEBHOOK_ERROR_LOG_URL'];
+
   SlackLogService._internal() {
     init();
   }
@@ -17,8 +20,16 @@ class SlackLogService {
     sendLogToSlack("🚀 Flutter App Started!");
   }
 
+  Future<void> sendErrorLogToSlack(String message) async {
+    await sendLog(slackWebhookErrorUrl, message);
+  }
+
   Future<void> sendLogToSlack(String message) async {
-    if (slackWebhookUrl == null) {
+    await sendLog(slackWebhookUrl, message);
+  }
+
+  Future<void> sendLog(String? url, String message) async {
+    if (url == null) {
       log("❌ Slack Webhook URL이 없습니다.");
       return;
     }
@@ -30,18 +41,18 @@ class SlackLogService {
 
       try {
         final response = await http.post(
-          Uri.parse(slackWebhookUrl!),
+          Uri.parse(url),
           headers: {"Content-Type": "application/json"},
           body: payload,
         );
 
         if (response.statusCode != 200) {
           log("❌ Slack Webhook 오류: ${response.body}");
-          log("curl -X POST -H \"Content-Type: application/json\" -d '$payload' $slackWebhookUrl");
+          log("curl -X POST -H \"Content-Type: application/json\" -d '$payload' $url");
         }
       } catch (e) {
         log("❌ Slack Webhook 오류: $e");
-        log("curl -X POST -H \"Content-Type: application/json\" -d '$payload' $slackWebhookUrl");
+        log("curl -X POST -H \"Content-Type: application/json\" -d '$payload' $url");
       }
     }
   }

--- a/lib/features/core/printer/card_printer.dart
+++ b/lib/features/core/printer/card_printer.dart
@@ -132,7 +132,8 @@ class PrinterService extends _$PrinterService {
       logger.i('7. Ejecting card...');
       _bindings.ejectCard();
 
-      startPrintLog();
+      // ❗️ 주석 처리된 부분은 나중에 필요할 때 활성화
+      // startPrintLog();
     } catch (e, stack) {
       logger.i('Print error: $e\nStack: $stack');
       rethrow;

--- a/lib/features/presentation/providers/states/payment_response_state.dart
+++ b/lib/features/presentation/providers/states/payment_response_state.dart
@@ -9,7 +9,20 @@ class PaymentResponseState extends _$PaymentResponseState {
   PaymentResponse? build() => null;
 
   void update(PaymentResponse response) {
-    SlackLogService().sendLogToSlack('PaymentResponseState.update: $response');
+    try {
+      if (response.res != '0000') {
+        final orderResponse = ref.read(createOrderInfoProvider);
+        if (orderResponse == null) {
+          throw Exception('No order response available');
+        }
+
+        SlackLogService().sendErrorLogToSlack('OrderResponse : $orderResponse \n PaymentResponse: $response');
+      }
+      SlackLogService().sendLogToSlack('PaymentResponse: $response');
+    } catch (e) {
+      SlackLogService().sendLogToSlack('PaymentResponseState Exception: $e');
+    }
+
     state = response;
   }
 


### PR DESCRIPTION
Why:
- 안정성을 고려하여 프린트 상태 로깅 기능 중단.
- 결제 실패의 경우 기존의 채널에서 확인하기 어렵기 때문에 새로운 슬랙 채널 생성.

What:
- SLACK_WEBHOOK_ERROR_LOG_URL , 새로운 슬랙 훅 URL 생성
- PrinterServiceProvider의 startPrintLog 주석 처리

How:
- .env 파일
```kotlin
SLACK_WEBHOOK_URL=https://hooks.slack.com/services/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
SLACK_WEBHOOK_ERROR_LOG_URL=https://hooks.slack.com/services/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
```