### PR TITLE
결제 승인번호 없을 시 사유 추가

### DIFF
--- a/lib/features/presentation/services/payment_service.dart
+++ b/lib/features/presentation/services/payment_service.dart
@@ -13,6 +13,25 @@ class PaymentService extends _$PaymentService {
 
   Future<void> processPayment() async {
     // 1. 사전 검증
+    _validatePreconditions();
+
+    // 2. 주문 생성
+    final orderResponse = await _createOrder().catchError((e) => throw OrderCreationException('Create order fail: $e'));
+    ref.read(createOrderInfoProvider.notifier).update(orderResponse);
+
+    try {
+      // 3. 결제 승인 및 처리
+      final paymentResponse = await _approvePayment();
+      await _handlePaymentResult(paymentResponse);
+    } catch (e) {
+      await _handlePaymentError();
+      logger.e('Payment process failed', error: e);
+      rethrow;
+    }
+  }
+
+  /// 사전 조건 검증
+  void _validatePreconditions() {
     final settings = ref.read(kioskInfoServiceProvider);
     final backPhoto = ref.watch(verifyPhotoCardProvider).value;
 
@@ -22,71 +41,112 @@ class PaymentService extends _$PaymentService {
     if (backPhoto == null) {
       throw PreconditionFailedException('No back photo available');
     }
+  }
 
-    // 2. 주문 생성
-    final orderResponse = await _createOrder().catchError((e) => throw OrderCreationException('Create order fail: $e'));
-    ref.read(createOrderInfoProvider.notifier).update(orderResponse);
+  /// 결제 승인 처리
+  Future<PaymentResponse> _approvePayment() async {
+    final price = ref.read(kioskInfoServiceProvider)!.photoCardPrice;
+    final paymentResponse = await ref.read(paymentRepositoryProvider).approve(
+          totalAmount: price,
+        );
+    ref.read(paymentResponseStateProvider.notifier).update(paymentResponse);
+    return paymentResponse;
+  }
 
-    try {
-      // 3. 결제 승인
-      final price = ref.read(kioskInfoServiceProvider)!.photoCardPrice;
-      final paymentResponse = await ref.read(paymentRepositoryProvider).approve(
-            totalAmount: price,
-          );
-      ref.read(paymentResponseStateProvider.notifier).update(paymentResponse);
-      final approvalNo = paymentResponse.approvalNo ?? '';
-      final machineId = ref.read(kioskInfoServiceProvider)!.kioskMachineId;
-      if (approvalNo.trim().isEmpty && paymentResponse.res == '0000') {
-        //승인번호가 빈 결제 건
-        SlackLogService().sendWarningLogToSlack('*[MachineId: $machineId]*\nNull approvalNo Card');
-        final BackPhotoStatusResponse response =
-            await ref.read(kioskRepositoryProvider).updateBackPhotoStatus(UpdateBackPhotoRequest(
-                  photoAuthNumber: backPhoto.photoAuthNumber,
-                  status: "STARTED",
-                ));
-        print("update status response : $response");
-        ref.read(paymentFailureProvider.notifier).triggerFailure();
-        final failResponse = await _updateFailOrder();
-        ref.read(updateOrderInfoProvider.notifier).update(failResponse);
-        SlackLogService().sendPaymentBroadcastLogToSlak(InfoKey.paymentFail.key,
-            paymentDescription:
-                "사유: 승인번호가 빈 결제 건\n- 인증번호: ${backPhoto.photoAuthNumber}\n- 승인번호: ${(paymentResponse.approvalNo != null) ? paymentResponse.approvalNo : "없음"}");
-      } else {
-        SlackLogService().sendLogToSlack("paymentResponse : $paymentResponse");
-        // 정상 결제, 결제 취소
-        if (paymentResponse.res == '0000') {
-          final response = await _updateOrder(isRefund: false);
-          ref.read(updateOrderInfoProvider.notifier).update(response);
-          await ref.read(cardCountProvider.notifier).decrease();
-          SlackLogService().sendLogToSlack("paymentResponse0000 : $response");
-        } else if (paymentResponse.res == '1004') {
-          final response = await _updateOrder(isRefund: false, description: "시간초과");
-          ref.read(updateOrderInfoProvider.notifier).update(response);
-          SlackLogService().sendLogToSlack("paymentResponse1004 : $response");
-          SlackLogService().sendPaymentBroadcastLogToSlak(InfoKey.paymentFail.key,
-              paymentDescription:
-                  "사유: 시간초과\n- 인증번호: ${backPhoto.photoAuthNumber}\n- 승인번호: ${(paymentResponse.approvalNo != null) ? paymentResponse.approvalNo : "없음"}");
-        } else if (paymentResponse.res == '1000') {
-          final response = await _updateOrder(isRefund: false, description: "고객취소");
-          ref.read(updateOrderInfoProvider.notifier).update(response);
-          SlackLogService().sendLogToSlack("paymentResponse1000 : $response");
-          SlackLogService().sendPaymentBroadcastLogToSlak(InfoKey.paymentFail.key,
-              paymentDescription:
-                  "사유: 사용자가 결제취소 누름\n- 인증번호: ${backPhoto.photoAuthNumber}\n- 승인번호: ${(paymentResponse.approvalNo != null) ? paymentResponse.approvalNo : "없음"}");
-        } else {
-          final response = await _updateOrder(isRefund: false, description: "확인필요");
-          ref.read(updateOrderInfoProvider.notifier).update(response);
-        }
-      }
-    } catch (e) {
-      final response = await _updateOrder(isRefund: false, description: "확인필요");
-      ref.read(updateOrderInfoProvider.notifier).update(response);
-      logger.e('Payment process failed', error: e);
-      rethrow;
-    } finally {
-      // final response = await _updateOrder();
-      // ref.read(updateOrderInfoProvider.notifier).update(response);
+  /// 결제 결과 처리
+  Future<void> _handlePaymentResult(PaymentResponse paymentResponse) async {
+    final approvalNo = paymentResponse.approvalNo ?? '';
+    final machineId = ref.read(kioskInfoServiceProvider)!.kioskMachineId.toString();
+
+    if (approvalNo.trim().isEmpty && paymentResponse.res == '0000') {
+      await _handleEmptyApprovalNumber(paymentResponse, machineId);
+    } else {
+      await _handlePaymentResponse(paymentResponse);
     }
+  }
+
+  /// 승인번호가 없는 결제 처리
+  Future<void> _handleEmptyApprovalNumber(PaymentResponse paymentResponse, String machineId) async {
+    final backPhoto = ref.watch(verifyPhotoCardProvider).value!;
+
+    SlackLogService().sendWarningLogToSlack('*[MachineId: $machineId]*\nNull approvalNo Card');
+
+    await ref.read(kioskRepositoryProvider).updateBackPhotoStatus(UpdateBackPhotoRequest(
+          photoAuthNumber: backPhoto.photoAuthNumber,
+          status: "STARTED",
+        ));
+
+    ref.read(paymentFailureProvider.notifier).triggerFailure();
+
+    final failResponse = await _updateFailOrder();
+    ref.read(updateOrderInfoProvider.notifier).update(failResponse);
+
+    SlackLogService().sendPaymentBroadcastLogToSlak(InfoKey.paymentFail.key,
+        paymentDescription:
+            "사유: ${paymentResponse.message1}, ${paymentResponse.message2}\n- 인증번호: ${backPhoto.photoAuthNumber}\n- 승인번호: ${paymentResponse.approvalNo ?? "없음"}");
+  }
+
+  /// 결제 응답 처리
+  Future<void> _handlePaymentResponse(PaymentResponse paymentResponse) async {
+    final backPhoto = ref.watch(verifyPhotoCardProvider).value!;
+
+    SlackLogService().sendLogToSlack("paymentResponse : $paymentResponse");
+
+    switch (paymentResponse.res) {
+      case '0000':
+        await _handleSuccessfulPayment();
+        break;
+      case '1004':
+        await _handleTimeoutPayment(backPhoto, paymentResponse);
+        break;
+      case '1000':
+        await _handleCancelledPayment(backPhoto, paymentResponse);
+        break;
+      default:
+        await _handleUnknownPayment();
+    }
+  }
+
+  /// 성공적인 결제 처리
+  Future<void> _handleSuccessfulPayment() async {
+    final response = await _updateOrder(isRefund: false);
+    ref.read(updateOrderInfoProvider.notifier).update(response);
+    await ref.read(cardCountProvider.notifier).decrease();
+    SlackLogService().sendLogToSlack("paymentResponse0000 : $response");
+  }
+
+  /// 시간 초과 결제 처리
+  Future<void> _handleTimeoutPayment(BackPhotoCardResponse backPhoto, PaymentResponse paymentResponse) async {
+    final response = await _updateOrder(isRefund: false, description: "시간초과");
+    ref.read(updateOrderInfoProvider.notifier).update(response);
+    SlackLogService().sendLogToSlack("paymentResponse1004 : $response");
+
+    SlackLogService().sendPaymentBroadcastLogToSlak(InfoKey.paymentFail.key,
+        paymentDescription:
+            "사유: 시간초과\n- 인증번호: ${backPhoto.photoAuthNumber}\n- 승인번호: ${paymentResponse.approvalNo ?? "없음"}");
+  }
+
+  /// 취소된 결제 처리
+  Future<void> _handleCancelledPayment(BackPhotoCardResponse backPhoto, PaymentResponse paymentResponse) async {
+    final response = await _updateOrder(isRefund: false, description: "고객취소");
+    ref.read(updateOrderInfoProvider.notifier).update(response);
+    SlackLogService().sendLogToSlack("paymentResponse1000 : $response");
+
+    SlackLogService().sendPaymentBroadcastLogToSlak(InfoKey.paymentFail.key,
+        paymentDescription:
+            "사유: 사용자가 결제취소 누름\n- 인증번호: ${backPhoto.photoAuthNumber}\n- 승인번호: ${paymentResponse.approvalNo ?? "없음"}");
+  }
+
+  /// 알 수 없는 결제 상태 처리
+  Future<void> _handleUnknownPayment() async {
+    final response = await _updateOrder(isRefund: false, description: "확인필요");
+    ref.read(updateOrderInfoProvider.notifier).update(response);
+  }
+
+  /// 결제 오류 처리
+  Future<void> _handlePaymentError() async {
+    final response = await _updateOrder(isRefund: false, description: "확인필요");
+    ref.read(updateOrderInfoProvider.notifier).update(response);
   }
 
   Future<void> refund() async {
@@ -117,7 +177,7 @@ class PaymentService extends _$PaymentService {
       final backPhoto = ref.watch(verifyPhotoCardProvider).value;
       final paymentRes = approvalInfo?.res;
       if (approvalInfo?.orderState == OrderStatus.refunded) {
-        final response = await _updateOrder(isRefund: true, description: "자동환불");
+        await _updateOrder(isRefund: true, description: "자동환불");
         SlackLogService().sendPaymentBroadcastLogToSlak(InfoKey.paymentRefund.key,
             paymentDescription:
                 "동작로직: 자동환불\n- 인증번호: ${backPhoto?.photoAuthNumber ?? "없음"}\n- 승인번호: ${approvalInfo?.approvalNo ?? "없음"}");
@@ -126,19 +186,19 @@ class PaymentService extends _$PaymentService {
       } else {
         switch (paymentRes) {
           case '1000':
-            final response = await _updateOrder(isRefund: true, description: "고객취소");
+            await _updateOrder(isRefund: true, description: "고객취소");
             SlackLogService().sendPaymentBroadcastLogToSlak(InfoKey.paymentRefundFail.key,
                 paymentDescription:
                     "동작로직: 자동환불\n- 사유: 사용자가 환불취소 누름\n- 인증번호: ${backPhoto?.photoAuthNumber ?? "없음"}\n- 승인번호: ${approvalInfo?.approvalNo ?? "없음"}");
             break;
           case '1004':
-            final response = await _updateOrder(isRefund: true, description: "시간초과");
+            await _updateOrder(isRefund: true, description: "시간초과");
             SlackLogService().sendPaymentBroadcastLogToSlak(InfoKey.paymentRefundFail.key,
                 paymentDescription:
                     "동작로직: 자동환불\n- 사유: 시간초과\n- 인증번호: ${backPhoto?.photoAuthNumber ?? "없음"}\n- 승인번호: ${approvalInfo?.approvalNo ?? "없음"}");
             break;
           default:
-            final response = await _updateOrder(isRefund: true, description: "확인필요");
+            await _updateOrder(isRefund: true, description: "확인필요");
             SlackLogService().sendPaymentBroadcastLogToSlak(InfoKey.paymentRefundFail.key,
                 paymentDescription:
                     "동작로직: 자동환불\n- 사유: 확인필요\n- 인증번호: ${backPhoto?.photoAuthNumber ?? "없음"}\n- 승인번호: ${approvalInfo?.approvalNo ?? "없음"}");
@@ -180,7 +240,8 @@ class PaymentService extends _$PaymentService {
       final code = ref.read(authCodeProvider);
       final approval = ref.read(paymentResponseStateProvider);
       if (approval?.orderState == OrderStatus.refunded) {
-        final response = await _updateOrder(isRefund: true, orderid: order.orderId, photoAuthNumber: code, description: "환불안내");
+        final response =
+            await _updateOrder(isRefund: true, orderid: order.orderId, photoAuthNumber: code, description: "환불안내");
         SlackLogService().sendLogToSlack('error409 response: $response'); //paymentTestSlack
         SlackLogService().sendPaymentBroadcastLogToSlak(InfoKey.paymentRefund.key,
             paymentDescription: "동작로직: 환불안내\n- 인증번호: $code\n- 승인번호: ${order.authSeqNumber ?? "없음"}");
@@ -191,19 +252,22 @@ class PaymentService extends _$PaymentService {
         final paymentRes = approvalInfo?.res;
         switch (paymentRes) {
           case '1000':
-            final response = await _updateOrder(isRefund: true, orderid: order.orderId, photoAuthNumber: code, description: "고객취소");
+            final response =
+                await _updateOrder(isRefund: true, orderid: order.orderId, photoAuthNumber: code, description: "고객취소");
             SlackLogService().sendPaymentBroadcastLogToSlak(InfoKey.paymentRefundFail.key,
                 paymentDescription:
                     "동작로직: 환불안내\n- 사유: 사용자가 환불취소 누름\n- 인증번호: $code\n- 승인번호: ${approvalInfo?.approvalNo ?? "없음"}");
             break;
           case '1004':
-            final response = await _updateOrder(isRefund: true, orderid: order.orderId, photoAuthNumber: code, description: "시간초과");
+            final response =
+                await _updateOrder(isRefund: true, orderid: order.orderId, photoAuthNumber: code, description: "시간초과");
             SlackLogService().sendPaymentBroadcastLogToSlak(InfoKey.paymentRefundFail.key,
                 paymentDescription:
                     "동작로직: 환불안내\n- 사유: 시간초과\n- 인증번호: $code\n- 승인번호: ${approvalInfo?.approvalNo ?? "없음"}");
             break;
           default:
-            final response = await _updateOrder(isRefund: true, orderid: order.orderId, photoAuthNumber: code, description: "확인필요");
+            final response =
+                await _updateOrder(isRefund: true, orderid: order.orderId, photoAuthNumber: code, description: "확인필요");
             SlackLogService().sendPaymentBroadcastLogToSlak(InfoKey.paymentRefundFail.key,
                 paymentDescription:
                     "동작로직: 환불안내\n- 사유: 확인필요\n- 인증번호: $code\n- 승인번호: ${approvalInfo?.approvalNo ?? "없음"}");


### PR DESCRIPTION
## 📌 작업 개요
- 결제 승인 번호 없을 시 사유 추가
- 결제 로직 리팩토링

## 🔍 변경 사항
- _handlePaymentResult, _handleEmptyApprovalNumber, _handlePaymentResponse 단일 책임 원칙 준수
- paymentResponse.message1, paymentResponse.message2 : 사유 추가

## 🧪 테스트 방법

## 📎 기타 참고 사항
- 

## 🙏 리뷰 요청 포인트
- 