### PR TITLE
Fix : GoRouter 15.2.0 변경으로 인한 버그 수정

### DIFF
--- a/lib/data/repositories/version_repository.dart
+++ b/lib/data/repositories/version_repository.dart
@@ -12,8 +12,8 @@ class VersionRepository {
   late final String launcherPath;
 
   VersionRepository() {
-    home = Platform.environment['USERPROFILE'] ??
-        (throw Exception("홈 디렉토리를 가져올 수 없습니다."));
+    home =
+        Platform.environment['HOME'] ?? Platform.environment['USERPROFILE'] ?? (throw Exception("홈 디렉토리를 가져올 수 없습니다."));
 
     snaptagDir = Directory(p.join(home, 'Snaptag'));
     if (!snaptagDir.existsSync()) {

--- a/lib/routers/router.dart
+++ b/lib/routers/router.dart
@@ -55,7 +55,7 @@ class ImageShellRouteData extends ShellRouteData {
   }
 }
 
-class SetupMainRouteData extends GoRouteData {
+class SetupMainRouteData extends GoRouteData with _$SetupMainRouteData {
   const SetupMainRouteData();
 
   @override
@@ -66,7 +66,7 @@ class SetupMainRouteData extends GoRouteData {
   }
 }
 
-class PaymentHistoryRouteData extends GoRouteData {
+class PaymentHistoryRouteData extends GoRouteData with _$PaymentHistoryRouteData {
   const PaymentHistoryRouteData();
 
   @override
@@ -77,7 +77,7 @@ class PaymentHistoryRouteData extends GoRouteData {
   }
 }
 
-class UnitTestRouteData extends GoRouteData {
+class UnitTestRouteData extends GoRouteData with _$UnitTestRouteData {
   const UnitTestRouteData();
 
   @override
@@ -88,7 +88,7 @@ class UnitTestRouteData extends GoRouteData {
   }
 }
 
-class KioskComponentsRouteData extends GoRouteData {
+class KioskComponentsRouteData extends GoRouteData with _$KioskComponentsRouteData {
   const KioskComponentsRouteData();
 
   @override
@@ -99,7 +99,7 @@ class KioskComponentsRouteData extends GoRouteData {
   }
 }
 
-class KioskInfoRouteData extends GoRouteData {
+class KioskInfoRouteData extends GoRouteData with _$KioskInfoRouteData {
   const KioskInfoRouteData();
 
   @override
@@ -110,7 +110,7 @@ class KioskInfoRouteData extends GoRouteData {
   }
 }
 
-class KioskRouteData extends GoRouteData {
+class KioskRouteData extends GoRouteData with _$KioskRouteData {
   const KioskRouteData();
 
   @override
@@ -121,7 +121,7 @@ class KioskRouteData extends GoRouteData {
   }
 }
 
-class PhotoCardUploadRouteData extends GoRouteData {
+class PhotoCardUploadRouteData extends GoRouteData with _$PhotoCardUploadRouteData {
   const PhotoCardUploadRouteData();
 
   @override
@@ -132,7 +132,7 @@ class PhotoCardUploadRouteData extends GoRouteData {
   }
 }
 
-class CodeVerificationRouteData extends GoRouteData {
+class CodeVerificationRouteData extends GoRouteData with _$CodeVerificationRouteData {
   const CodeVerificationRouteData();
 
   @override
@@ -143,7 +143,7 @@ class CodeVerificationRouteData extends GoRouteData {
   }
 }
 
-class PhotoCardPreviewRouteData extends GoRouteData {
+class PhotoCardPreviewRouteData extends GoRouteData with _$PhotoCardPreviewRouteData {
   const PhotoCardPreviewRouteData();
 
   @override
@@ -154,7 +154,7 @@ class PhotoCardPreviewRouteData extends GoRouteData {
   }
 }
 
-class PrintProcessRouteData extends GoRouteData {
+class PrintProcessRouteData extends GoRouteData with _$PrintProcessRouteData {
   const PrintProcessRouteData();
 
   @override
@@ -165,7 +165,7 @@ class PrintProcessRouteData extends GoRouteData {
   }
 }
 
-class MaintenanceRouteData extends GoRouteData {
+class MaintenanceRouteData extends GoRouteData with _$MaintenanceRouteData {
   const MaintenanceRouteData();
 
   @override
@@ -175,4 +175,3 @@ class MaintenanceRouteData extends GoRouteData {
     );
   }
 }
-

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -55,7 +55,7 @@ dev_dependencies:
   # Code Generation
   build_runner: ^2.4.14
   riverpod_generator: ^2.3.9
-  go_router_builder: ^2.7.1
+  go_router_builder: ^3.0.0
   freezed: ^2.5.7
   json_serializable: ^6.9.0
   retrofit_generator: ^9.1.5


### PR DESCRIPTION
Why:

- GoRouter 15.2.0 변경으로 인한 버그 발생
    - `UnimplementedError: Should be generated using Type-safe routing`
- Home 환경 변수 MAC OS 로 인한 버그 발생

How:

1. go_router_builder : 2.7.1 -> 3.0.0 변경
2. VersionRepository, home 환경 변수 추가
3. GoRouter 15+의 타입 세이프 라우팅 요구사항 충족 -> 모든 Router에 mixin 추가