### PR TITLE
Device ID(MAC) 통한 업체 및 이벤트 자동 연동 기능 / WindowManager 설정 안정화

### DIFF
--- a/assets/lang/en-US.json
+++ b/assets/lang/en-US.json
@@ -46,5 +46,6 @@
   "alert_title_auto_refund_alert": "Refund Notice",
   "alert_txt_auto_refund_alert": "The printer is not working properly.\r\nA refund will be processed.",
   "alert_btn_cancel": "Cancel",
-  "alert_btn_ok": "OK"
+  "alert_btn_ok": "OK",
+  "alert_title_empty_event": "Enter the kiosk devic\nnumber to run the event."
 }

--- a/assets/lang/ja-JP.json
+++ b/assets/lang/ja-JP.json
@@ -46,5 +46,6 @@
   "alert_title_auto_refund_alert": "返金のお知らせ",
   "alert_txt_auto_refund_alert": "プリンターが正常に動作しないため\r\n返金を進めます。",
   "alert_btn_cancel": "キャンセル",
-  "alert_btn_ok": "確認"
+  "alert_btn_ok": "確認",
+  "alert_title_empty_event": "イベントを実行するには、\nキオスクの機器番号を入力してください。"
 }

--- a/assets/lang/ko-KR.json
+++ b/assets/lang/ko-KR.json
@@ -47,5 +47,5 @@
   "alert_txt_auto_refund_alert": "프린터가 정상 작동하지 않아\r\n환불을 진행합니다.",
   "alert_btn_cancel": "취소",
   "alert_btn_ok": "확인",
-  "alert_title_empty_event": "이벤트를 실행하려면 \n키오스크 기기번호를 입력해 주세요."
+  "alert_title_empty_event": "이벤트를 실행하려면\n키오스크 기기번호를 입력해 주세요."
 }

--- a/assets/lang/ko-KR.json
+++ b/assets/lang/ko-KR.json
@@ -46,5 +46,6 @@
   "alert_title_auto_refund_alert": "환불 안내",
   "alert_txt_auto_refund_alert": "프린터가 정상 작동하지 않아\r\n환불을 진행합니다.",
   "alert_btn_cancel": "취소",
-  "alert_btn_ok": "확인"
+  "alert_btn_ok": "확인",
+  "alert_title_empty_event": "이벤트를 실행하려면 \n키오스크 기기번호를 입력해 주세요."
 }

--- a/assets/lang/zh-CN.json
+++ b/assets/lang/zh-CN.json
@@ -45,5 +45,6 @@
   "alert_title_auto_refund_alert": "退款信息",
   "alert_txt_auto_refund_alert": "由于打印机无法正常工作，\\r\\n将进行退款。",
   "alert_btn_cancel": "返回",
-  "alert_btn_ok": "确定"
+  "alert_btn_ok": "确定",
+  "alert_title_empty_event": "请输入设备编号以运行事件。"
 }

--- a/lib/app.dart
+++ b/lib/app.dart
@@ -1,15 +1,50 @@
+import 'dart:io';
 import 'dart:ui';
 
 import 'package:easy_localization/easy_localization.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_snaptag_kiosk/lib.dart';
+import 'package:window_manager/window_manager.dart';
 
