### PR TITLE
버전 정보 관리 일원화 

### DIFF
--- a/lib/core/utils/version_util.dart
+++ b/lib/core/utils/version_util.dart
@@ -20,7 +20,7 @@ class VersionUtil {
       return _cachedVersion!;
     } catch (e) {
       // 오류 발생 시 기본값 반환
-      return 'v3.3.0';
+      return 'v0.0.0';
     }
   }
 
@@ -36,4 +36,3 @@ class VersionUtil {
     _packageInfo = null;
   }
 }
-

--- a/lib/data/repositories/version_repository.dart
+++ b/lib/data/repositories/version_repository.dart
@@ -38,16 +38,7 @@ class VersionRepository {
       return version.startsWith('v') ? version : 'v$version';
     } catch (e) {
       // 오류 발생 시 .env.version 파일에서 읽기 시도
-      try {
-        final envFile = File('assets/.env.version');
-        if (await envFile.exists()) {
-          final version = await envFile.readAsString();
-          return version.trim().isNotEmpty ? version.trim() : 'v3.3.0';
-        }
-      } catch (_) {
-        // 파일 읽기 실패 시 기본값 반환
-      }
-      return 'v3.3.0';
+      return 'v0.0.0';
     }
   }
 

--- a/lib/features/move_me/screens/setup_main_screen.dart
+++ b/lib/features/move_me/screens/setup_main_screen.dart
@@ -531,8 +531,7 @@ class _SetupMainScreenState extends ConsumerState<SetupMainScreen> {
                       height: 314.h,
                       child: SetupUpdateCard(
                         title: '현재 버전',
-                        //version: currentVersion,
-                        version: "v3.3.0",
+                        version: currentVersion,
                         buttonName: '업데이트',
                         isActive: isUpdateAvailable,
                         onUpdatePressed: () async {

--- a/lib/features/presentation/screens/print_process_screen.dart
+++ b/lib/features/presentation/screens/print_process_screen.dart
@@ -2,6 +2,7 @@ import 'package:easy_localization/easy_localization.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_screenutil/flutter_screenutil.dart';
+import 'package:flutter_snaptag_kiosk/core/providers/version_notifier.dart';
 import 'package:flutter_snaptag_kiosk/lib.dart';
 
 import 'dart:io';
@@ -17,7 +18,7 @@ class PrintProcessScreen extends ConsumerStatefulWidget {
 class _PrintProcessScreenState extends ConsumerState<PrintProcessScreen> {
   @override
   Widget build(BuildContext context) {
-    final randomAdImage = getRandomAdImageFilePath();
+    final randomAdImage = getRandomAdImageFilePath(ref);
     /**
         final printProcess = ref.watch(printProcessScreenProviderProvider);
         if (printProcess.isLoading) {
@@ -197,33 +198,18 @@ class _PrintProcessScreenState extends ConsumerState<PrintProcessScreen> {
     }
   }
 
-  /// .env.version 파일에서 버전 문자열을 동기적으로 읽어옵니다.
-  String? getAppVersionSync() {
-    try {
-      final file = File('assets/.env.version');
-      if (!file.existsSync()) {
-        print('❌ .env.version 파일이 존재하지 않습니다.');
-        return null;
-      }
-      return file.readAsStringSync().trim();
-    } catch (e) {
-      print('❌ .env.version 파일 읽기 오류: $e');
-      return null;
-    }
-  }
-
   /// 사용자 홈 디렉토리를 동기적으로 반환합니다.
   String? getUserDirectorySync() {
     return Platform.environment['USERPROFILE']; // Windows 전용
   }
 
   /// 최종: 랜덤 이미지 파일 경로 반환
-  String? getRandomAdImagePath() {
-    final version = getAppVersionSync();
+  String? getRandomAdImagePath(WidgetRef ref) {
+    final version = ref.read(versionStateProvider).currentVersion;
     final userDir = getUserDirectorySync();
 
-    if (version == null || userDir == null) {
-      print('❌ 사용자 디렉토리 또는 버전을 불러올 수 없습니다.');
+    if (userDir == null) {
+      print('❌ 사용자 디렉토리를 불러올 수 없습니다.');
       return null;
     }
 
@@ -253,12 +239,12 @@ class _PrintProcessScreenState extends ConsumerState<PrintProcessScreen> {
     return 'assets/adImages/$fileName';
   }
 
-  String? getRandomAdImageFilePath() {
-    final version = getAppVersionSync();
+  String? getRandomAdImageFilePath(WidgetRef ref) {
+    final version = ref.read(versionStateProvider).currentVersion;
     final userDir = getUserDirectorySync();
     final machineId = ref.read(kioskInfoServiceProvider)?.kioskMachineId ?? 0;
-    if (version == null || userDir == null) {
-      SlackLogService().sendLogToSlack('machineId: $machineId 배너를 불러오기 위한 사용자 디렉토리 또는 버전을 불러올 수 없습니다.');
+    if (userDir == null) {
+      SlackLogService().sendLogToSlack('machineId: $machineId 배너를 불러오기 위한 사용자 디렉토리를 불러올 수 없습니다.');
       return null;
     }
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: flutter_snaptag_kiosk
 description: "A new Flutter project."
 publish_to: "none"
-version: 0.1.0
+version: 3.3.0
 
 environment:
   sdk: ^3.6.0


### PR DESCRIPTION
## 📌 작업 개요
- print_process_screen에서 버전 정보를 version_notifier를 통해 중앙 관리하도록 리팩토링
- .env.version 파일 직접 읽기 로직 제거 및 버전 정보 소스 일관성 확보
- 앱 실행 시 KioskInfo 및 AlertDefinition 미리 로드로 화면 전환 시 대기 시간 감소

## 🔍 변경 사항

### 🔧 버그 수정 및 개선
- **버전 정보 관리 일원화**
  - `print_process_screen.dart`에서 `.env.version` 파일을 직접 읽던 `getAppVersionSync()` 메서드 제거
  - `versionStateProvider`의 `currentVersion`을 사용하도록 변경하여 버전 정보 소스 통일
  - `getRandomAdImagePath()` 및 `getRandomAdImageFilePath()` 메서드에 `WidgetRef ref` 파라미터 추가

- **앱 시작 성능 개선**
  - `app.dart`에서 앱 실행과 동시에 `getKioskMachineInfo()` 및 `alertDefinitionProvider.load()` 미리 로드
  - `setup_main_screen.dart`에서 중복 초기화 로직 제거
  - 화면 전환 시 대기 시간 감소

### 🗂️ 파일 구조 변경
- `lib/features/presentation/screens/print_process_screen.dart`: 버전 정보 조회 방식 변경 (34줄 수정)
- `lib/core/utils/version_util.dart`: 버전 유틸리티 함수 개선
- `lib/data/repositories/version_repository.dart`: 버전 리포지토리 로직 개선
- `lib/features/move_me/screens/setup_main_screen.dart`: 중복 초기화 로직 제거
- `lib/app.dart`: 앱 시작 시 초기 데이터 로딩 로직 추가

## 🧪 테스트 방법

### 1. 버전 정보 조회 테스트
1. 앱 실행 후 print_process_screen 진입
   - 광고 이미지가 정상적으로 로드되는지 확인
   - 버전 정보가 올바르게 사용되는지 확인
   - `versionStateProvider`의 `currentVersion`이 정상적으로 조회되는지 확인

2. 버전 정보 소스 일관성 확인
   - `.env.version` 파일을 직접 읽지 않고 `version_notifier`를 통해 조회하는지 확인
   - 다른 화면에서도 동일한 버전 정보 소스를 사용하는지 확인

### 2. 앱 시작 성능 테스트
1. 앱 실행 후 로그 확인
   - `getKioskMachineInfo()` 호출이 앱 시작 시점에 이루어지는지 확인
   - `alertDefinitionProvider.load()` 호출이 앱 시작 시점에 이루어지는지 확인

## 📎 기타 참고 사항

### 주요 변경 파일 목록
- `lib/features/presentation/screens/print_process_screen.dart`: 버전 정보 조회 방식 변경
- `lib/app.dart`: 앱 시작 시 초기 데이터 로딩 로직 추가
- `lib/features/move_me/screens/setup_main_screen.dart`: 중복 초기화 로직 제거
- `lib/core/utils/version_util.dart`: 버전 유틸리티 함수 개선
- `lib/data/repositories/version_repository.dart`: 버전 리포지토리 로직 개선

### 커밋 히스토리 요약
- `refactor: print_process_screen에서 version_notifier 사용하도록 변경`
  - getAppVersionSync() 메서드 제거
  - versionStateProvider의 currentVersion 사용으로 통일
  - 버전 정보 관리 일원화

- `feat: 앱 실행 시 KioskInfo 및 AlertDefinition 미리 로드`
  - app.dart에서 앱 시작과 동시에 초기 데이터 로딩 수행
  - setup_main_screen.dart에서 중복 로직 제거
  - 네트워크 에러 처리 및 앱 종료 플로우 구현
