### PR TITLE
전파자 Slack 알림 기능 구현 및 결제·단말기 상태 연동

### DIFF
--- a/lib/core/constants/alert_key.dart
+++ b/lib/core/constants/alert_key.dart
@@ -1,0 +1,34 @@
+enum ErrorKey {
+  printerRibonEmpty("Printer_Ribon_Empty"),
+  printerFilmEmpty("Printer_Film_Empty"),
+  printerCardEmpty("Printer_Card_Empty"),
+  printerEjectFail("Printer_Eject_Fail"),
+  printerReadyFail("Printer_Ready_Fail"),
+  printerPrintFail("Printer_Print_Fail"),
+  severError("Sever_Error");
+
+  final String key;
+  const ErrorKey(this.key);
+}
+
+enum WarningKey {
+  printerRibonR20("Printer_Ribon_R20"),
+  printerRibonR10("Printer_Ribon_R10"),
+  printerRibonR5("Printer_Ribon_R5"),
+  printerFilmR20("Printer_Film_R20"),
+  printerFilmR10("Printer_Film_R10"),
+  printerFilmR5("Printer_Film_R5");
+
+  final String key;
+  const WarningKey(this.key);
+}
+
+enum InfoKey {
+  cardPrintModeSwitchDuplex("Card_PrintMode_Switch_Duplex"),
+  cardPrintModeSwitchSingle("Card_PrintMode_Switch_Single"),
+  inspectionStart("Inspection_Start"),
+  inspectionEnd("Inspection_End");
+
+  final String key;
+  const InfoKey(this.key);
+}

--- a/lib/core/constants/alert_key.dart
+++ b/lib/core/constants/alert_key.dart
@@ -26,6 +26,9 @@ enum WarningKey {
 enum InfoKey {
   cardPrintModeSwitchDuplex("Card_PrintMode_Switch_Duplex"),
   cardPrintModeSwitchSingle("Card_PrintMode_Switch_Single"),
+  paymentFail("Payment_Fail"),
+  paymentRefund("Payment_Refund"),
+  paymentRefundFail("Payment_Refund_Fail"),
   inspectionStart("Inspection_Start"),
   inspectionEnd("Inspection_End");
 

--- a/lib/core/constants/constants.dart
+++ b/lib/core/constants/constants.dart
@@ -1,2 +1,3 @@
 export 'directory_paths.dart';
 export 'image_paths.dart';
+export 'alert_key.dart';

--- a/lib/data/datasources/remote/dio_client.dart
+++ b/lib/data/datasources/remote/dio_client.dart
@@ -56,6 +56,7 @@ final dioProvider = Provider.family<Dio, String>((ref, baseUrl) {
             SlackLogService().sendWarningLogToSlack(formattedMessage);
           } else if (statusCode >= 500) {
             SlackLogService().sendErrorLogToSlack(formattedMessage);
+            SlackLogService().sendBroadcastLogToSlack(ErrorKey.severError.key);
           } 
         },
         request: false,
@@ -69,7 +70,7 @@ final dioProvider = Provider.family<Dio, String>((ref, baseUrl) {
           // ServerException으로 wrapping
           return handler.reject(ServerException.fromDioError(err));
         } catch (e) {
-          logger.i('ServerError 파싱 실패: $e');
+          logger.i('SeverError 파싱 실패: $e');
         }
       }
       return handler.next(err); // 원래 에러 전달

--- a/lib/data/datasources/remote/kiosk_api_client.dart
+++ b/lib/data/datasources/remote/kiosk_api_client.dart
@@ -69,4 +69,7 @@ abstract class KioskApiClient {
   Future<void> updatePrintLog({
     @Body() required Map<String, dynamic> body,
   });
+
+  @GET('/v1/error-code')
+  Future<List<AlertDefinitionResponse>> getAlertDefinitions();
 }

--- a/lib/data/datasources/remote/payment_api_client.dart
+++ b/lib/data/datasources/remote/payment_api_client.dart
@@ -1,5 +1,6 @@
 import 'dart:convert';
 
+import 'package:flutter_snaptag_kiosk/data/models/response/kscat_device_response.dart';
 import 'package:flutter_snaptag_kiosk/lib.dart';
 import 'package:http/http.dart' as http;
 
@@ -30,6 +31,30 @@ class PaymentApiClient {
     final paymentResponse = trim..addAll({'KSNET': '$callback($trim)'});
     logger.i(paymentResponse.toString());
     return PaymentResponse.fromJson(paymentResponse);
+  }
+
+  Future<KscatDeviceResponse> requestDeivce(String callback, String request) async {
+    // URL을 직접 구성 - 인코딩 없이
+    final url = '$baseUrl?callback=$callback&REQ=$request';
+    logger.i('\n=== Raw KscatDevice Request URL ===\n$url');
+
+    final response = await http.get(
+      Uri.parse(url),
+      headers: {'Content-Type': 'application/json; charset=euc-kr'},
+    );
+
+    final body = response.body;
+    final broken = body.substring(
+      callback.length + 1, // callback( 제거
+      body.length - 1, // ) 제거
+    );
+
+    // EUC-KR 디코딩
+    final decode = cp949.decodeString(broken);
+    final trim = trimValues(json.decode(decode));
+    final kscatDeviceResponse = trim..addAll({'KSNET': '$callback($trim)'});
+    logger.i(kscatDeviceResponse.toString());
+    return KscatDeviceResponse.fromJson(kscatDeviceResponse);
   }
 
   // 모든 String 값의 공백을 trim

--- a/lib/data/datasources/remote/slack_log_service.dart
+++ b/lib/data/datasources/remote/slack_log_service.dart
@@ -137,8 +137,8 @@ ${def.description}
   }) {
     final cardInfo =
       '''
-      ${cardCount == 0 ? "단면 -> 양면 모드" : "단면 모드 설정"}
-      단면 설정 개수 : $cardCount개
+${cardCount == 0 ? "단면 -> 양면 모드" : "단면 모드 설정"}
+        단면 설정 개수 : $cardCount개
       '''
     ;
 
@@ -151,8 +151,8 @@ ${def.description}
 
     final formattedTitle =
     (title == "점검 완료" || title == "점검 시작")
-        ? '*[$title]*'
-        : '$emoji $title';
+        ? '     *[$title]*'
+        : '$emoji  *$title*';
 
     final guidePart = guideText != null
         ? "[${guideUrl != null ? '<$guideUrl|$guideText>' : guideText}]"
@@ -160,14 +160,14 @@ ${def.description}
 
     return '''
 $formattedTitle
+        ────────────────────────────────────────
+        KioskID: $kioskId  /  앱버전: $appVersion  /  업체: $serviceName
+        ────────────────────────────────────────
+        $description
+        ${ title == "카드 인쇄 모드 변경" ? cardInfo : ""}
+        ────────────────────────────────────────
+        $guidePart
 
-  •  이벤트: $serviceName  •  KioskID: $kioskId  •  앱버전: $appVersion
-────────────────────────────────────────
-
-$description
-${ title == "카드 인쇄 모드 변경" ? cardInfo : ""}
-
-$guidePart
 ''';
   }
 }