-class App extends ConsumerWidget {
+class App extends ConsumerStatefulWidget {
   const App({super.key});
 
   @override
-  Widget build(BuildContext context, WidgetRef ref) {
+  ConsumerState<App> createState() => _AppState();
+}
+
+class _AppState extends ConsumerState<App> with WindowListener {
+
+  @override
+  void initState() {
+    super.initState();
+    if (Platform.isWindows) {
+      windowManager.addListener(this);
+      _initializeWindow();
+    }
+  }
+
+  @override
+  void dispose() {
+    if (Platform.isWindows) {
+      windowManager.removeListener(this);
+    }
+    super.dispose();
+  }
+
+  Future<void> _initializeWindow() async {
+    await windowManager.setFullScreen(true);
+  }
+
+  @override
+  void onWindowFocus() {
+    // 포커스를 받을 때마다 fullscreen 보장
+    windowManager.setFullScreen(true);
+  }
+  
+  @override
+  Widget build(BuildContext context) {
     final router = ref.watch(routerProvider);
     final theme = ref.watch(themeNotifierProvider);
     return theme.when(

--- a/lib/data/datasources/cache/kiosk_info_service.dart
+++ b/lib/data/datasources/cache/kiosk_info_service.dart
@@ -57,6 +57,7 @@ class KioskInfoService extends _$KioskInfoService {
 
       return response;
     } catch (e) {
+      _getInfoByKey = false;
       _isLoading = false;
       return null;
     }

--- a/lib/data/datasources/cache/kiosk_info_service.dart
+++ b/lib/data/datasources/cache/kiosk_info_service.dart
@@ -9,7 +9,7 @@ class KioskInfoService extends _$KioskInfoService {
   Timer? _periodicTimer;
   int? _cachedMachineId;
   int? _cachedKioskEventId;
-  bool _getInfoByKey = false;
+  bool _getInfoByKey = true;
   bool _isLoading = false;
 
   bool get getInfoByKey => _getInfoByKey;

--- a/lib/data/datasources/cache/kiosk_info_service.dart
+++ b/lib/data/datasources/cache/kiosk_info_service.dart
@@ -26,7 +26,7 @@ class KioskInfoService extends _$KioskInfoService {
   Future<KioskMachineInfo?> getKioskMachineInfo() async {
     try {
       final kioskRepo = ref.read(kioskRepositoryProvider);
-      final deviceUUID = await ref.watch(deviceUuidProvider.future);
+      final deviceUUID = await ref.read(deviceUuidProvider.future);
       final response = await kioskRepo.getKioskMachineInfoByKey(deviceUUID);
 
       state = response;
@@ -39,8 +39,6 @@ class KioskInfoService extends _$KioskInfoService {
 
       // 응답을 받은 후 10분마다 실행되는 타이머 시작
       await _startPeriodicTimer();
-
-      _getInfoByKey = true;
 
       return response;
     } catch (e) {

--- a/lib/data/datasources/remote/kiosk_api_client.dart
+++ b/lib/data/datasources/remote/kiosk_api_client.dart
@@ -23,6 +23,11 @@ abstract class KioskApiClient {
     @Query('kioskEventId') required int kioskEventId,
   });
 
+  @GET('/v1/machine/info/by-key')
+  Future<KioskMachineInfo> getKioskMachineInfoByKey({
+    @Query('uniqueKey') required String uniqueKey,
+  });
+
   @GET('/v1/kiosk-event/back-photo')
   Future<BackPhotoCardResponse> getBackPhotoCard({
     @Query('kioskEventId') required int kioskEventId,
@@ -88,4 +93,9 @@ abstract class KioskApiClient {
       {@Path('kioskEventId') required int kioskEventId,
       @Path('machineId') required int machineId,
       @Query('remainingSingleSidedCount') required String remainingSingleSidedCount});
+
+  @POST('/v1/machine/unique-key/history')
+  Future<void> createUniqueKeyHistory({
+    @Body() required Map<String, dynamic> body,
+  });
 }

--- a/lib/data/models/request/unique_key_request.dart
+++ b/lib/data/models/request/unique_key_request.dart
@@ -1,0 +1,14 @@
+import 'package:freezed_annotation/freezed_annotation.dart';
+
+part 'unique_key_request.freezed.dart';
+part 'unique_key_request.g.dart';
+
+@freezed
+class UniqueKeyRequest with _$UniqueKeyRequest {
+  const factory UniqueKeyRequest({
+    required String kioskMachineId,
+    required String uniqueKey,
+  }) = _UniqueKeyRequest;
+
+  factory UniqueKeyRequest.fromJson(Map<String, dynamic> json) => _$UniqueKeyRequestFromJson(json);
+}

--- a/lib/data/models/response/event_video.dart
+++ b/lib/data/models/response/event_video.dart
@@ -1,0 +1,15 @@
+import 'package:freezed_annotation/freezed_annotation.dart';
+
+part 'event_video.freezed.dart';
+part 'event_video.g.dart';
+
+@freezed
+class EventVideo with _$EventVideo {
+  const factory EventVideo({
+    required int id,
+    required String videoUrl,
+    required String created,
+  }) = _EventVideo;
+
+  factory EventVideo.fromJson(Map<String, dynamic> json) => _$EventVideoFromJson(json);
+}

--- a/lib/data/models/response/kiosk_machine_info.dart
+++ b/lib/data/models/response/kiosk_machine_info.dart
@@ -1,5 +1,7 @@
 import 'package:freezed_annotation/freezed_annotation.dart';
 
+import 'event_video.dart';
+
 part 'kiosk_machine_info.freezed.dart';
 part 'kiosk_machine_info.g.dart';
 
@@ -11,6 +13,7 @@ class KioskMachineInfo with _$KioskMachineInfo {
     @Default('') String kioskMachineName,
     @Default('') String kioskMachineDescription,
     @Default(0) int photoCardPrice,
+    @Default('') String cardMetalType,
     @Default('') String eventType,
     @Default('') String printedEventName,
     @Default('') String topBannerUrl,
@@ -22,6 +25,7 @@ class KioskMachineInfo with _$KioskMachineInfo {
     @Default('#000000') String mainTextColor,
     @Default('#000000') String popupButtonColor,
     @Default(false) bool isMetal,
+    @Default([]) List<EventVideo> eventVideos,
   }) = _KioskMachineInfo;
 
   factory KioskMachineInfo.fromJson(Map<String, dynamic> json) => _$KioskMachineInfoFromJson(json);

--- a/lib/data/models/response/models.dart
+++ b/lib/data/models/response/models.dart
@@ -1,4 +1,5 @@
 export 'back_photo_card_response.dart';
+export 'event_video.dart';
 export 'kiosk_machine_info.dart';
 export 'nominated_photo.dart';
 export 'nominated_photo_list.dart';

--- a/lib/data/repositories/kiosk_repository.dart
+++ b/lib/data/repositories/kiosk_repository.dart
@@ -1,8 +1,6 @@
-import 'package:flutter_snaptag_kiosk/data/datasources/remote/remote.dart';
-import 'package:flutter_snaptag_kiosk/data/models/models.dart';
+import 'package:flutter_snaptag_kiosk/data/models/request/unique_key_request.dart';
 import 'package:flutter_snaptag_kiosk/data/models/request/update_back_photo_request.dart';
 import 'package:flutter_snaptag_kiosk/features/core/printer/printer_log.dart';
-import 'package:flutter_snaptag_kiosk/flavors.dart';
 import 'package:flutter_snaptag_kiosk/lib.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
@@ -45,6 +43,14 @@ class _KioskRepository {
   Future<KioskMachineInfo> getKioskMachineInfo(int machineId) async {
     try {
       return await _apiClient.getKioskMachineInfo(kioskMachineId: machineId);
+    } catch (e) {
+      rethrow;
+    }
+  }
+
+  Future<KioskMachineInfo> getKioskMachineInfoByKey(String uniqueKey) async {
+    try {
+      return await _apiClient.getKioskMachineInfoByKey(uniqueKey: uniqueKey);
     } catch (e) {
       rethrow;
     }
@@ -188,6 +194,14 @@ class _KioskRepository {
     try {
       await _apiClient.checkKioskAlive(
           kioskEventId: kioskEventId, machineId: machineId, remainingSingleSidedCount: remainingSingleSidedCount);
+    } catch (e) {
+      rethrow;
+    }
+  }
+
+  Future<void> createUniqueKeyHistory({required UniqueKeyRequest request}) async {
+    try {
+      await _apiClient.createUniqueKeyHistory(body: request.toJson());
     } catch (e) {
       rethrow;
     }

--- a/lib/features/move_me/providers/uuid_provider.dart
+++ b/lib/features/move_me/providers/uuid_provider.dart
@@ -1,7 +1,6 @@
 import "package:flutter_riverpod/flutter_riverpod.dart";
 import "package:flutter_snaptag_kiosk/core/utils/uuid/mac_util.dart";
 import "package:flutter_snaptag_kiosk/core/utils/uuid/crypto_util.dart";
-import "dart:convert";
 
 final macAddressProvider = FutureProvider<String>((ref) async {
   return await getWindowsMacAddress();

--- a/lib/features/move_me/screens/setup_main_screen.dart
+++ b/lib/features/move_me/screens/setup_main_screen.dart
@@ -82,9 +82,13 @@ class _SetupMainScreenState extends ConsumerState<SetupMainScreen> {
 
     final kioskInfo = ref.read(kioskInfoServiceProvider);
 
-    print('kioskInfo: $kioskInfo kioskEventId: ${kioskInfo?.kioskEventId} kioskMachineId: ${kioskInfo?.kioskMachineId}');
+    print(
+        'kioskInfo: $kioskInfo kioskEventId: ${kioskInfo?.kioskEventId} kioskMachineId: ${kioskInfo?.kioskMachineId}');
     if (kioskInfo == null) {
-      if (kioskInfo?.kioskEventId == 0 || kioskInfo?.kioskEventId == null || kioskInfo?.kioskMachineId == 0 || kioskInfo?.kioskMachineId == null) {
+      if (kioskInfo?.kioskEventId == 0 ||
+          kioskInfo?.kioskEventId == null ||
+          kioskInfo?.kioskMachineId == 0 ||
+          kioskInfo?.kioskMachineId == null) {
         await DialogHelper.showSetupDialog(
           context,
           title: LocaleKeys.alert_title_empty_event.tr(),
@@ -108,11 +112,17 @@ class _SetupMainScreenState extends ConsumerState<SetupMainScreen> {
     final connected = await ref.read(printerServiceProvider.notifier).checkConnectedPrint();
     final settingPrinter = ref.read(printerServiceProvider.notifier).settingPrinter();
     if (!connected) {
-      await DialogHelper.showPrintWaitingDialog(context);
+      await DialogHelper.showSetupDialog(
+        context,
+        title: '프린트가 준비중입니다.',
+      );
       return false;
     }
     if (!settingPrinter) {
-      await DialogHelper.showCheckPrintStateDialog(context);
+      await DialogHelper.showSetupDialog(
+        context,
+        title: '프린트 기기 상태를 확인해주세요.',
+      );
       return false;
     }
     return true;

--- a/lib/features/move_me/screens/setup_main_screen.dart
+++ b/lib/features/move_me/screens/setup_main_screen.dart
@@ -1,6 +1,7 @@
 import 'dart:async';
 import 'dart:io';
 
+import 'package:easy_localization/easy_localization.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_screenutil/flutter_screenutil.dart';
@@ -81,11 +82,12 @@ class _SetupMainScreenState extends ConsumerState<SetupMainScreen> {
 
     final kioskInfo = ref.read(kioskInfoServiceProvider);
 
+    print('kioskInfo: $kioskInfo kioskEventId: ${kioskInfo?.kioskEventId} kioskMachineId: ${kioskInfo?.kioskMachineId}');
     if (kioskInfo == null) {
-      if (kioskInfo?.kioskEventId == 0 || kioskInfo?.kioskMachineId == 0) {
+      if (kioskInfo?.kioskEventId == 0 || kioskInfo?.kioskEventId == null || kioskInfo?.kioskMachineId == 0 || kioskInfo?.kioskMachineId == null) {
         await DialogHelper.showSetupDialog(
           context,
-          title: LocaleKeys.alert_title_empty_event,
+          title: LocaleKeys.alert_title_empty_event.tr(),
         );
         return;
       }

--- a/lib/features/move_me/screens/setup_main_screen.dart
+++ b/lib/features/move_me/screens/setup_main_screen.dart
@@ -85,7 +85,7 @@ class _SetupMainScreenState extends ConsumerState<SetupMainScreen> {
       if (kioskInfo?.kioskEventId == 0 || kioskInfo?.kioskMachineId == 0) {
         await DialogHelper.showSetupDialog(
           context,
-          title: '이벤트를 실행하려면 \n키오스크 기기번호를 입력해 주세요.',
+          title: LocaleKeys.alert_title_empty_event,
         );
         return;
       }

--- a/lib/features/move_me/screens/setup_main_screen.dart
+++ b/lib/features/move_me/screens/setup_main_screen.dart
@@ -85,7 +85,7 @@ class _SetupMainScreenState extends ConsumerState<SetupMainScreen> {
       if (kioskInfo?.kioskEventId == 0 || kioskInfo?.kioskMachineId == 0) {
         await DialogHelper.showSetupDialog(
           context,
-          title: '이벤트를 선택해주세요.',
+          title: '이벤트를 실행하려면 \n키오스크 기기번호를 입력해 주세요.',
         );
         return;
       }
@@ -151,6 +151,7 @@ class _SetupMainScreenState extends ConsumerState<SetupMainScreen> {
     final kioskEventId = ref.read(kioskInfoServiceProvider)?.kioskEventId ?? 0;
     final cardCountState = ref.read(cardCountProvider);
     final deviceUUID = await ref.read(deviceUuidProvider.future);
+    final getInfoByKey = ref.read(kioskInfoServiceProvider.notifier).getInfoByKey;
 
     await ref.read(printerServiceProvider.notifier).startPrintLog();
 
@@ -160,12 +161,14 @@ class _SetupMainScreenState extends ConsumerState<SetupMainScreen> {
           remainingSingleSidedCount: cardCountState.remainingSingleSidedCount,
         );
 
-    await ref.read(kioskRepositoryProvider).createUniqueKeyHistory(
-          request: UniqueKeyRequest(
-            kioskMachineId: machineId.toString(),
-            uniqueKey: deviceUUID,
-          ),
-        );
+    if (!getInfoByKey) {
+      await ref.read(kioskRepositoryProvider).createUniqueKeyHistory(
+            request: UniqueKeyRequest(
+              kioskMachineId: machineId.toString(),
+              uniqueKey: deviceUUID,
+            ),
+          );
+    }
 
     SlackLogService()
         .sendLogToSlack('machineId:$machineId, currentVersion:$currentVersion, latestVersion:$latestVersion');

--- a/lib/features/move_me/screens/setup_main_screen.dart
+++ b/lib/features/move_me/screens/setup_main_screen.dart
@@ -32,7 +32,6 @@ class _SetupMainScreenState extends ConsumerState<SetupMainScreen> {
       final kioskInfo = await ref.read(kioskInfoServiceProvider.notifier).getKioskMachineInfo();
       if (kioskInfo == null) {
         SlackLogService().sendErrorLogToSlack('Kiosk info not found');
-        return;
       }
     });
 

--- a/lib/features/move_me/screens/setup_main_screen.dart
+++ b/lib/features/move_me/screens/setup_main_screen.dart
@@ -208,14 +208,14 @@ class _SetupMainScreenState extends ConsumerState<SetupMainScreen> {
   @override
   Widget build(BuildContext context) {
     ref.read(alertDefinitionProvider);
-    final machineId = ref.read(kioskInfoServiceProvider)?.kioskMachineId ?? 0;
+    final machineId = ref.watch(kioskInfoServiceProvider)?.kioskMachineId ?? 0;
     final versionState = ref.watch(versionStateProvider);
     final cardCountState = ref.watch(cardCountProvider);
     final currentVersion = versionState.currentVersion;
     final latestVersion = versionState.latestVersion;
     final isUpdateAvailable = currentVersion != latestVersion;
     final isConnectedPrinter = ref.watch(printerConnectProvider) == PrinterConnectState.connected;
-    final getInfoByKey = ref.read(kioskInfoServiceProvider.notifier).getInfoByKey;
+    final getInfoByKey = ref.watch(kioskInfoServiceProvider.notifier).getInfoByKey;
     //final isUpdateAvailable = false;
 
     return Theme(

--- a/lib/features/move_me/screens/setup_main_screen.dart
+++ b/lib/features/move_me/screens/setup_main_screen.dart
@@ -278,7 +278,7 @@ class _SetupMainScreenState extends ConsumerState<SetupMainScreen> {
               SizedBox(height: 50.h),
               Center(
                 child: Text(
-                  '*인쇄 모드를 선택 후 미리보기를 해주세요.',
+                  getInfoByKey ? '*인쇄 모드를 선택 후 이벤트를 실행 해주세요.' : '*인쇄 모드를 선택 후 미리보기를 해주세요.',
                   style: context.typography.kioskBody1B.copyWith(color: Colors.red),
                 ),
               ),

--- a/lib/features/move_me/screens/setup_main_screen.dart
+++ b/lib/features/move_me/screens/setup_main_screen.dart
@@ -89,7 +89,7 @@ class _SetupMainScreenState extends ConsumerState<SetupMainScreen> {
           kioskInfo?.kioskEventId == null ||
           kioskInfo?.kioskMachineId == 0 ||
           kioskInfo?.kioskMachineId == null) {
-        await DialogHelper.showSetupDialog(
+        await DialogHelper.showSetupOneButtonDialog(
           context,
           title: LocaleKeys.alert_title_empty_event.tr(),
         );
@@ -112,14 +112,14 @@ class _SetupMainScreenState extends ConsumerState<SetupMainScreen> {
     final connected = await ref.read(printerServiceProvider.notifier).checkConnectedPrint();
     final settingPrinter = ref.read(printerServiceProvider.notifier).settingPrinter();
     if (!connected) {
-      await DialogHelper.showSetupDialog(
+      await DialogHelper.showSetupOneButtonDialog(
         context,
         title: '프린트가 준비중입니다.',
       );
       return false;
     }
     if (!settingPrinter) {
-      await DialogHelper.showSetupDialog(
+      await DialogHelper.showSetupOneButtonDialog(
         context,
         title: '프린트 기기 상태를 확인해주세요.',
       );

--- a/lib/features/move_me/widgets/dialog_helper.dart
+++ b/lib/features/move_me/widgets/dialog_helper.dart
@@ -97,6 +97,67 @@ class DialogHelper {
     );
   }
 
+  static Future<bool> showSetupOneButtonDialog(
+    BuildContext context, {
+    required String title,
+    String confirmButtonText = '확인',
+  }) async {
+    return await showDialog(
+      context: context,
+      barrierDismissible: false,
+      builder: (BuildContext context) {
+        return DefaultTextStyle(
+          style: TextStyle(
+            fontFamily: context.locale.languageCode == 'ja' ? 'MPLUSRounded' : 'Cafe24Ssurround2',
+          ),
+          child: AlertDialog(
+            backgroundColor: Colors.white,
+            insetPadding: EdgeInsets.symmetric(horizontal: 100.w),
+            shape: RoundedRectangleBorder(
+              borderRadius: BorderRadius.circular(20.r),
+            ),
+            titlePadding: EdgeInsets.zero,
+            actionsPadding: EdgeInsets.zero,
+            title: Center(
+              child: Padding(
+                padding: EdgeInsets.only(top: 60.h, bottom: 36.h),
+                child: Text(
+                  title,
+                  textAlign: TextAlign.center,
+                  style: context.typography.kioskAlert1B.copyWith(
+                    fontFamily: 'Pretendard',
+                    color: Colors.black,
+                  ),
+                ),
+              ),
+            ),
+            actions: [
+              Padding(
+                padding: EdgeInsets.only(bottom: 40.h, left: 40.w, right: 40.w),
+                child: Row(
+                  children: [
+                    Expanded(
+                      child: ElevatedButton(
+                        onPressed: () async {
+                          await SoundManager().playSound();
+                          Navigator.of(context).pop(true);
+                        },
+                        style: context.setupDialogConfirmButtonStyle,
+                        child: Text(
+                          confirmButtonText,
+                        ),
+                      ),
+                    ),
+                  ],
+                ),
+              )
+            ],
+          ),
+        );
+      },
+    );
+  }
+
   static Future<bool> showSetupDialog(
     BuildContext context, {
     required String title,

--- a/lib/features/move_me/widgets/dialog_helper.dart
+++ b/lib/features/move_me/widgets/dialog_helper.dart
@@ -117,6 +117,11 @@ class DialogHelper {
             shape: RoundedRectangleBorder(
               borderRadius: BorderRadius.circular(20.r),
             ),
+            contentPadding: EdgeInsets.only(
+              left: 40.w,
+              right: 40.w,
+            ),
+            titlePadding: EdgeInsets.only(top: 60.h, bottom: 36.h),
             title: Center(
               child: Text(
                 title,

--- a/lib/features/move_me/widgets/dialog_helper.dart
+++ b/lib/features/move_me/widgets/dialog_helper.dart
@@ -117,50 +117,53 @@ class DialogHelper {
             shape: RoundedRectangleBorder(
               borderRadius: BorderRadius.circular(20.r),
             ),
-            contentPadding: EdgeInsets.only(
-              left: 40.w,
-              right: 40.w,
-            ),
-            titlePadding: EdgeInsets.only(top: 60.h, bottom: 36.h),
+            titlePadding: EdgeInsets.zero,
+            actionsPadding: EdgeInsets.zero,
             title: Center(
-              child: Text(
-                title,
-                textAlign: TextAlign.center,
-                style: context.typography.kioskAlert1B.copyWith(
-                  fontFamily: 'Pretendard',
-                  color: Colors.black,
+              child: Padding(
+                padding: EdgeInsets.only(top: 60.h, bottom: 36.h),
+                child: Text(
+                  title,
+                  textAlign: TextAlign.center,
+                  style: context.typography.kioskAlert1B.copyWith(
+                    fontFamily: 'Pretendard',
+                    color: Colors.black,
+                  ),
                 ),
               ),
             ),
             actions: [
-              Row(
-                children: [
-                  Expanded(
-                    child: OutlinedButton(
-                      onPressed: () async {
-                        await SoundManager().playSound();
-                        Navigator.of(context).pop(false);
-                      },
-                      style: context.setupDialogCancelButtonStyle,
-                      child: Text(
-                        cancelButtonText,
+              Padding(
+                padding: EdgeInsets.only(bottom: 40.h, left: 40.w, right: 40.w),
+                child: Row(
+                  children: [
+                    Expanded(
+                      child: OutlinedButton(
+                        onPressed: () async {
+                          await SoundManager().playSound();
+                          Navigator.of(context).pop(false);
+                        },
+                        style: context.setupDialogCancelButtonStyle,
+                        child: Text(
+                          cancelButtonText,
+                        ),
                       ),
                     ),
-                  ),
-                  SizedBox(width: 12.w),
-                  Expanded(
-                    child: ElevatedButton(
-                      onPressed: () async {
-                        await SoundManager().playSound();
-                        Navigator.of(context).pop(true);
-                      },
-                      style: context.setupDialogConfirmButtonStyle,
-                      child: Text(
-                        confirmButtonText,
+                    SizedBox(width: 12.w),
+                    Expanded(
+                      child: ElevatedButton(
+                        onPressed: () async {
+                          await SoundManager().playSound();
+                          Navigator.of(context).pop(true);
+                        },
+                        style: context.setupDialogConfirmButtonStyle,
+                        child: Text(
+                          confirmButtonText,
+                        ),
                       ),
                     ),
-                  ),
-                ],
+                  ],
+                ),
               )
             ],
           ),

--- a/lib/features/move_me/widgets/dialog_helper.dart
+++ b/lib/features/move_me/widgets/dialog_helper.dart
@@ -120,6 +120,7 @@ class DialogHelper {
             title: Center(
               child: Text(
                 title,
+                textAlign: TextAlign.center,
                 style: context.typography.kioskAlert1B.copyWith(
                   fontFamily: 'Pretendard',
                   color: Colors.black,
@@ -474,6 +475,15 @@ class DialogHelper {
       title: LocaleKeys.alert_title_authNum_reissue_complete.tr(),
       message: LocaleKeys.alert_txt_authNum_reissue_complete.tr(),
       buttonText: LocaleKeys.alert_btn_authNum_reissue_complete.tr(),
+    );
+  }
+
+  static Future<void> showEmptyEventDialog(BuildContext context) async {
+    await _showOneButtonKioskDialog(
+      context,
+      title: LocaleKeys.alert_title_empty_event.tr(),
+      message: "",
+      buttonText: LocaleKeys.alert_btn_ok.tr(),
     );
   }
 

--- a/lib/locale_keys.dart
+++ b/lib/locale_keys.dart
@@ -48,6 +48,7 @@ abstract class LocaleKeys {
   static const alert_txt_refund_info = 'alert_txt_refund_info';
   static const alert_btn_cancel = 'alert_btn_cancel';
   static const alert_btn_ok = 'alert_btn_ok';
+  static const alert_title_empty_event = 'Enter the kiosk devic\nnumber to run the event.';
 
   static const alert_title_auto_refund_alert = 'alert_title_auto_refund_alert';
   static const alert_txt_auto_refund_alert = 'alert_txt_auto_refund_alert';

--- a/lib/locale_keys.dart
+++ b/lib/locale_keys.dart
@@ -48,7 +48,7 @@ abstract class LocaleKeys {
   static const alert_txt_refund_info = 'alert_txt_refund_info';
   static const alert_btn_cancel = 'alert_btn_cancel';
   static const alert_btn_ok = 'alert_btn_ok';
-  static const alert_title_empty_event = 'Enter the kiosk devic\nnumber to run the event.';
+  static const alert_title_empty_event = 'alert_title_empty_event';
 
   static const alert_title_auto_refund_alert = 'alert_title_auto_refund_alert';
   static const alert_txt_auto_refund_alert = 'alert_txt_auto_refund_alert';

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -70,23 +70,6 @@ void main() async {
   );
 }
 
-void windowManagerSetting() {
-  //platform이 windows인 경우에만 실행
-  if (Platform.isWindows) {
-    WindowOptions windowOptions = WindowOptions(
-      fullScreen: true,
-      backgroundColor: Colors.transparent,
-      skipTaskbar: false,
-      titleBarStyle: TitleBarStyle.hidden,
-    );
-    windowManager.waitUntilReadyToShow(windowOptions, () async {
-      windowManager.setFullScreen(true);
-      await windowManager.show();
-      await windowManager.focus();
-    });
-  }
-}
-
 // 🚨 SSL 인증서 오류(HandshakeException) 해결을 위한 설정
 // ➤ 신뢰할 수 없는 인증서로 인해 발생하는 HandshakeException을 방지하기 위해 인증서 검증을 무시하는 작업
 // ➤ Windows IOT 버전에서 발생한 오류

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -24,7 +24,12 @@ void main() async {
   runZonedGuarded(
     () async {
       WidgetsFlutterBinding.ensureInitialized();
-      await windowManagerSetting();
+      
+      // WindowManager 초기화만 수행 (설정은 App에서)
+      if (Platform.isWindows) {
+        await windowManager.ensureInitialized();
+      }
+      
       // ✅ FlutterError 로그 자동 감지
       FlutterError.onError = (FlutterErrorDetails details) {
         slackCall.sendLogToSlack("[FLUTTER ERROR] ${details.exceptionAsString()}");
@@ -65,10 +70,9 @@ void main() async {
   );
 }
 
-Future<void> windowManagerSetting() async {
+void windowManagerSetting() {
   //platform이 windows인 경우에만 실행
   if (Platform.isWindows) {
-    await windowManager.ensureInitialized();
     WindowOptions windowOptions = WindowOptions(
       fullScreen: true,
       backgroundColor: Colors.transparent,
@@ -76,7 +80,7 @@ Future<void> windowManagerSetting() async {
       titleBarStyle: TitleBarStyle.hidden,
     );
     windowManager.waitUntilReadyToShow(windowOptions, () async {
-      await windowManager.setFullScreen(true);
+      windowManager.setFullScreen(true);
       await windowManager.show();
       await windowManager.focus();
     });


### PR DESCRIPTION
## 📌 작업 개요
- 업체 및 이벤트 자동 연동 기능을 위한 기능 추가
- DeviceID (=MAC 주소)를 기반으로 기기 등록 및 이벤트 연동
- **SetupMainScreen 의 appPostFrameCallBack 과 windowManagerSetting 함수의 타이밍 경쟁 이슈 발생**

## 🔍 변경 사항
- /v1/machine/info/by-key 추가 (키오스크 정보 불러오는 API)
- _getInfoByKey 상태 추가 -> DeviceID 기반으로 데이터를 불러왔는지 체크
- 셋업 화면에서 getKioskMachineInfo 호출
- main 함수에서 windowManager 설정 제거
- App 컴포넌트 ConsumerStatefulWidget 으로 변경 및 WindowListener 상속
- initState 후 setFullScreen 설정 적용

## 🧪 테스트 방법

## 📎 기타 참고 사항

## 🙏 리뷰 요청 포인트