### PR TITLE
프린트 연결 상태 대응 로직 수정

### DIFF
--- a/lib/features/core/printer/card_printer.dart
+++ b/lib/features/core/printer/card_printer.dart
@@ -32,6 +32,8 @@ class PrinterService extends _$PrinterService {
       // 1. 라이브러리 초기화 전에 이전 상태 정리
       _bindings.clearLibrary();
 
+      _bindings.initLibrary();
+
       // checkConnectedWithPrinterLog();
 
       // settingPrinter();

--- a/lib/features/core/printer/printer_bindings.dart
+++ b/lib/features/core/printer/printer_bindings.dart
@@ -372,9 +372,6 @@ class PrinterBindings {
     final numPtr = calloc<Int32>()..value = 10;
 
     try {
-      // 먼저 이전 상태를 정리
-      _libInit();
-
       logger.i('Enumerating USB printer...'); // 디버그 로그 추가
       // USB 프린터만 사용
       int result = _enumUsbPrt(enumListPtr.cast(), listLenPtr, numPtr);


### PR DESCRIPTION
Why:

- 프린트 off, 앱 처음 켰을 때  프린트 연결 시 앱 crash 발생 

How:

- 프린트 연결 로직에서 Init 함수 분리
- Init 함수는 Provider 초기화 함수에 같이 포함.