### PR TITLE
주기적인 프린터 상태 공유 추가 / 슬랙 호출 부분 리팩토링

### DIFF
--- a/lib/core/constants/alert_key.dart
+++ b/lib/core/constants/alert_key.dart
@@ -33,7 +33,8 @@ enum InfoKey {
   inspectionEnd("Inspection_End"),
   serviceMaintenanceEnter("Service_Maintenance_Enter"),
   serviceMaintenanceExit("Service_Maintenance_Exit"),
-  adminModeEnter("Admin_Mode_Enter");
+  adminModeEnter("Admin_Mode_Enter"),
+  periodicInfo("Periodic_Info");
 
   final String key;
   const InfoKey(this.key);

--- a/lib/data/datasources/remote/slack_log_service.dart
+++ b/lib/data/datasources/remote/slack_log_service.dart
@@ -99,8 +99,7 @@ class SlackLogService {
       description = '''
 ${slackLogTemplate.description}
 
-- 단면 카드 세팅 수량 : ${cardCount.initialCount}개
-- 현재 단면 카드 수량 : ${cardCount.currentCount}개
+- 단면 카드 수량 : ${cardCount.currentCount} / ${cardCount.initialCount}
 - 불러온 이벤트 : $eventName
 - 프린터 연결 상태 : 정상
 - 결제 단말기 연결 상태 : ${isPaymentOn == true ? '정상' : '미연결'}
@@ -216,7 +215,7 @@ ${cardCount == 0 ? "- 단면 -> 양면 모드" : "- 단면 모드 설정\n- 단�
     final emoji = emojiMap[slackLogTemplate.category.toLowerCase()] ?? 'ℹ️';
 
     final formattedTitle = (slackLogTemplate.title == "점검 완료" || slackLogTemplate.title == "점검 시작")
-        ? '*[${slackLogTemplate.title}]*'
+        ? '🔵  *${slackLogTemplate.title}*'
         : '$emoji  *${slackLogTemplate.title}*';
 
     final guidePart = slackLogTemplate.guideText != null

--- a/lib/data/datasources/remote/slack_log_service.dart
+++ b/lib/data/datasources/remote/slack_log_service.dart
@@ -1,6 +1,7 @@
 import 'dart:convert';
 import 'dart:developer';
 
+import 'package:flutter_snaptag_kiosk/data/models/entities/slack_log_template.dart';
 import 'package:flutter_snaptag_kiosk/lib.dart';
 import 'package:flutter_dotenv/flutter_dotenv.dart';
 import 'package:http/http.dart' as http;
@@ -46,37 +47,57 @@ class SlackLogService {
     await sendLog(slackWebhookWarningUrl, message);
   }
 
-  Future<void> sendBroadcastLogToSlack(String errorKey, {String? authNum, String? paymentDescription, String? approvalNum, bool? isPaymentOn}) async {
+  // 1) 객체 만드는 함수 LogState
+  // 2) 분기 처리 하는 함수 key, LogState. 결제 sendBraas
+  // 3) buildSlackAlertMessage 실행 LogState
+
+  Future<SlackLogTemplate> createSlackLogTemplate(
+    String? errorKey,
+  ) async {
     final definitions = _container.read(alertDefinitionProvider);
     final def = definitions.firstWhereOrNull((e) => e.key == errorKey);
     final kioskInfo = _container.read(kioskInfoServiceProvider);
-    final machineId = kioskInfo?.kioskMachineId ?? 0;
-    final version =  _container.read(versionStateProvider).currentVersion;
-    final cardCount = _container.read(cardCountProvider);
-    final printLog = _container.read(printerLogProvider);
-    final printerheadTemp = printLog?.heaterTemperature ?? 0;
-    final printerheadTempString = printerheadTemp != 0? "${(printerheadTemp/100).toStringAsFixed(2)}" : "알 수 없음";
+    final version = _container.read(versionStateProvider).currentVersion;
     final eventType = kioskInfo?.eventType ?? "-";
-    final eventName = kioskInfo?.printedEventName ?? "-";
-    final serviceNameMap = {
-      "SUF": "수원FC",
-      "SEF": "서울 이랜드 FC",
-      "KEEFO": "성수 B'Day",
-      "AGFC": "안산그리너스FC"
-    };
 
-    final paymentKey = [
-      InfoKey.paymentFail.key,
-      InfoKey.paymentRefund.key,
-      InfoKey.paymentRefundFail.key,
-    ];
+    final serviceNameMap = {"SUF": "수원FC", "SEF": "서울 이랜드 FC", "KEEFO": "성수 B'Day", "AGFC": "안산그리너스FC"};
+
     final serviceName = serviceNameMap[eventType] ?? '-';
-    String description;
-    if (def != null) {
-      if (def.key == "Inspection_End"){
-          description =
-          '''
-${def.description}
+
+    return def != null && errorKey != null
+        ? SlackLogTemplate(
+            key: errorKey,
+            category: def.category,
+            title: def.title,
+            serviceName: serviceName,
+            appVersion: version,
+            description: def.description,
+            kioskMachineInfo: kioskInfo)
+        : SlackLogTemplate(
+            key: '',
+            category: '',
+            title: '',
+            serviceName: serviceName,
+            appVersion: version,
+            description: '',
+            kioskMachineInfo: kioskInfo);
+  }
+
+  Future<void> sendInspectionEndBroadcastLogToSlack(String errorKey, {required bool isPaymentOn}) async {
+    final slackLogTemplate = await createSlackLogTemplate(errorKey);
+    final cardCount = _container.read(cardCountProvider);
+
+    if (slackLogTemplate.category.isNotEmpty) {
+      final kioskInfo = slackLogTemplate.kioskMachineInfo;
+      final eventName = kioskInfo?.printedEventName ?? "-";
+      final printLog = _container.read(printerLogProvider);
+      final printerheadTemp = printLog?.heaterTemperature ?? 0;
+      final printerheadTempString = printerheadTemp != 0 ? (printerheadTemp / 100).toStringAsFixed(2) : "알 수 없음";
+
+      String description;
+
+      description = '''
+${slackLogTemplate.description}
 
 - 단면 카드 세팅 수량 : ${cardCount.initialCount}개
 - 현재 단면 카드 수량 : ${cardCount.currentCount}개
@@ -85,29 +106,64 @@ ${def.description}
 - 결제 단말기 연결 상태 : ${isPaymentOn == true ? '정상' : '미연결'}
 - 프린터 온도 : $printerheadTempString°C
 - 리본 잔량 : ${printLog?.rbnRemainingRatio != null ? "${printLog?.rbnRemainingRatio}%" : "알 수 없음"}
-- 필름 잔량 : ${printLog?.filmRemainingRatio != null ? "${printLog?.filmRemainingRatio}%": "알 수 없음"}
-'''
-          ;
-      } else if (paymentKey.contains(def.key)){
-        description =
-            '''
-${def.description}
-            
-- $paymentDescription''';
-      } else {
-        description = def.description;
-      }
-
+- 필름 잔량 : ${printLog?.filmRemainingRatio != null ? "${printLog?.filmRemainingRatio}%" : "알 수 없음"}
+''';
 
       final message = buildSlackAlertMessage(
-        category: def.category,
-        title: def.title,
-        serviceName: serviceName,
-        kioskId: machineId.toString(),
-        appVersion: version,
-        description: description,
-        guideText: def.guideText,
-        guideUrl: def.guideUrl,
+        slackLogTemplate: slackLogTemplate.copyWith(description: description),
+        cardCount: cardCount.currentCount,
+      );
+
+      await sendLog(slackWebhookBroadcastUrl, message);
+    }
+  }
+
+  Future<void> sendPaymentBroadcastLogToSlak(String errorKey, {required String paymentDescription}) async {
+    final slackLogTemplate = await createSlackLogTemplate(errorKey);
+
+    if (slackLogTemplate.category.isNotEmpty) {
+      String description;
+
+      description = '''
+${slackLogTemplate.description}
+            
+- $paymentDescription''';
+
+      final message = buildSlackAlertMessage(slackLogTemplate: slackLogTemplate.copyWith(description: description));
+
+      await sendLog(slackWebhookBroadcastUrl, message);
+    }
+  }
+
+  Future<void> sendPeriodicLogBroadcastLogToSlack() async {
+    final slackLogTemplate = await createSlackLogTemplate(null);
+    final machineId = slackLogTemplate.kioskMachineInfo?.kioskMachineId ?? 0;
+
+    if (machineId != 0) {
+      final printerLog = _container.read(printerLogProvider);
+      final cardCount = _container.read(cardCountProvider);
+      String description;
+
+      description = '''
+- 리본 잔량 : ${printerLog?.rbnRemainingRatio != null ? "${printerLog?.rbnRemainingRatio}%" : "알 수 없음"}
+- 필름 잔량 : ${printerLog?.filmRemainingRatio != null ? "${printerLog?.filmRemainingRatio}%" : "알 수 없음"}
+- 단면 카드 장수 : ${cardCount.currentCount}개
+''';
+
+      final message = buildSlackAlertMessage(
+          slackLogTemplate: slackLogTemplate.copyWith(title: '프린트 상태', category: 'info', description: description));
+
+      await sendLog(slackWebhookBroadcastUrl, message);
+    }
+  }
+
+  Future<void> sendBroadcastLogToSlack(String errorKey) async {
+    final slackLogTemplate = await createSlackLogTemplate(errorKey);
+    final cardCount = _container.read(cardCountProvider);
+
+    if (slackLogTemplate.category.isNotEmpty) {
+      final message = buildSlackAlertMessage(
+        slackLogTemplate: slackLogTemplate,
         cardCount: cardCount.currentCount,
       );
 
@@ -145,46 +201,36 @@ ${def.description}
   }
 
   String buildSlackAlertMessage({
-    required String category,
-    required String title,
-    required String serviceName,
-    required String kioskId,
-    required String appVersion,
-    required String description,
-    String? guideText,
-    String? guideUrl,
+    required SlackLogTemplate slackLogTemplate,
     int? cardCount,
   }) {
-    final cardInfo =
-      '''
+    final cardInfo = '''
 ${cardCount == 0 ? "- 단면 -> 양면 모드" : "- 단면 모드 설정\n- 단면 설정 개수 : $cardCount개"}
-      '''
-    ;
+      ''';
 
     final emojiMap = {
       'error': '🔴',
       'warning': '🟡',
       'info': '🟢',
     };
-    final emoji = emojiMap[category.toLowerCase()] ?? 'ℹ️';
+    final emoji = emojiMap[slackLogTemplate.category.toLowerCase()] ?? 'ℹ️';
 
-    final formattedTitle =
-    (title == "점검 완료" || title == "점검 시작")
-        ? '*[$title]*'
-        : '$emoji  *$title*';
+    final formattedTitle = (slackLogTemplate.title == "점검 완료" || slackLogTemplate.title == "점검 시작")
+        ? '*[${slackLogTemplate.title}]*'
+        : '$emoji  *${slackLogTemplate.title}*';
 
-    final guidePart = guideText != null
-        ? "[${guideUrl != null ? '<$guideUrl|$guideText>' : guideText}]"
+    final guidePart = slackLogTemplate.guideText != null
+        ? "[${slackLogTemplate.guideUrl != null ? '<${slackLogTemplate.guideUrl}|${slackLogTemplate.guideText}>' : slackLogTemplate.guideText}]"
         : '';
 
     return '''
 $formattedTitle
 ───────────────────
-Kiosk: $kioskId  /  ${appVersion}
-업체(구단): $serviceName
+Kiosk: ${slackLogTemplate.kioskMachineInfo?.kioskEventId ?? 0}  /  ${slackLogTemplate.appVersion}
+업체(구단): ${slackLogTemplate.serviceName}
 ───────────────────
-$description
-${ title == "카드 인쇄 모드 변경" ? cardInfo : ""}
+${slackLogTemplate.description}
+${slackLogTemplate.title == "카드 인쇄 모드 변경" ? cardInfo : ""}
 $guidePart
 ''';
   }

--- a/lib/data/datasources/remote/slack_log_service.dart
+++ b/lib/data/datasources/remote/slack_log_service.dart
@@ -146,7 +146,7 @@ ${slackLogTemplate.description}
       description = '''
 - 리본 잔량 : ${printerLog?.rbnRemainingRatio != null ? "${printerLog?.rbnRemainingRatio}%" : "알 수 없음"}
 - 필름 잔량 : ${printerLog?.filmRemainingRatio != null ? "${printerLog?.filmRemainingRatio}%" : "알 수 없음"}
-- 단면 카드 장수 : ${cardCount.currentCount}개
+- 단면 카드 수량 : ${cardCount.currentCount} / ${cardCount.initialCount}
 ''';
 
       final message = buildSlackAlertMessage(

--- a/lib/data/datasources/remote/slack_log_service.dart
+++ b/lib/data/datasources/remote/slack_log_service.dart
@@ -225,7 +225,7 @@ ${cardCount == 0 ? "- 단면 -> 양면 모드" : "- 단면 모드 설정\n- 단�
     return '''
 $formattedTitle
 ───────────────────
-Kiosk: ${slackLogTemplate.kioskMachineInfo?.kioskEventId ?? 0}  /  ${slackLogTemplate.appVersion}
+Kiosk: ${slackLogTemplate.kioskMachineInfo?.kioskMachineId ?? 0}  /  ${slackLogTemplate.appVersion}
 업체(구단): ${slackLogTemplate.serviceName}
 ───────────────────
 ${slackLogTemplate.description}

--- a/lib/data/models/entities/slack_log_template.dart
+++ b/lib/data/models/entities/slack_log_template.dart
@@ -1,0 +1,48 @@
+import 'package:flutter_snaptag_kiosk/data/models/response/kiosk_machine_info.dart';
+
+class SlackLogTemplate {
+  final String key;
+  final String category;
+  final String title;
+  final String serviceName;
+  final String appVersion;
+  final String description;
+  final KioskMachineInfo? kioskMachineInfo;
+  final String? guideText;
+  final String? guideUrl;
+
+  const SlackLogTemplate({
+    required this.key,
+    required this.category,
+    required this.title,
+    required this.serviceName,
+    required this.appVersion,
+    required this.description,
+    this.kioskMachineInfo,
+    this.guideText,
+    this.guideUrl,
+  });
+
+  SlackLogTemplate copyWith({
+    String? category,
+    String? title,
+    String? serviceName,
+    String? kioskId,
+    String? appVersion,
+    String? description,
+    String? guideText,
+    String? guideUrl,
+    KioskMachineInfo? kioskMachineInfo,
+  }) {
+    return SlackLogTemplate(
+        key: key,
+        category: category ?? this.category,
+        title: title ?? this.title,
+        serviceName: serviceName ?? this.serviceName,
+        appVersion: appVersion ?? this.appVersion,
+        description: description ?? this.description,
+        guideText: guideText ?? this.guideText,
+        guideUrl: guideUrl ?? this.guideUrl,
+        kioskMachineInfo: kioskMachineInfo ?? this.kioskMachineInfo);
+  }
+}

--- a/lib/features/core/printer/card_printer.dart
+++ b/lib/features/core/printer/card_printer.dart
@@ -2,6 +2,7 @@ import 'dart:ffi' as ffi; // ffi 임포트 확인
 import 'dart:io';
 
 import 'package:ffi/ffi.dart'; // Utf8 사용을 위한 임포트
+import 'package:flutter_snaptag_kiosk/features/core/printer/print_state_provider.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
 
 import 'package:flutter_snaptag_kiosk/features/core/printer/printer_log.dart';
@@ -62,8 +63,7 @@ class PrinterService extends _$PrinterService {
       final printerLog = getPrinterLogData(_bindings);
       if (printerLog != null) {
         ref.read(printerLogProvider.notifier).update(printerLog);
-      }
-      else {
+      } else {
         SlackLogService().sendLogToSlack("CheckConnected Print - PrinterLog is null");
       }
       final isReady = printerLog?.printerMainStatusCode == "1004";
@@ -212,6 +212,7 @@ class PrinterService extends _$PrinterService {
       final machineId = ref.read(kioskInfoServiceProvider)?.kioskMachineId ?? 0;
       final log = printerLog.copyWith(kioskMachineId: machineId);
       if (machineId != 0) {
+        ref.read(printerLogProvider.notifier).update(printerLog);
         await ref.read(kioskRepositoryProvider).updatePrintLog(request: log);
         SlackLogService().sendLogToSlack('Machine ID: $machineId , PrintState : $log');
       }

--- a/lib/features/core/printer/print_state_provider.dart
+++ b/lib/features/core/printer/print_state_provider.dart
@@ -1,0 +1,24 @@
+import 'package:riverpod_annotation/riverpod_annotation.dart';
+import 'package:flutter_snaptag_kiosk/features/core/printer/printer_log.dart';
+
+part 'print_state_provider.g.dart';
+
+/// 프린터 상태(PrinterLog)를 보관하는 전역 Provider.
+/// - 최신 프린트 상태를 저장/조회
+/// - 필요 시 clear 가능
+@Riverpod(keepAlive: true)
+class PrintState extends _$PrintState {
+  /// 초기값: 없음
+  @override
+  PrinterLog? build() => null;
+
+  /// 상태 저장/갱신
+  void set(PrinterLog? log) {
+    state = log;
+  }
+
+  /// 상태 초기화
+  void clear() {
+    state = null;
+  }
+}

--- a/lib/features/move_me/providers/alert_definition_provider.dart
+++ b/lib/features/move_me/providers/alert_definition_provider.dart
@@ -1,6 +1,5 @@
 import 'package:flutter_snaptag_kiosk/lib.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
-import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:collection/collection.dart';
 
 part 'alert_definition_provider.g.dart';

--- a/lib/features/move_me/providers/setup_refund_process_provider.dart
+++ b/lib/features/move_me/providers/setup_refund_process_provider.dart
@@ -67,32 +67,33 @@ class SetupRefundProcess extends _$SetupRefundProcess {
           paymentDescription:
               "동작로직: 관리자 환불\n- 사유: 기취소된 거래\n- 인증번호: ${order.photoAuthNumber}\n- 승인번호: ${order.paymentAuthNumber ?? "없음"}");
     } else {
-      switch(payment?.res) {
-        case '0000':
-          await ref.read(kioskRepositoryProvider).updateOrderStatus(
-            order.orderId.toInt(),
-            request,
-          );
       switch (payment?.res) {
         case '0000':
-          SlackLogService().sendPaymentBroadcastLogToSlak(InfoKey.paymentRefund.key,
-              paymentDescription:
-                  "동작로직: 관리자 환불\n- 인증번호: ${order.photoAuthNumber}\n- 승인번호: ${order.paymentAuthNumber ?? "없음"}");
-          break;
-        case '1000':
-          SlackLogService().sendPaymentBroadcastLogToSlak(InfoKey.paymentRefundFail.key,
-              paymentDescription:
-                  "동작로직: 관리자 환불\n- 사유: 사용자가 환불취소 누름\n- 인증번호: ${order.photoAuthNumber}\n- 승인번호: ${order.paymentAuthNumber ?? "없음"}");
-          break;
-        case '1004':
-          SlackLogService().sendPaymentBroadcastLogToSlak(InfoKey.paymentRefundFail.key,
-              paymentDescription:
-                  "동작로직: 관리자 환불\n- 사유: 시간초과\n- 인증번호: ${order.photoAuthNumber}\n- 승인번호: ${order.paymentAuthNumber ?? "없음"}");
-          break;
-        default:
-          SlackLogService().sendPaymentBroadcastLogToSlak(InfoKey.paymentRefundFail.key,
-              paymentDescription:
-                  "동작로직: 관리자 환불\n- 사유: 확인필요\n- 인증번호: ${order.photoAuthNumber}\n- 승인번호: ${order.paymentAuthNumber ?? "없음"}");
+          await ref.read(kioskRepositoryProvider).updateOrderStatus(
+                order.orderId.toInt(),
+                request,
+              );
+          switch (payment?.res) {
+            case '0000':
+              SlackLogService().sendPaymentBroadcastLogToSlak(InfoKey.paymentRefund.key,
+                  paymentDescription:
+                      "동작로직: 관리자 환불\n- 인증번호: ${order.photoAuthNumber}\n- 승인번호: ${order.paymentAuthNumber ?? "없음"}");
+              break;
+            case '1000':
+              SlackLogService().sendPaymentBroadcastLogToSlak(InfoKey.paymentRefundFail.key,
+                  paymentDescription:
+                      "동작로직: 관리자 환불\n- 사유: 사용자가 환불취소 누름\n- 인증번호: ${order.photoAuthNumber}\n- 승인번호: ${order.paymentAuthNumber ?? "없음"}");
+              break;
+            case '1004':
+              SlackLogService().sendPaymentBroadcastLogToSlak(InfoKey.paymentRefundFail.key,
+                  paymentDescription:
+                      "동작로직: 관리자 환불\n- 사유: 시간초과\n- 인증번호: ${order.photoAuthNumber}\n- 승인번호: ${order.paymentAuthNumber ?? "없음"}");
+              break;
+            default:
+              SlackLogService().sendPaymentBroadcastLogToSlak(InfoKey.paymentRefundFail.key,
+                  paymentDescription:
+                      "동작로직: 관리자 환불\n- 사유: 확인필요\n- 인증번호: ${order.photoAuthNumber}\n- 승인번호: ${order.paymentAuthNumber ?? "없음"}");
+          }
       }
     }
   }

--- a/lib/features/move_me/providers/setup_refund_process_provider.dart
+++ b/lib/features/move_me/providers/setup_refund_process_provider.dart
@@ -63,24 +63,34 @@ class SetupRefundProcess extends _$SetupRefundProcess {
             order.orderId.toInt(),
             request.copyWith(status: OrderStatus.refunded),
           );
-      SlackLogService().sendBroadcastLogToSlack(InfoKey.paymentRefundFail.key, paymentDescription: "동작로직: 관리자 환불\n- 사유: 기취소된 거래\n- 인증번호: ${order.photoAuthNumber}\n- 승인번호: ${order.paymentAuthNumber ?? "없음"}");
+      SlackLogService().sendPaymentBroadcastLogToSlak(InfoKey.paymentRefundFail.key,
+          paymentDescription:
+              "동작로직: 관리자 환불\n- 사유: 기취소된 거래\n- 인증번호: ${order.photoAuthNumber}\n- 승인번호: ${order.paymentAuthNumber ?? "없음"}");
     } else {
       await ref.read(kioskRepositoryProvider).updateOrderStatus(
             order.orderId.toInt(),
             request,
           );
-      switch(payment?.res) {
+      switch (payment?.res) {
         case '0000':
-          SlackLogService().sendBroadcastLogToSlack(InfoKey.paymentRefund.key, paymentDescription: "동작로직: 관리자 환불\n- 인증번호: ${order.photoAuthNumber}\n- 승인번호: ${order.paymentAuthNumber ?? "없음"}");
+          SlackLogService().sendPaymentBroadcastLogToSlak(InfoKey.paymentRefund.key,
+              paymentDescription:
+                  "동작로직: 관리자 환불\n- 인증번호: ${order.photoAuthNumber}\n- 승인번호: ${order.paymentAuthNumber ?? "없음"}");
           break;
         case '1000':
-          SlackLogService().sendBroadcastLogToSlack(InfoKey.paymentRefundFail.key, paymentDescription: "동작로직: 관리자 환불\n- 사유: 사용자가 환불취소 누름\n- 인증번호: ${order.photoAuthNumber}\n- 승인번호: ${order.paymentAuthNumber ?? "없음"}");
+          SlackLogService().sendPaymentBroadcastLogToSlak(InfoKey.paymentRefundFail.key,
+              paymentDescription:
+                  "동작로직: 관리자 환불\n- 사유: 사용자가 환불취소 누름\n- 인증번호: ${order.photoAuthNumber}\n- 승인번호: ${order.paymentAuthNumber ?? "없음"}");
           break;
         case '1004':
-          SlackLogService().sendBroadcastLogToSlack(InfoKey.paymentRefundFail.key, paymentDescription: "동작로직: 관리자 환불\n- 사유: 시간초과\n- 인증번호: ${order.photoAuthNumber}\n- 승인번호: ${order.paymentAuthNumber ?? "없음"}");
+          SlackLogService().sendPaymentBroadcastLogToSlak(InfoKey.paymentRefundFail.key,
+              paymentDescription:
+                  "동작로직: 관리자 환불\n- 사유: 시간초과\n- 인증번호: ${order.photoAuthNumber}\n- 승인번호: ${order.paymentAuthNumber ?? "없음"}");
           break;
         default:
-          SlackLogService().sendBroadcastLogToSlack(InfoKey.paymentRefundFail.key, paymentDescription: "동작로직: 관리자 환불\n- 사유: 확인필요\n- 인증번호: ${order.photoAuthNumber}\n- 승인번호: ${order.paymentAuthNumber ?? "없음"}");
+          SlackLogService().sendPaymentBroadcastLogToSlak(InfoKey.paymentRefundFail.key,
+              paymentDescription:
+                  "동작로직: 관리자 환불\n- 사유: 확인필요\n- 인증번호: ${order.photoAuthNumber}\n- 승인번호: ${order.paymentAuthNumber ?? "없음"}");
       }
     }
   }

--- a/lib/features/move_me/screens/kiosk_shell.dart
+++ b/lib/features/move_me/screens/kiosk_shell.dart
@@ -1,103 +1,109 @@
+import 'dart:async';
+
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_screenutil/flutter_screenutil.dart';
 import 'package:flutter_snaptag_kiosk/lib.dart';
 import 'package:loader_overlay/loader_overlay.dart';
 
-class KioskShell extends ConsumerWidget {
+class KioskShell extends ConsumerStatefulWidget {
   final Widget child;
 
-  const KioskShell({
-    super.key,
-    required this.child,
-  });
+  const KioskShell({super.key, required this.child});
 
   @override
-  Widget build(BuildContext context, WidgetRef ref) {
+  ConsumerState<KioskShell> createState() => _KioskShellState();
+}
+
+class _KioskShellState extends ConsumerState<KioskShell> {
+  Timer? _periodicTimer;
+
+  @override
+  void initState() {
+    super.initState();
+
+    Future.delayed(const Duration(minutes: 30), () {
+      _periodicTimer = Timer.periodic(const Duration(minutes: 30), (timer) {
+        SlackLogService().sendPeriodicLogBroadcastLogToSlack();
+      });
+    });
+  }
+
+  @override
+  void dispose() {
+    _periodicTimer?.cancel();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
     final hasNetworkError = ref.watch(backgroundImageProvider);
     final settings = ref.read(kioskInfoServiceProvider);
+
     return Stack(
-        children: [
+      children: [
         Scaffold(
-      body: Column(
-        children: [
-          SizedBox(
-            height: 855.h,
-            width: double.infinity,
-            child: Image.network(
-              ref.read(kioskInfoServiceProvider)?.topBannerUrl ?? '',
-              fit: BoxFit.cover,
-              errorBuilder: (context, error, stackTrace) {
-                return Center(
-                  child: const Text('이미지를 찾을 수 없습니다.'),
-                );
-              },
-            ),
-          ),
-          Expanded(
-            child: LoaderOverlay(
-              overlayWidgetBuilder: (dynamic progress) {
-                return Center(
-                  child: SizedBox(
-                    width: 350.h,
-                    height: 350.h,
-                    child: CircularProgressIndicator(
-                      strokeWidth: 15.h,
-                    ),
-                  ),
-                );
-              },
-              child: DecoratedBox(
-                decoration: BoxDecoration(
-                  image: !hasNetworkError
-                      ? DecorationImage(
-                          image: NetworkImage(settings?.mainImageUrl ?? ''),
-                          onError: (Object e, StackTrace? stackTrace) {
-                            debugPrint(
-                              "Could not load the network image, showing fallback instead. Error: ${e.toString()}",
-                            );
-                            if (stackTrace != null) {
-                              debugPrint(stackTrace.toString());
-                            }
-                            ref.read(backgroundImageProvider.notifier).setNetworkError();
-                          },
-                          fit: BoxFit.cover,
-                        )
-                      : DecorationImage(
-                          image: const AssetImage('assets/images/fallback_body.jpg'),
-                          fit: BoxFit.cover,
-                        ),
-                ),
-                child: Column(
-                  children: [
-                    // 앱바 영역
-                    SizedBox(
-                      height: 70.h,
-                      child: Row(
-                        children: [
-                          const Spacer(),
-                          KioskNavigatorButton(),
-                          SizedBox(width: 30.w),
-                        ],
-                      ),
-                    ),
-                    SizedBox(
-                      height: 230.h,
-                    ),
-                    // 실제 콘텐츠
-                    Expanded(
-                      child: child,
-                    ),
-                  ],
+          body: Column(
+            children: [
+              SizedBox(
+                height: 855.h,
+                width: double.infinity,
+                child: Image.network(
+                  settings?.topBannerUrl ?? '',
+                  fit: BoxFit.cover,
+                  errorBuilder: (context, error, stackTrace) {
+                    return const Center(child: Text('이미지를 찾을 수 없습니다.'));
+                  },
                 ),
               ),
-            ),
+              Expanded(
+                child: LoaderOverlay(
+                  overlayWidgetBuilder: (_) => Center(
+                    child: SizedBox(
+                      width: 350.h,
+                      height: 350.h,
+                      child: CircularProgressIndicator(strokeWidth: 15.h),
+                    ),
+                  ),
+                  child: DecoratedBox(
+                    decoration: BoxDecoration(
+                      image: !hasNetworkError
+                          ? DecorationImage(
+                              image: NetworkImage(settings?.mainImageUrl ?? ''),
+                              onError: (_, __) {
+                                ref.read(backgroundImageProvider.notifier).setNetworkError();
+                              },
+                              fit: BoxFit.cover,
+                            )
+                          : const DecorationImage(
+                              image: AssetImage('assets/images/fallback_body.jpg'),
+                              fit: BoxFit.cover,
+                            ),
+                    ),
+                    child: Column(
+                      children: [
+                        SizedBox(
+                          height: 70.h,
+                          child: Row(
+                            children: [
+                              const Spacer(),
+                              KioskNavigatorButton(),
+                              SizedBox(width: 30.w),
+                            ],
+                          ),
+                        ),
+                        SizedBox(height: 230.h),
+                        Expanded(child: widget.child),
+                      ],
+                    ),
+                  ),
+                ),
+              ),
+            ],
           ),
-        ],
-      ),
-      floatingActionButtonLocation: FloatingActionButtonLocation.endTop,
-      floatingActionButton: TripleTapFloatingButton(),
-    ),
+          floatingActionButtonLocation: FloatingActionButtonLocation.endTop,
+          floatingActionButton: TripleTapFloatingButton(),
+        ),
         const Positioned(
           top: 20,
           left: 20,

--- a/lib/features/move_me/screens/kiosk_shell.dart
+++ b/lib/features/move_me/screens/kiosk_shell.dart
@@ -22,10 +22,8 @@ class _KioskShellState extends ConsumerState<KioskShell> {
   void initState() {
     super.initState();
 
-    Future.delayed(const Duration(minutes: 30), () {
-      _periodicTimer = Timer.periodic(const Duration(minutes: 30), (timer) {
-        SlackLogService().sendPeriodicLogBroadcastLogToSlack();
-      });
+    _periodicTimer = Timer.periodic(const Duration(minutes: 30), (timer) {
+      SlackLogService().sendPeriodicLogBroadcastLogToSlack();
     });
   }
 

--- a/lib/features/move_me/screens/setup_main_screen.dart
+++ b/lib/features/move_me/screens/setup_main_screen.dart
@@ -324,10 +324,12 @@ class _SetupMainScreenState extends ConsumerState<SetupMainScreen> {
                             PhotoCardUploadRouteData().go(context);
                             try {
                               final response = await ref.read(paymentRepositoryProvider).check();
-                              SlackLogService().sendBroadcastLogToSlack(InfoKey.inspectionEnd.key, isPaymentOn: true);
+                              SlackLogService()
+                                  .sendInspectionEndBroadcastLogToSlack(InfoKey.inspectionEnd.key, isPaymentOn: true);
                               SlackLogService().sendLogToSlack("Payment Device check: $response");
                             } catch (e) {
-                              SlackLogService().sendBroadcastLogToSlack(InfoKey.inspectionEnd.key, isPaymentOn: false);
+                              SlackLogService()
+                                  .sendInspectionEndBroadcastLogToSlack(InfoKey.inspectionEnd.key, isPaymentOn: false);
                               SlackLogService().sendErrorLogToSlack("Payment Device check: $e");
                             }
                           }

--- a/lib/features/presentation/services/payment_service.dart
+++ b/lib/features/presentation/services/payment_service.dart
@@ -48,22 +48,22 @@ class PaymentService extends _$PaymentService {
         ref.read(paymentFailureProvider.notifier).triggerFailure();
         final failResponse = await _updateFailOrder();
         ref.read(updateOrderInfoProvider.notifier).update(failResponse);
-        SlackLogService().sendBroadcastLogToSlack(InfoKey.paymentFail.key,
+        SlackLogService().sendPaymentBroadcastLogToSlak(InfoKey.paymentFail.key,
             paymentDescription:
-                "사유: 승인번호가 빈 결제 건\n- 인증번호: ${backPhoto.photoAuthNumber}\n- 승인번호: ${(paymentResponse.approvalNo != null)? paymentResponse.approvalNo : "없음"}");
+                "사유: 승인번호가 빈 결제 건\n- 인증번호: ${backPhoto.photoAuthNumber}\n- 승인번호: ${(paymentResponse.approvalNo != null) ? paymentResponse.approvalNo : "없음"}");
       } else {
         final response = await _updateOrder(isRefund: false); //결제 취소, 정상 결제
         ref.read(updateOrderInfoProvider.notifier).update(response);
         if (paymentResponse.res == '0000') {
           ref.read(cardCountProvider.notifier).decrease();
         } else if (paymentResponse.res == '1004') {
-          SlackLogService().sendBroadcastLogToSlack(InfoKey.paymentFail.key,
+          SlackLogService().sendPaymentBroadcastLogToSlak(InfoKey.paymentFail.key,
               paymentDescription:
-                  "사유: 시간초과\n- 인증번호: ${backPhoto.photoAuthNumber}\n- 승인번호: ${(paymentResponse.approvalNo != null)? paymentResponse.approvalNo : "없음"}");
+                  "사유: 시간초과\n- 인증번호: ${backPhoto.photoAuthNumber}\n- 승인번호: ${(paymentResponse.approvalNo != null) ? paymentResponse.approvalNo : "없음"}");
         } else if (paymentResponse.res == '1000') {
-          SlackLogService().sendBroadcastLogToSlack(InfoKey.paymentFail.key,
+          SlackLogService().sendPaymentBroadcastLogToSlak(InfoKey.paymentFail.key,
               paymentDescription:
-                  "사유: 사용자가 결제취소 누름\n- 인증번호: ${backPhoto.photoAuthNumber}\n- 승인번호: ${(paymentResponse.approvalNo != null)? paymentResponse.approvalNo : "없음"}");
+                  "사유: 사용자가 결제취소 누름\n- 인증번호: ${backPhoto.photoAuthNumber}\n- 승인번호: ${(paymentResponse.approvalNo != null) ? paymentResponse.approvalNo : "없음"}");
         }
       }
     } catch (e) {
@@ -106,23 +106,27 @@ class PaymentService extends _$PaymentService {
       final paymentRes = approvalInfo?.res;
       final response = await _updateOrder(isRefund: true);
       if (response.status == OrderStatus.refunded) {
-        SlackLogService().sendBroadcastLogToSlack(InfoKey.paymentRefund.key,
-            paymentDescription: "동작로직: 자동환불\n- 인증번호: ${backPhoto?.photoAuthNumber ?? "없음"}\n- 승인번호: ${approvalInfo?.approvalNo ?? "없음"}");
+        SlackLogService().sendPaymentBroadcastLogToSlak(InfoKey.paymentRefund.key,
+            paymentDescription:
+                "동작로직: 자동환불\n- 인증번호: ${backPhoto?.photoAuthNumber ?? "없음"}\n- 승인번호: ${approvalInfo?.approvalNo ?? "없음"}");
         ref.read(paymentResponseStateProvider.notifier).reset();
         SlackLogService().sendLogToSlack('paymentResponseState Reset'); //paymentTestSlack
       } else {
         switch (paymentRes) {
           case '1000':
-            SlackLogService().sendBroadcastLogToSlack(InfoKey.paymentRefundFail.key,
-                paymentDescription: "동작로직: 자동환불\n- 사유: 사용자가 환불취소 누름\n- 인증번호: ${backPhoto?.photoAuthNumber ?? "없음"}\n- 승인번호: ${approvalInfo?.approvalNo ?? "없음"}");
+            SlackLogService().sendPaymentBroadcastLogToSlak(InfoKey.paymentRefundFail.key,
+                paymentDescription:
+                    "동작로직: 자동환불\n- 사유: 사용자가 환불취소 누름\n- 인증번호: ${backPhoto?.photoAuthNumber ?? "없음"}\n- 승인번호: ${approvalInfo?.approvalNo ?? "없음"}");
             break;
           case '1004':
-            SlackLogService().sendBroadcastLogToSlack(InfoKey.paymentRefundFail.key,
-                paymentDescription: "동작로직: 자동환불\n- 사유: 시간초과\n- 인증번호: ${backPhoto?.photoAuthNumber ?? "없음"}\n- 승인번호: ${approvalInfo?.approvalNo ?? "없음"}");
+            SlackLogService().sendPaymentBroadcastLogToSlak(InfoKey.paymentRefundFail.key,
+                paymentDescription:
+                    "동작로직: 자동환불\n- 사유: 시간초과\n- 인증번호: ${backPhoto?.photoAuthNumber ?? "없음"}\n- 승인번호: ${approvalInfo?.approvalNo ?? "없음"}");
             break;
           default:
-            SlackLogService().sendBroadcastLogToSlack(InfoKey.paymentRefundFail.key,
-                paymentDescription: "동작로직: 자동환불\n- 사유: 확인필요\n- 인증번호: ${backPhoto?.photoAuthNumber ?? "없음"}\n- 승인번호: ${approvalInfo?.approvalNo ?? "없음"}");
+            SlackLogService().sendPaymentBroadcastLogToSlak(InfoKey.paymentRefundFail.key,
+                paymentDescription:
+                    "동작로직: 자동환불\n- 사유: 확인필요\n- 인증번호: ${backPhoto?.photoAuthNumber ?? "없음"}\n- 승인번호: ${approvalInfo?.approvalNo ?? "없음"}");
         }
       }
     }
@@ -162,8 +166,8 @@ class PaymentService extends _$PaymentService {
       final response = await _updateOrder(isRefund: true, orderid: order.orderId, photoAuthNumber: code);
       SlackLogService().sendLogToSlack('error409 response: $response'); //paymentTestSlack
       if (response.status == OrderStatus.refunded) {
-        SlackLogService()
-            .sendBroadcastLogToSlack(InfoKey.paymentRefund.key, paymentDescription: "동작로직: 환불안내\n- 인증번호: $code\n- 승인번호: ${order.authSeqNumber ?? "없음"}");
+        SlackLogService().sendPaymentBroadcastLogToSlak(InfoKey.paymentRefund.key,
+            paymentDescription: "동작로직: 환불안내\n- 인증번호: $code\n- 승인번호: ${order.authSeqNumber ?? "없음"}");
         ref.read(paymentResponseStateProvider.notifier).reset();
         SlackLogService().sendLogToSlack('error409 paymentResponseState Reset'); //paymentTestSlack
       } else {
@@ -171,16 +175,19 @@ class PaymentService extends _$PaymentService {
         final paymentRes = approvalInfo?.res;
         switch (paymentRes) {
           case '1000':
-            SlackLogService().sendBroadcastLogToSlack(InfoKey.paymentRefundFail.key,
-                paymentDescription: "동작로직: 환불안내\n- 사유: 사용자가 환불취소 누름\n- 인증번호: $code\n- 승인번호: ${approvalInfo?.approvalNo ?? "없음"}");
+            SlackLogService().sendPaymentBroadcastLogToSlak(InfoKey.paymentRefundFail.key,
+                paymentDescription:
+                    "동작로직: 환불안내\n- 사유: 사용자가 환불취소 누름\n- 인증번호: $code\n- 승인번호: ${approvalInfo?.approvalNo ?? "없음"}");
             break;
           case '1004':
-            SlackLogService().sendBroadcastLogToSlack(InfoKey.paymentRefundFail.key,
-                paymentDescription: "동작로직: 환불안내\n- 사유: 시간초과\n- 인증번호: $code\n- 승인번호: ${approvalInfo?.approvalNo ?? "없음"}");
+            SlackLogService().sendPaymentBroadcastLogToSlak(InfoKey.paymentRefundFail.key,
+                paymentDescription:
+                    "동작로직: 환불안내\n- 사유: 시간초과\n- 인증번호: $code\n- 승인번호: ${approvalInfo?.approvalNo ?? "없음"}");
             break;
           default:
-            SlackLogService().sendBroadcastLogToSlack(InfoKey.paymentRefundFail.key,
-                paymentDescription: "동작로직: 환불안내\n- 사유: 확인필요\n- 인증번호: $code\n- 승인번호: ${approvalInfo?.approvalNo ?? "없음"}");
+            SlackLogService().sendPaymentBroadcastLogToSlak(InfoKey.paymentRefundFail.key,
+                paymentDescription:
+                    "동작로직: 환불안내\n- 사유: 확인필요\n- 인증번호: $code\n- 승인번호: ${approvalInfo?.approvalNo ?? "없음"}");
         }
       }
     }


### PR DESCRIPTION
## 📌 작업 개요
- 주기적인 프린터 상태 공유 추가
- 30분 마다 프린터 상태 Slack WebHook 호출
- BroadcastLogToSlack 관련 로직 리팩토링
- 단면 카드 수량 알림 워딩 수정

## 🔍 변경 사항
- createSlackLogTemplate 함수 추가 -> Template에 필요한 객체 생성 함수
- sendInspectionEndBroadcastLogToSlack 함수 추가 -> 점검 관련 알림 호출 함수
- sendPaymentBroadcastLogToSlak 함수 추가 -> 결제 관련 알림 호출 함수
- sendPeriodicLogBroadcastLogToSlack 함수 추가-> 프린터 상태 공유 알림 호출 함수
- sendBroadcastLogToSlack 함수 변경 -> 예외 처리가 필요 없는 서비스 알림 호출 함수
- KioskShell에 30분 주기 타이머 추가, 프린터 상태 공유 함수 호출

## 🧪 테스트 방법
- 이벤트 실행 시 30분 주기 상태 공유 알림 확인

## 📎 기타 참고 사항
- 30분 주기가 끝난 타이밍에 프린팅 중이라면 프린팅이 끝나고 로직이 실행 됨 ( UI 블로킹에 의한 콜백 지연 )
- 콜백 지연된 경우, 로직이 실행됐을 때 시점에서 주기가 다시 시작 됨.
- 프린트 작업에 Isolate적용 시 UI 블로킹 제외 , 콜백 지연 제거 가능.

## 🙏 리뷰 요청 포인트
- Refactoring 코드 중점적으로 부탁드립니다.