### PR TITLE
fix: go_router 버전 14.6.2 -> 15.2.0

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -22,7 +22,7 @@ dependencies:
   easy_localization: ^3.0.7
 
   # Routing
-  go_router: ^14.6.2
+  go_router: ^15.2.0
 
   # Code Generation
   freezed_annotation: ^2.4.4


### PR DESCRIPTION
flutter 빌드 이슈로 인한 go_router 버전 업그레이드

go_router 버전 14.6.2 -> 15.2.0 업그레이드


**go_router change log**
```
## 15.1.0

- Adds `caseSensitive` to `TypedGoRoute`.
```