--- a/lib/data/datasources/remote/slack_log_service.dart
+++ b/lib/data/datasources/remote/slack_log_service.dart
@@ -46,7 +46,7 @@ class SlackLogService {
     await sendLog(slackWebhookWarningUrl, message);
   }
 
-  Future<void> sendBroadcastLogToSlack(String errorKey) async {
+  Future<void> sendBroadcastLogToSlack(String errorKey, {String? authNum, String? paymentDescription, String? approvalNum}) async {
     final definitions = _container.read(alertDefinitionProvider);
     final def = definitions.firstWhereOrNull((e) => e.key == errorKey);
     final kioskInfo = _container.read(kioskInfoServiceProvider);
@@ -61,6 +61,11 @@ class SlackLogService {
       "KEEFO": "성수 B'Day",
     };
 
+    final paymentKey = [
+      InfoKey.paymentFail.key,
+      InfoKey.paymentRefund.key,
+      InfoKey.paymentFail.key,
+    ];
     final serviceName = serviceNameMap[eventType] ?? '-';
     String description;
     if (def != null) {
@@ -69,11 +74,18 @@ class SlackLogService {
           '''
 ${def.description}
 
- - 단면 카드 입력 수량 : $cardCount
- - 불러온 이벤트 : $eventName
- - 프린터 연결 상태 : 정상
+     - 단면 카드 입력 수량 : $cardCount
+     - 불러온 이벤트 : $eventName
+     - 프린터 연결 상태 : 정상
 '''
           ;
+      } else if (paymentKey.contains(def.key)){
+        description =
+            '''
+${def.description}
+            
+     - $paymentDescription
+''';
       } else {
         description = def.description;
       }
@@ -165,7 +177,7 @@ $formattedTitle
         ────────────────────────────────────────
         $description
         ${ title == "카드 인쇄 모드 변경" ? cardInfo : ""}
-        ────────────────────────────────────────
+        
         $guidePart
 
 ''';

--- a/lib/data/datasources/remote/slack_log_service.dart
+++ b/lib/data/datasources/remote/slack_log_service.dart
@@ -46,7 +46,7 @@ class SlackLogService {
     await sendLog(slackWebhookWarningUrl, message);
   }
 
-  Future<void> sendBroadcastLogToSlack(String errorKey, {String? authNum, String? paymentDescription, String? approvalNum}) async {
+  Future<void> sendBroadcastLogToSlack(String errorKey, {String? authNum, String? paymentDescription, String? approvalNum, bool? isPaymentOn}) async {
     final definitions = _container.read(alertDefinitionProvider);
     final def = definitions.firstWhereOrNull((e) => e.key == errorKey);
     final kioskInfo = _container.read(kioskInfoServiceProvider);
@@ -64,7 +64,7 @@ class SlackLogService {
     final paymentKey = [
       InfoKey.paymentFail.key,
       InfoKey.paymentRefund.key,
-      InfoKey.paymentFail.key,
+      InfoKey.paymentRefundFail.key,
     ];
     final serviceName = serviceNameMap[eventType] ?? '-';
     String description;
@@ -77,6 +77,7 @@ ${def.description}
      - 단면 카드 입력 수량 : $cardCount
      - 불러온 이벤트 : $eventName
      - 프린터 연결 상태 : 정상
+     - 결제 단말기 연결 상태 : ${isPaymentOn == true ? '정상' : '미연결'}
 '''
           ;
       } else if (paymentKey.contains(def.key)){

--- a/lib/data/models/request/kscat_device_request.dart
+++ b/lib/data/models/request/kscat_device_request.dart
@@ -1,0 +1,27 @@
+import 'package:freezed_annotation/freezed_annotation.dart';
+
+part 'kscat_device_request.freezed.dart';
+part 'kscat_device_request.g.dart';
+
+@freezed
+class KscatDeviceRequest with _$KscatDeviceRequest {
+  const factory KscatDeviceRequest({
+    required String req,
+  }) = _KscatDeivceRequest;
+
+  factory KscatDeviceRequest.fromJson(Map<String, dynamic> json) =>
+      _$KscatDeviceRequestFromJson(json);
+}
+
+extension KscatDeviceRequestExtension on KscatDeviceRequest {
+  String serialize() {
+    final buffer = StringBuffer();
+
+    buffer.write(req);
+
+    final msg = buffer.toString();
+    final msgLength = msg.length.toString().padLeft(4, '0');
+
+    return 'AP$msgLength$msg';
+  }
+}

--- a/lib/data/models/response/alert_definition_response.dart
+++ b/lib/data/models/response/alert_definition_response.dart
@@ -1,0 +1,22 @@
+import 'package:freezed_annotation/freezed_annotation.dart';
+
+part 'alert_definition_response.freezed.dart';
+part 'alert_definition_response.g.dart';
+
+@freezed
+class AlertDefinitionResponse with _$AlertDefinitionResponse {
+  const factory AlertDefinitionResponse({
+    required int id,
+    required String created,
+    required String modified,
+    required bool isDeleted,
+    required String key,
+    required String category,
+    required String title,
+    required String description,
+    String? guideText,
+    String? guideUrl,
+  }) = _AlertDefinitionResponse;
+
+  factory AlertDefinitionResponse.fromJson(Map<String, dynamic> json) => _$AlertDefinitionResponseFromJson(json);
+}

--- a/lib/data/models/response/kiosk_machine_info.dart
+++ b/lib/data/models/response/kiosk_machine_info.dart
@@ -11,6 +11,7 @@ class KioskMachineInfo with _$KioskMachineInfo {
     @Default('') String kioskMachineName,
     @Default('') String kioskMachineDescription,
     @Default(0) int photoCardPrice,
+    @Default('') String eventType,
     @Default('') String printedEventName,
     @Default('') String topBannerUrl,
     @Default('') String mainImageUrl,

--- a/lib/data/models/response/kscat_device_response.dart
+++ b/lib/data/models/response/kscat_device_response.dart
@@ -1,0 +1,27 @@
+import 'dart:convert';
+
+import 'package:flutter_snaptag_kiosk/lib.dart';
+import 'package:freezed_annotation/freezed_annotation.dart';
+
+part 'kscat_device_response.freezed.dart';
+part 'kscat_device_response.g.dart';
+
+@freezed
+class KscatDeviceResponse with _$KscatDeviceResponse {
+  const KscatDeviceResponse._(); // freezed에서 메서드를 추가하기 위한 private constructor
+
+  const factory KscatDeviceResponse({
+    @JsonKey(name: 'REQ') String? req,
+    @JsonKey(name: 'RES') required String? res,
+    @JsonKey(name: 'ERRCODE') String? errcode,
+    @JsonKey(name: 'READER') String? reader,
+    @JsonKey(name: 'SERIALNO') String? serialno,
+    @JsonKey(name: 'SWVERSION') String? swversion,
+    @JsonKey(name: 'KEYYN') String? keyyn,
+    @JsonKey(name: 'BAUDRATE') String? baudrate,
+    @JsonKey(name: 'KEYDATE') String? keydate,
+    @JsonKey(name: 'EMVDATE') String? emvdate,
+  }) = _KscatDeviceResponse;
+
+  factory KscatDeviceResponse.fromJson(Map<String, dynamic> json) => _$KscatDeviceResponseFromJson(json);
+}

--- a/lib/data/models/response/response.dart
+++ b/lib/data/models/response/response.dart
@@ -12,3 +12,4 @@ export 'payment_response.dart';
 export 'server_error.dart';
 export 'update_order_response.dart';
 export 'update_print_response.dart';
+export 'alert_definition_response.dart';

--- a/lib/data/repositories/kiosk_repository.dart
+++ b/lib/data/repositories/kiosk_repository.dart
@@ -29,6 +29,15 @@ class _KioskRepository {
     }
   }
 
+  // Slack Alert definitions
+  Future<List<AlertDefinitionResponse>> getAlertDefinition() async {
+    try {
+      return await _apiClient.getAlertDefinitions();
+    } catch (e) {
+      rethrow;
+    }
+  }
+
   // Machine Info Operations
   Future<KioskMachineInfo> getKioskMachineInfo(int machineId) async {
     try {

--- a/lib/data/repositories/payment_repository.dart
+++ b/lib/data/repositories/payment_repository.dart
@@ -1,4 +1,6 @@
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_snaptag_kiosk/data/models/request/kscat_device_request.dart';
+import 'package:flutter_snaptag_kiosk/data/models/response/kscat_device_response.dart';
 import 'package:flutter_snaptag_kiosk/lib.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
 
@@ -37,6 +39,14 @@ class PaymentRepository {
     return _request(request);
   }
 
+  Future<KscatDeviceResponse> check() async {
+    final request = KscatDeviceRequest(
+      req: 'C0',
+    );
+
+    return _deviceRequest(request);
+  }
+
   Future<PaymentResponse> cancel({
     required int totalAmount,
     required String originalApprovalNo,
@@ -57,6 +67,19 @@ class PaymentRepository {
   Future<PaymentResponse> _request(PaymentRequest request) async {
     try {
       final response = await _client.requestPayment(
+        _getCallback(),
+        request.serialize(),
+      );
+
+      return response;
+    } catch (e) {
+      rethrow;
+    }
+  }
+
+  Future<KscatDeviceResponse> _deviceRequest(KscatDeviceRequest request) async {
+    try {
+      final response = await _client.requestDeivce(
         _getCallback(),
         request.serialize(),
       );

--- a/lib/features/core/printer/ribbon_warning_provider.dart
+++ b/lib/features/core/printer/ribbon_warning_provider.dart
@@ -202,6 +202,7 @@ class RibbonWarning extends _$RibbonWarning {
     // 각 레벨별로 독립적으로 경고 상태 확인
     // 2% 미만 체크 (가장 심각한 경고)
     if (ribbonLevel < 2 && !state.isSentUnder2Ribbon) {
+      SlackLogService().sendBroadcastLogToSlack(ErrorKey.printerRibonEmpty.key);
       SlackLogService().sendErrorLogToSlack(
           '*[MachineId : $machineId]* ERROR: Ribbon level is ${ribbonLevel.toInt()}% (under 1%), please replace immediately!');
       SlackLogService().sendRibbonFilmWarningLog(
@@ -213,6 +214,7 @@ class RibbonWarning extends _$RibbonWarning {
     }
 
     if (filmLevel < 2 && !state.isSentUnder2Film) {
+      SlackLogService().sendBroadcastLogToSlack(ErrorKey.printerFilmEmpty.key);
       SlackLogService().sendErrorLogToSlack(
           '*[MachineId : $machineId]* ERROR: Film level is ${filmLevel.toInt()}% (under 1%), please replace immediately!');
       SlackLogService().sendRibbonFilmWarningLog(
@@ -225,6 +227,7 @@ class RibbonWarning extends _$RibbonWarning {
 
     // 5% 미만 체크
     if (ribbonLevel <= 5 && !state.isSentUnder5Ribbon) {
+      SlackLogService().sendBroadcastLogToSlack(WarningKey.printerRibonR5.key);
       SlackLogService().sendRibbonFilmWarningLog(
           '*[MachineId : $machineId]* CRITICAL: Ribbon level is ${ribbonLevel.toInt()}% (under 5%), please replace immediately!');
       setRibbonUnder20Sent(ribbonLevel); // 5% 미만이므로 20% 경고도 함께 설정
@@ -233,6 +236,7 @@ class RibbonWarning extends _$RibbonWarning {
     }
 
     if (filmLevel <= 5 && !state.isSentUnder5Film) {
+      SlackLogService().sendBroadcastLogToSlack(WarningKey.printerFilmR5.key);
       SlackLogService().sendRibbonFilmWarningLog(
           '*[MachineId : $machineId]* CRITICAL: Film level is ${filmLevel.toInt()}% (under 5%), please replace immediately!');
       setFilmUnder20Sent(filmLevel); // 5% 미만이므로 20% 경고도 함께 설정
@@ -242,6 +246,7 @@ class RibbonWarning extends _$RibbonWarning {
 
     // 10% 미만 체크 (5% 경고와 독립적으로 실행)
     if (ribbonLevel <= 10 && !state.isSentUnder10Ribbon) {
+      SlackLogService().sendBroadcastLogToSlack(WarningKey.printerRibonR10.key);
       SlackLogService().sendRibbonFilmWarningLog(
           '*[MachineId : $machineId]* WARNING: Ribbon level is ${ribbonLevel.toInt()}% (under 10%), please check the printer');
       setRibbonUnder20Sent(ribbonLevel); // 10% 미만이므로 20% 경고도 함께 설정
@@ -249,6 +254,7 @@ class RibbonWarning extends _$RibbonWarning {
     }
 
     if (filmLevel <= 10 && !state.isSentUnder10Film) {
+      SlackLogService().sendBroadcastLogToSlack(WarningKey.printerFilmR10.key);
       SlackLogService().sendRibbonFilmWarningLog(
           '*[MachineId : $machineId]* WARNING: Film level is ${filmLevel.toInt()}% (under 10%), please check the printer');
       setFilmUnder20Sent(filmLevel); // 10% 미만이므로 20% 경고도 함께 설정
@@ -257,12 +263,14 @@ class RibbonWarning extends _$RibbonWarning {
 
     // 20% 미만 체크 (다른 경고와 독립적으로 실행)
     if (ribbonLevel <= 20 && !state.isSentUnder20Ribbon) {
+      SlackLogService().sendBroadcastLogToSlack(WarningKey.printerRibonR20.key);
       SlackLogService().sendRibbonFilmWarningLog(
           '*[MachineId : $machineId]* INFO: Ribbon level is ${ribbonLevel.toInt()}% (under 20%), please check the printer');
       setRibbonUnder20Sent(ribbonLevel);
     }
 
     if (filmLevel <= 20 && !state.isSentUnder20Film) {
+      SlackLogService().sendBroadcastLogToSlack(WarningKey.printerFilmR20.key);
       SlackLogService().sendRibbonFilmWarningLog(
           '*[MachineId : $machineId]* INFO: Film level is ${filmLevel.toInt()}% (under 20%), please check the printer');
       setFilmUnder20Sent(filmLevel);

--- a/lib/features/move_me/providers/alert_definition_provider.dart
+++ b/lib/features/move_me/providers/alert_definition_provider.dart
@@ -1,0 +1,22 @@
+import 'package:flutter_snaptag_kiosk/lib.dart';
+import 'package:riverpod_annotation/riverpod_annotation.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:collection/collection.dart';
+
+part 'alert_definition_provider.g.dart';
+
+@Riverpod(keepAlive: true)
+class AlertDefinition extends _$AlertDefinition {
+  @override
+  List<AlertDefinitionResponse> build() => [];
+
+  Future<void> load() async {
+    final kioskRepo = ref.read(kioskRepositoryProvider);
+    final list = await kioskRepo.getAlertDefinition();
+    state = list;
+  }
+
+  AlertDefinitionResponse? findByKey(String key) {
+    return state.firstWhereOrNull((e) => e.key == key);
+  }
+}

--- a/lib/features/move_me/providers/page_print_provider.dart
+++ b/lib/features/move_me/providers/page_print_provider.dart
@@ -1,4 +1,6 @@
+import 'package:flutter/cupertino.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
+import 'package:flutter_snaptag_kiosk/lib.dart';
 
 part 'page_print_provider.g.dart';
 
@@ -9,8 +11,17 @@ class PagePrint extends _$PagePrint {
 
   void switchType() {
     state = state == PagePrintType.double ? PagePrintType.single : PagePrintType.double;
+    SlackLogService().sendBroadcastLogToSlack(
+        state == PagePrintType.single ? InfoKey.cardPrintModeSwitchSingle.key : InfoKey.cardPrintModeSwitchDuplex.key);
   }
-  void set(PagePrintType type) => state = type;
+
+  void set(PagePrintType type) {
+    if (type != state) {
+      print("chaneg Printe type : $type");
+      if (type == PagePrintType.double) SlackLogService().sendBroadcastLogToSlack(InfoKey.cardPrintModeSwitchDuplex.key);
+    }
+    state = type;
+  }
 }
 
 enum PagePrintType {

--- a/lib/features/move_me/providers/page_print_provider.dart
+++ b/lib/features/move_me/providers/page_print_provider.dart
@@ -16,9 +16,10 @@ class PagePrint extends _$PagePrint {
   }
 
   void set(PagePrintType type) {
+    final machineId = ref.read(kioskInfoServiceProvider)?.kioskMachineId ?? 0;
     if (type != state) {
       print("chaneg Printe type : $type");
-      if (type == PagePrintType.double) SlackLogService().sendBroadcastLogToSlack(InfoKey.cardPrintModeSwitchDuplex.key);
+      if (type == PagePrintType.double && machineId != 0) SlackLogService().sendBroadcastLogToSlack(InfoKey.cardPrintModeSwitchDuplex.key);
     }
     state = type;
   }

--- a/lib/features/move_me/providers/providers.dart
+++ b/lib/features/move_me/providers/providers.dart
@@ -7,3 +7,4 @@ export 'triple_tap_state.dart';
 export 'verify_photo_card_provider.dart';
 export 'page_print_provider.dart';
 export 'card_count_provider.dart';
+export 'alert_definition_provider.dart';

--- a/lib/features/move_me/screens/kiosk_info_screen.dart
+++ b/lib/features/move_me/screens/kiosk_info_screen.dart
@@ -41,6 +41,7 @@ class KioskInfoScreen extends ConsumerWidget {
               final result = await DialogHelper.showSetupDialog(context, title: '최신 이벤트로 새로고침 됩니다.');
               if (result == true) {
                 await ref.read(kioskInfoServiceProvider.notifier).refreshWithMachineId(int.parse(value));
+                SlackLogService().sendBroadcastLogToSlack(InfoKey.inspectionStart.key);
               }
             },
             icon: SvgPicture.asset(

--- a/lib/features/move_me/screens/setup_main_screen.dart
+++ b/lib/features/move_me/screens/setup_main_screen.dart
@@ -510,8 +510,7 @@ class SetupMainCard extends StatelessWidget {
                     Spacer(),
                   ],
                 )
-              : Expanded(
-                  child: Center(
+              : Center(
                     child: SizedBox(
                       width: 260.w,
                       child: Text(
@@ -526,7 +525,6 @@ class SetupMainCard extends StatelessWidget {
                         ),
                       ),
                     ),
-                  ),
                 ),
         ),
       ),

--- a/lib/features/move_me/screens/setup_main_screen.dart
+++ b/lib/features/move_me/screens/setup_main_screen.dart
@@ -324,8 +324,15 @@ class _SetupMainScreenState extends ConsumerState<SetupMainScreen> {
                               SlackLogService().sendLogToSlack(
                                   'machineId: $machineId, singleCard: $cardCountState, set pagePrintType single');
                             }
-                            SlackLogService().sendBroadcastLogToSlack(InfoKey.inspectionEnd.key);
                             PhotoCardUploadRouteData().go(context);
+                            try{
+                              final response = await ref.read(paymentRepositoryProvider).check();
+                              SlackLogService().sendBroadcastLogToSlack(InfoKey.inspectionEnd.key, isPaymentOn: true);
+                              SlackLogService().sendLogToSlack("Payment Device check: $response");
+                            } catch (e){
+                              SlackLogService().sendBroadcastLogToSlack(InfoKey.inspectionEnd.key, isPaymentOn: false);
+                              SlackLogService().sendErrorLogToSlack("Payment Device check: $e");
+                            }
                           }
                         },
                       ),

--- a/lib/features/move_me/screens/setup_main_screen.dart
+++ b/lib/features/move_me/screens/setup_main_screen.dart
@@ -141,6 +141,9 @@ class _SetupMainScreenState extends ConsumerState<SetupMainScreen> {
                         if (cardCountState < 1) {
                           await SoundManager().playSound();
                           ref.read(pagePrintProvider.notifier).set(PagePrintType.double);
+                          if (machineId != 0) {
+                            SlackLogService().sendBroadcastLogToSlack(InfoKey.cardPrintModeSwitchSingle.key);
+                          }
                         }
                       },
                     ),
@@ -208,7 +211,9 @@ class _SetupMainScreenState extends ConsumerState<SetupMainScreen> {
                             ref.read(pagePrintProvider.notifier).set(PagePrintType.double);
                           } else {
                             ref.read(pagePrintProvider.notifier).set(PagePrintType.single);
-                            SlackLogService().sendBroadcastLogToSlack(InfoKey.cardPrintModeSwitchSingle.key);
+                            if (machineId != 0) {
+                              SlackLogService().sendBroadcastLogToSlack(InfoKey.cardPrintModeSwitchSingle.key);
+                            }
                           }
                         } else {
                           print('click when pagePringType not single');

--- a/lib/features/presentation/screens/print_process_screen.dart
+++ b/lib/features/presentation/screens/print_process_screen.dart
@@ -19,25 +19,25 @@ class _PrintProcessScreenState extends ConsumerState<PrintProcessScreen> {
   Widget build(BuildContext context) {
     final randomAdImage = getRandomAdImageFilePath();
     /**
-         final printProcess = ref.watch(printProcessScreenProviderProvider);
-    if (printProcess.isLoading) {
-      if (!context.loaderOverlay.visible) context.loaderOverlay.show();
-    } else {
-      if (context.loaderOverlay.visible) context.loaderOverlay.hide();
-    }
+        final printProcess = ref.watch(printProcessScreenProviderProvider);
+        if (printProcess.isLoading) {
+        if (!context.loaderOverlay.visible) context.loaderOverlay.show();
+        } else {
+        if (context.loaderOverlay.visible) context.loaderOverlay.hide();
+        }
      */
 
     // listen 부분에서는 로딩 오버레이 처리를 제거
     ref.listen(printProcessScreenProviderProvider, (previous, next) async {
       /**
-            if (next.isLoading && !context.loaderOverlay.visible) {
-        context.loaderOverlay.show();
-        return;
-      }
+          if (next.isLoading && !context.loaderOverlay.visible) {
+          context.loaderOverlay.show();
+          return;
+          }
 
-      if (context.loaderOverlay.visible) {
-        context.loaderOverlay.hide();
-      }
+          if (context.loaderOverlay.visible) {
+          context.loaderOverlay.hide();
+          }
        */
       if (!next.isLoading) {
         // 로딩이 아닐 때만 처리
@@ -47,6 +47,21 @@ class _PrintProcessScreenState extends ConsumerState<PrintProcessScreen> {
             final machineId = ref.read(kioskInfoServiceProvider)?.kioskMachineId ?? 0;
             SlackLogService().sendErrorLogToSlack('*[Machine ID: $machineId]*\nPrint process error\nError: $error');
             SlackLogService().sendErrorLogToSlack('Print process error\nError: $error');
+            switch (error) {
+              case "Card feeder is empty":
+                SlackLogService().sendBroadcastLogToSlack(ErrorKey.printerCardEmpty.key);
+                break;
+              case "Failed to eject card":
+                SlackLogService().sendBroadcastLogToSlack(ErrorKey.printerEjectFail.key);
+                break;
+              case "Printer is not ready":
+                SlackLogService().sendBroadcastLogToSlack(ErrorKey.printerReadyFail.key);
+                break;
+              default:
+                SlackLogService().sendBroadcastLogToSlack(ErrorKey.printerPrintFail.key);
+                break;
+            }
+
             final errorMessage = error.toString();
             // 에러 발생 시 환불 처리
             try {

--- a/lib/features/presentation/services/payment_service.dart
+++ b/lib/features/presentation/services/payment_service.dart
@@ -102,7 +102,7 @@ class PaymentService extends _$PaymentService {
       final paymentRes = approvalInfo?.res;
       final response = await _updateOrder(isRefund: true);
       if (response.status == OrderStatus.refunded) {
-        SlackLogService().sendBroadcastLogToSlack(InfoKey.paymentRefund.key, paymentDescription: "승인번호: ${approvalInfo?.approvalNo ?? "-"}");
+        SlackLogService().sendBroadcastLogToSlack(InfoKey.paymentRefund.key, paymentDescription: "동작로직: 자동환불\n        승인번호: ${approvalInfo?.approvalNo ?? "-"}");
         ref.read(paymentResponseStateProvider.notifier).reset();
         SlackLogService().sendLogToSlack('paymentResponseState Reset'); //paymentTestSlack
       } else {

--- a/lib/features/presentation/services/payment_service.dart
+++ b/lib/features/presentation/services/payment_service.dart
@@ -51,11 +51,16 @@ class PaymentService extends _$PaymentService {
         ref.read(paymentFailureProvider.notifier).triggerFailure();
         final failResponse = await _updateFailOrder();
         ref.read(updateOrderInfoProvider.notifier).update(failResponse);
+        SlackLogService().sendBroadcastLogToSlack(InfoKey.paymentFail.key, paymentDescription: "사유: 승인번호가 빈 결제 건\n        인증번호: ${backPhoto.photoAuthNumber}\n        승인번호: ${paymentResponse.approvalNo}");
       } else {
         final response = await _updateOrder(isRefund: false); //결제 취소, 정상 결제
         ref.read(updateOrderInfoProvider.notifier).update(response);
         if (paymentResponse.res == '0000') {
           ref.read(cardCountProvider.notifier).decrease();
+        } else if (paymentResponse.res == '1004'){
+          SlackLogService().sendBroadcastLogToSlack(InfoKey.paymentFail.key, paymentDescription: "사유: 시간초과\n        인증번호: ${backPhoto.photoAuthNumber}\n        승인번호: ${paymentResponse.approvalNo}");
+        } else if (paymentResponse.res == '1000') {
+          SlackLogService().sendBroadcastLogToSlack(InfoKey.paymentFail.key, paymentDescription: "사유: 결제취소\n        인증번호: ${backPhoto.photoAuthNumber}\n        승인번호: ${paymentResponse.approvalNo}");
         }
       }
     } catch (e) {
@@ -93,10 +98,24 @@ class PaymentService extends _$PaymentService {
       logger.e('Refund failed', error: e);
       rethrow;
     } finally {
+      final approvalInfo = ref.read(paymentResponseStateProvider);
+      final paymentRes = approvalInfo?.res;
       final response = await _updateOrder(isRefund: true);
       if (response.status == OrderStatus.refunded) {
+        SlackLogService().sendBroadcastLogToSlack(InfoKey.paymentRefund.key, paymentDescription: "승인번호: ${approvalInfo?.approvalNo ?? "-"}");
         ref.read(paymentResponseStateProvider.notifier).reset();
         SlackLogService().sendLogToSlack('paymentResponseState Reset'); //paymentTestSlack
+      } else {
+        switch(paymentRes) {
+          case '1000':
+            SlackLogService().sendBroadcastLogToSlack(InfoKey.paymentRefundFail.key, paymentDescription: "동작로직: 자동환불\n        사유: 결제취소\n        승인번호: ${approvalInfo?.approvalNo ?? "-"}");
+            break;
+          case '1004':
+            SlackLogService().sendBroadcastLogToSlack(InfoKey.paymentRefundFail.key, paymentDescription: "동작로직: 자동환불\n        사유: 시간초과\n        승인번호: ${approvalInfo?.approvalNo ?? "-"}");
+            break;
+          default:
+            SlackLogService().sendBroadcastLogToSlack(InfoKey.paymentRefundFail.key, paymentDescription: "동작로직: 자동환불\n        사유: 확인필요\n        승인번호: ${approvalInfo?.approvalNo ?? "-"}");
+        }
       }
     }
   }
@@ -136,7 +155,21 @@ class PaymentService extends _$PaymentService {
       SlackLogService().sendLogToSlack('error409 response: $response'); //paymentTestSlack
       if (response.status == OrderStatus.refunded) {
         ref.read(paymentResponseStateProvider.notifier).reset();
+        SlackLogService().sendBroadcastLogToSlack(InfoKey.paymentRefund.key, paymentDescription: "동작로직: 환불안내\n        인증번호: $code");
         SlackLogService().sendLogToSlack('error409 paymentResponseState Reset'); //paymentTestSlack
+      } else {
+        final approvalInfo = ref.read(paymentResponseStateProvider);
+        final paymentRes = approvalInfo?.res;
+        switch(paymentRes) {
+          case '1000':
+            SlackLogService().sendBroadcastLogToSlack(InfoKey.paymentRefundFail.key, paymentDescription: "동작로직: 환불안내\n        사유: 결제취소\n        인증번호: $code");
+            break;
+          case '1004':
+            SlackLogService().sendBroadcastLogToSlack(InfoKey.paymentRefundFail.key, paymentDescription: "동작로직: 환불안내\n        사유: 시간초과\n        인증번호: $code");
+            break;
+          default:
+            SlackLogService().sendBroadcastLogToSlack(InfoKey.paymentRefundFail.key, paymentDescription: "동작로직: 환불안내\n        사유: 확인필요\n        인증번호: $code");
+        }
       }
     }
     return isSuccess;

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -44,11 +44,18 @@ void main() async {
           path: 'assets/lang',
           fallbackLocale: const Locale('ko', 'KR'),
           child: ProviderScope(
-            child: ScreenUtilInit(
-              designSize: const Size(1080, 1920),
-              minTextAdapt: true,
-              splitScreenMode: true,
-              child: App(),
+            child: Builder(
+              builder: (context) {
+                final container = ProviderScope.containerOf(context);
+                SlackLogService().init(container);
+                return ScreenUtilInit(
+                  designSize: const Size(1080, 1920),
+                  minTextAdapt: true,
+                  splitScreenMode: true,
+                  child: App(),
+
+                );
+              },
             ),
           ),
         ),


### PR DESCRIPTION
# 전파자 Slack 알림 기능 구현 및 결제·단말기 상태 연동

운영자가 개발자의 도움 없이 키오스크 상태 및 결제 흐름을 실시간으로 파악할 수 있도록  
전파자 전용 Slack 알림 기능을 구현했습니다. 점검 이벤트, 프린터/리소스 오류, 결제 실패, 단말기 연결 상태 등  
주요 이슈 발생 시 Slack 전파자 채널로 자동 전파됩니다.

---

## 주요 변경 사항

### 1. 시스템 구성 및 기능 구현

- `error-code API` 연동을 통한 오류 이벤트 감지
- 이벤트 점검 일부 자동화
- 전파자 전용 Slack Webhook 채널(`slackWebhookBroadcastUrl`) 설정
- `SlackLogService` 구조 개선  
  - `ProviderContainer` 주입 방식 도입 → `kioskInfo`, `pagePrintType`, `cardCount` 등 상태 접근 가능
- Slack 메시지 템플릿 정의 및 포맷 통일  
  - 메시지 유형별(Error, Warning, Info) 포맷 구분  
  - 조치 가이드 URL 포함

---

### 2. Slack 전송 대상 이벤트

#### Error
- 프린터 오류
  - 리본/필름/카드 없음
  - 카드 배출 실패, 프린터 미준비, 인쇄 실패
- 결제 단말기
  - 연결 오류
- 서버 오류

#### Warning
- 리본/필름 잔량 임계 도달 (20%, 10%, 5%)

#### Info
- 점검 시작 / 점검 완료
- 단면 ↔ 양면 인쇄 모드 변경
- 결제 실패 / 환불 / 환불 실패 (사유 포함)

---

### 3. 기타 개선 사항

- MachineID 존재 시에만 Slack 알림 전송되도록 조건 처리
- 단면 카드 수량이 있는 경우 양면 전환 불가 처리

---

### 4. 단말기 연결 상태 확인 기능 추가

- 이벤트 실행 시 KSCAT 암호화 리더기 초기화 API 호출
- 응답 결과 기반으로 단말기 연결 여부 판단
- 전파자 Slack 점검 완료 메시지에 단말기 연결 상태 포함 (`정상` / `미연결`)
