### PR TITLE
프린터 상태 슬랙 로그 타이밍 변경 / 홈 화면에서 프린터 연결 상태 체크 추가

### DIFF
--- a/lib/features/core/printer/card_printer.dart
+++ b/lib/features/core/printer/card_printer.dart
@@ -16,8 +16,6 @@ part 'card_printer.g.dart';
 class PrinterService extends _$PrinterService {
   late final PrinterBindings _bindings;
 
-  bool _firstConnectedFailed = false;
-
   @override
   FutureOr<void> build() async {
     logger.i('Printer initialization..');
@@ -57,19 +55,10 @@ class PrinterService extends _$PrinterService {
     }
   }
 
-  Future<bool> checkConnectedPrint() async {
+  bool checkConnectedPrint() {
     try {
       final connected = _bindings.connectPrinter();
       logger.e('checkConnectedPrint: $connected');
-
-      if (!connected) {
-        if (!_firstConnectedFailed) {
-          _firstConnectedFailed = true;
-          SlackLogService().sendErrorLogToSlack('PrintConnected Failed - First Attempt');
-        }
-        return false;
-      }
-
       final printerLog = getPrinterLogData(_bindings);
 
       final isReady = printerLog?.printerMainStatusCode == "1004";

--- a/lib/features/core/printer/print_connect_state.dart
+++ b/lib/features/core/printer/print_connect_state.dart
@@ -1,0 +1,35 @@
+import 'package:flutter_snaptag_kiosk/data/datasources/cache/kiosk_info_service.dart';
+import 'package:flutter_snaptag_kiosk/data/datasources/remote/slack_log_service.dart';
+import 'package:riverpod_annotation/riverpod_annotation.dart';
+
+part 'print_connect_state.g.dart';
+
+enum PrintConnectState {
+  connected,
+  disconnected,
+  pending,
+}
+
+@Riverpod(keepAlive: true)
+class PrintConnect extends _$PrintConnect {
+  @override
+  PrintConnectState build() {
+    return PrintConnectState.pending;
+  }
+
+  /// 프린터 연결 상태 업데이트
+  /// @param state 연결 상태
+  void update(PrintConnectState state) {
+    final machineId = ref.read(kioskInfoServiceProvider)?.kioskMachineId ?? 0;
+
+    if (this.state == state || state == PrintConnectState.pending) {
+      // 현재 상태와 동일하거나, 상태가 'pending'인 경우
+      // 'pending' 상태는 연결 상태가 아직 결정되지 않은 경우이므로, 아무 작업도 하지 않음
+      return;
+    }
+
+    SlackLogService().sendLogToSlack('MachineId : $machineId Printer ${state.name}');
+
+    this.state = state;
+  }
+}

--- a/lib/features/core/printer/printer_connect_state.dart
+++ b/lib/features/core/printer/printer_connect_state.dart
@@ -2,33 +2,34 @@ import 'package:flutter_snaptag_kiosk/data/datasources/cache/kiosk_info_service.
 import 'package:flutter_snaptag_kiosk/data/datasources/remote/slack_log_service.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
 
-part 'print_connect_state.g.dart';
+part 'printer_connect_state.g.dart';
 
-enum PrintConnectState {
+enum PrinterConnectState {
   connected,
   disconnected,
+  setupInComplete,
   pending,
 }
 
 @Riverpod(keepAlive: true)
-class PrintConnect extends _$PrintConnect {
+class PrinterConnect extends _$PrinterConnect {
   @override
-  PrintConnectState build() {
-    return PrintConnectState.pending;
+  PrinterConnectState build() {
+    return PrinterConnectState.pending;
   }
 
   /// 프린터 연결 상태 업데이트
   /// @param state 연결 상태
-  void update(PrintConnectState state) {
+  void update(PrinterConnectState state) {
     final machineId = ref.read(kioskInfoServiceProvider)?.kioskMachineId ?? 0;
 
-    if (this.state == state || state == PrintConnectState.pending) {
+    if (this.state == state || state == PrinterConnectState.pending) {
       // 현재 상태와 동일하거나, 상태가 'pending'인 경우
       // 'pending' 상태는 연결 상태가 아직 결정되지 않은 경우이므로, 아무 작업도 하지 않음
       return;
     }
 
-    SlackLogService().sendLogToSlack('MachineId : $machineId Printer ${state.name}');
+    SlackLogService().sendLogToSlack('*[MachineId: $machineId]*\nPrinter ${state.name}');
 
     this.state = state;
   }

--- a/lib/features/move_me/screens/photo_card_upload_screen.dart
+++ b/lib/features/move_me/screens/photo_card_upload_screen.dart
@@ -107,29 +107,6 @@ class PhotoCardUploadScreen extends ConsumerWidget {
   }
 
   Future<void> showNeedRibbonFilmDialog(BuildContext context, WidgetRef ref) async {
-    int machineId = ref.read(kioskInfoServiceProvider)?.kioskMachineId ?? 0;
-    final connected = await ref.read(printerServiceProvider.notifier).checkConnectedPrint();
-
-    if (!connected) {
-      SlackLogService()
-          .sendErrorLogToSlack('*[MachineId: $machineId]*\nPrinter ${PrinterConnectState.disconnected.name}');
-      DialogHelper.showNeedRibbonFilmDialog(context, () {
-        showNeedRibbonFilmDialog(context, ref);
-      });
-      return;
-    }
-    if (connected) {
-      final settingCompleted = ref.read(printerServiceProvider.notifier).settingPrinter();
-      if (!settingCompleted) {
-        SlackLogService()
-            .sendErrorLogToSlack('*[MachineId: $machineId]*\nPrinter ${PrinterConnectState.setupInComplete.name}');
-        DialogHelper.showNeedRibbonFilmDialog(context, () {
-          showNeedRibbonFilmDialog(context, ref);
-        });
-        return;
-      }
-    }
-
     RibbonStatus ribbonStatus = ref.read(printerServiceProvider.notifier).getRibbonStatus();
     bool isRibbonShouldBeChanged = ref.read(ribbonWarningProvider.notifier).isRibbonShouldBeChanged(ribbonStatus);
     bool isFilmShouldBeChanged = ref.read(ribbonWarningProvider.notifier).isFilmShouldBeChanged(ribbonStatus);

--- a/lib/features/move_me/screens/photo_card_upload_screen.dart
+++ b/lib/features/move_me/screens/photo_card_upload_screen.dart
@@ -3,6 +3,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_screenutil/flutter_screenutil.dart';
 import 'package:flutter_snaptag_kiosk/core/utils/sound_manager.dart';
+import 'package:flutter_snaptag_kiosk/features/core/printer/printer_connect_state.dart';
 import 'package:flutter_snaptag_kiosk/features/core/printer/ribbon_status.dart';
 import 'package:flutter_snaptag_kiosk/lib.dart';
 import 'package:flutter_snaptag_kiosk/features/core/printer/ribbon_warning_provider.dart';
@@ -14,9 +15,26 @@ class PhotoCardUploadScreen extends ConsumerWidget {
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     final kiosk = ref.watch(kioskInfoServiceProvider);
-    
-    WidgetsBinding.instance.addPostFrameCallback((_) {
+
+    WidgetsBinding.instance.addPostFrameCallback((_) async {
       int machineId = ref.read(kioskInfoServiceProvider)?.kioskMachineId ?? 0;
+      final connected = await ref.read(printerServiceProvider.notifier).checkConnectedPrint();
+      if (!connected) {
+        SlackLogService()
+            .sendErrorLogToSlack('*[MachineId: $machineId]*\nPrinter ${PrinterConnectState.disconnected.name}');
+        await showNeedRibbonFilmDialog(context, ref);
+        return;
+      }
+      if (connected) {
+        final settingCompleted = ref.read(printerServiceProvider.notifier).settingPrinter();
+        if (!settingCompleted) {
+          SlackLogService()
+              .sendErrorLogToSlack('*[MachineId: $machineId]*\nPrinter ${PrinterConnectState.setupInComplete.name}');
+          showNeedRibbonFilmDialog(context, ref);
+          return;
+        }
+      }
+
       RibbonStatus ribbonStatus = ref.read(printerServiceProvider.notifier).getRibbonStatus();
       ref.read(ribbonWarningProvider.notifier).checkAndSendWarnings(machineId, ribbonStatus);
       showNeedRibbonFilmDialog(context, ref);
@@ -88,11 +106,35 @@ class PhotoCardUploadScreen extends ConsumerWidget {
     );
   }
 
-  void showNeedRibbonFilmDialog(BuildContext context, WidgetRef ref) {
+  Future<void> showNeedRibbonFilmDialog(BuildContext context, WidgetRef ref) async {
+    int machineId = ref.read(kioskInfoServiceProvider)?.kioskMachineId ?? 0;
+    final connected = await ref.read(printerServiceProvider.notifier).checkConnectedPrint();
+
+    if (!connected) {
+      SlackLogService()
+          .sendErrorLogToSlack('*[MachineId: $machineId]*\nPrinter ${PrinterConnectState.disconnected.name}');
+      DialogHelper.showNeedRibbonFilmDialog(context, () {
+        showNeedRibbonFilmDialog(context, ref);
+      });
+      return;
+    }
+    if (connected) {
+      final settingCompleted = ref.read(printerServiceProvider.notifier).settingPrinter();
+      if (!settingCompleted) {
+        SlackLogService()
+            .sendErrorLogToSlack('*[MachineId: $machineId]*\nPrinter ${PrinterConnectState.setupInComplete.name}');
+        DialogHelper.showNeedRibbonFilmDialog(context, () {
+          showNeedRibbonFilmDialog(context, ref);
+        });
+        return;
+      }
+    }
+
     RibbonStatus ribbonStatus = ref.read(printerServiceProvider.notifier).getRibbonStatus();
     bool isRibbonShouldBeChanged = ref.read(ribbonWarningProvider.notifier).isRibbonShouldBeChanged(ribbonStatus);
     bool isFilmShouldBeChanged = ref.read(ribbonWarningProvider.notifier).isFilmShouldBeChanged(ribbonStatus);
-    bool isBothRibbonAndFilmShouldBeChanged = ref.read(ribbonWarningProvider.notifier).isBothRibbonAndFilmShouldBeChanged(ribbonStatus);
+    bool isBothRibbonAndFilmShouldBeChanged =
+        ref.read(ribbonWarningProvider.notifier).isBothRibbonAndFilmShouldBeChanged(ribbonStatus);
 
     if (isRibbonShouldBeChanged || isFilmShouldBeChanged || isBothRibbonAndFilmShouldBeChanged) {
       DialogHelper.showNeedRibbonFilmDialog(context, () {

--- a/lib/features/move_me/screens/photo_card_upload_screen.dart
+++ b/lib/features/move_me/screens/photo_card_upload_screen.dart
@@ -16,13 +16,13 @@ class PhotoCardUploadScreen extends ConsumerWidget {
   Widget build(BuildContext context, WidgetRef ref) {
     final kiosk = ref.watch(kioskInfoServiceProvider);
 
-    WidgetsBinding.instance.addPostFrameCallback((_) async {
+    WidgetsBinding.instance.addPostFrameCallback((_) {
       int machineId = ref.read(kioskInfoServiceProvider)?.kioskMachineId ?? 0;
-      final connected = await ref.read(printerServiceProvider.notifier).checkConnectedPrint();
+      final connected = ref.read(printerServiceProvider.notifier).checkConnectedPrint();
       if (!connected) {
         SlackLogService()
             .sendErrorLogToSlack('*[MachineId: $machineId]*\nPrinter ${PrinterConnectState.disconnected.name}');
-        await showNeedRibbonFilmDialog(context, ref);
+        showNeedRibbonFilmDialog(context, ref);
         return;
       }
       if (connected) {
@@ -106,7 +106,7 @@ class PhotoCardUploadScreen extends ConsumerWidget {
     );
   }
 
-  Future<void> showNeedRibbonFilmDialog(BuildContext context, WidgetRef ref) async {
+  void showNeedRibbonFilmDialog(BuildContext context, WidgetRef ref) {
     RibbonStatus ribbonStatus = ref.read(printerServiceProvider.notifier).getRibbonStatus();
     bool isRibbonShouldBeChanged = ref.read(ribbonWarningProvider.notifier).isRibbonShouldBeChanged(ribbonStatus);
     bool isFilmShouldBeChanged = ref.read(ribbonWarningProvider.notifier).isFilmShouldBeChanged(ribbonStatus);

--- a/lib/features/move_me/screens/setup_main_screen.dart
+++ b/lib/features/move_me/screens/setup_main_screen.dart
@@ -25,8 +25,8 @@ class _SetupMainScreenState extends ConsumerState<SetupMainScreen> {
   void initState() {
     super.initState();
 
-    _timer = Timer.periodic(Duration(seconds: 2), (timer) async {
-      final connected = await ref.read(printerServiceProvider.notifier).checkConnectedPrint();
+    _timer = Timer.periodic(Duration(seconds: 2), (timer) {
+      final connected = ref.read(printerServiceProvider.notifier).checkConnectedPrint();
 
       if (mounted) {
         setState(() {

--- a/lib/features/move_me/screens/setup_main_screen.dart
+++ b/lib/features/move_me/screens/setup_main_screen.dart
@@ -5,7 +5,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_screenutil/flutter_screenutil.dart';
 import 'package:flutter_snaptag_kiosk/core/utils/sound_manager.dart';
-import 'package:flutter_snaptag_kiosk/features/core/printer/print_connect_state.dart';
+import 'package:flutter_snaptag_kiosk/features/core/printer/printer_connect_state.dart';
 import 'package:flutter_snaptag_kiosk/lib.dart';
 import 'package:flutter_svg/flutter_svg.dart';
 import 'package:flutter_snaptag_kiosk/core/providers/version_notifier.dart';
@@ -30,12 +30,17 @@ class _SetupMainScreenState extends ConsumerState<SetupMainScreen> {
 
       if (mounted) {
         setState(() {
-          // 프린터 연결상태 우선 - 프린터 상태 연결 완료 이후 리본 잔량 및 필름 잔량 체크
           if (connected) {
             final settingCompleted = ref.read(printerServiceProvider.notifier).settingPrinter();
-            ref.read(printConnectProvider.notifier).update(
-                  settingCompleted ? PrintConnectState.connected : PrintConnectState.disconnected,
+            ref.read(printerConnectProvider.notifier).update(
+                  connected && settingCompleted
+                      ? PrinterConnectState.connected
+                      : settingCompleted
+                          ? PrinterConnectState.connected
+                          : PrinterConnectState.setupInComplete,
                 );
+          } else {
+            ref.read(printerConnectProvider.notifier).update(PrinterConnectState.disconnected);
           }
         });
       }
@@ -55,8 +60,7 @@ class _SetupMainScreenState extends ConsumerState<SetupMainScreen> {
     final currentVersion = versionState.currentVersion;
     final latestVersion = versionState.latestVersion;
     final isUpdateAvailable = currentVersion != latestVersion;
-    final machineId = ref.read(kioskInfoServiceProvider)?.kioskMachineId ?? 0;
-    final isConnectedPrinter = ref.watch(printConnectProvider) == PrintConnectState.connected;
+    final isConnectedPrinter = ref.watch(printerConnectProvider) == PrinterConnectState.connected;
     //final isUpdateAvailable = false;
 
     return Theme(
@@ -194,7 +198,6 @@ class _SetupMainScreenState extends ConsumerState<SetupMainScreen> {
 
                           if (value == null || value.isEmpty) return; // 값이 없으면 종료
                           int cardNumber = int.parse(value);
-                          final machineId = ref.read(kioskInfoServiceProvider)?.kioskMachineId ?? 0;
                           ref.read(cardCountProvider.notifier).update(cardNumber);
                           if (cardNumber <= 0) {
                             ref.read(pagePrintProvider.notifier).set(PagePrintType.double);


### PR DESCRIPTION
## 📌 작업 개요
- 프린터 상태 추가
- 기존에 프린터 상태를 2초 마다 slack webhook log를 보내는 로직 제거
- 프린터 상태가 변경될 때만 보내는 로직으로 변경
- 리본/필름 상태 체크 전에 프린터 연결부터 확인 하도록 로직 수정.

## 🔍 변경 사항
- PrinterConnectState 상태 추가
- connected : 연결
- disconnected : 프린터 미 연결
- setupInComplete : 프린터 연결은 됐으나 프린터 셋팅이 안됨
- checkAndSendWarnings 전에 프린터 연결 로직 추가

## 🧪 테스트 방법
- 셋업 환경에서 프린터 on/off
- QR 홈 화면에서 프린터 off

## 📎 기타 참고 사항
- 

## 🙏 리뷰 요청 포인트
- 