### PR TITLE
bugfix: 프린트 후 앱 종료 버그 수정

### DIFF
--- a/lib/app.dart
+++ b/lib/app.dart
@@ -15,13 +15,13 @@ class App extends ConsumerStatefulWidget {
 }
 
 class _AppState extends ConsumerState<App> with WindowListener {
-
+  bool _initializedFullScreen = false;
   @override
   void initState() {
     super.initState();
     if (Platform.isWindows) {
       windowManager.addListener(this);
-      _initializeWindow();
+      _ensureFullScreenOnce();
     }
   }
 
@@ -33,16 +33,21 @@ class _AppState extends ConsumerState<App> with WindowListener {
     super.dispose();
   }
 
-  Future<void> _initializeWindow() async {
-    await windowManager.setFullScreen(true);
+  Future<void> _ensureFullScreenOnce() async {
+    if (_initializedFullScreen) return;
+    _initializedFullScreen = true;
+
+    if (Platform.isWindows) {
+      await windowManager.setFullScreen(true);
+    }
   }
 
   @override
   void onWindowFocus() {
     // 포커스를 받을 때마다 fullscreen 보장
-    windowManager.setFullScreen(true);
+    // windowManager.setFullScreen(true);
   }
-  
+
   @override
   Widget build(BuildContext context) {
     final router = ref.watch(routerProvider);

--- a/lib/features/core/printer/card_printer.dart
+++ b/lib/features/core/printer/card_printer.dart
@@ -201,7 +201,7 @@ class PrinterService extends _$PrinterService {
       _bindings.ejectCard();
 
       // ❗️ 주석 처리된 부분은 나중에 필요할 때 활성화
-      startPrintLog();
+      await startPrintLog();
     } catch (e, stack) {
       logger.i('Print error: $e\nStack: $stack');
       rethrow;


### PR DESCRIPTION
## 📌 작업 개요
- 프린트 후 앱 종료 현상 발생 (버그)  
- 작업 관리자에서 프로세스 종료 해야만 사라짐
- 원인 : ConsumerState의 initState 에서 윈도우 전체 화면 설정과 프린팅 I/O 작업 과의 충돌 

## 🔍 변경 사항
- app.dart 에서 initState 로직 최초 한번만 실행 하도록 변경

## 🧪 테스트 방법

## 📎 기타 참고 사항

## 🙏 리뷰 요청 포인트