### PR TITLE
KSCAT config.ini의 webport를 읽어 baseUrl 자동 설정

### DIFF
--- a/lib/core/data/datasources/remote/payment_api_client.dart
+++ b/lib/core/data/datasources/remote/payment_api_client.dart
@@ -1,4 +1,5 @@
 import 'dart:convert';
+import 'dart:io';
 
 import 'package:flutter_snaptag_kiosk/core/data/models/response/kscat_device_response.dart';
 import 'package:flutter_snaptag_kiosk/lib.dart';
@@ -7,10 +8,68 @@ import 'package:http/http.dart' as http;
 class PaymentApiClient {
   PaymentApiClient();
 
-  static const baseUrl = 'http://127.0.0.1:27098';
+  static const int _defaultWebPort = 27098;
+  static const String _configPath = r'C:\KSCAT\config.ini';
+
+  static String? _cachedBaseUrl;
+
+  Future<String> _resolveBaseUrl() async {
+    // Cache to avoid reading/parsing the INI on every request.
+    if (_cachedBaseUrl != null) return _cachedBaseUrl!;
+
+    try {
+      final ini = await File(_configPath).readAsString();
+      final daemon = _parseIniSection(ini, 'daemon');
+
+      // Prefer webport when present. If missing, fall back to default.
+      final webPort = int.tryParse((daemon['webport'] ?? '').trim()) ?? _defaultWebPort;
+      final baseUrl = 'http://127.0.0.1:$webPort';
+
+      _cachedBaseUrl = baseUrl;
+      logger.i('KSCAT baseUrl resolved from INI: $baseUrl ($_configPath)');
+      return baseUrl;
+    } catch (e) {
+      final baseUrl = 'http://127.0.0.1:$_defaultWebPort';
+      _cachedBaseUrl = baseUrl;
+      logger.w('Failed to read/parse KSCAT INI ($_configPath). Falling back to $baseUrl. Error: $e');
+      return baseUrl;
+    }
+  }
+
+  /// Minimal INI parser (key=value) for a single section like [daemon].
+  /// - Ignores blank lines and comment-like lines starting with ';' or '#'
+  /// - Case-insensitive section name & keys
+  Map<String, String> _parseIniSection(String ini, String sectionName) {
+    final target = sectionName.trim().toLowerCase();
+    final map = <String, String>{};
+
+    String? currentSection;
+    for (final rawLine in const LineSplitter().convert(ini)) {
+      final line = rawLine.trim();
+      if (line.isEmpty) continue;
+      if (line.startsWith(';') || line.startsWith('#')) continue;
+
+      if (line.startsWith('[') && line.endsWith(']')) {
+        currentSection = line.substring(1, line.length - 1).trim().toLowerCase();
+        continue;
+      }
+
+      if (currentSection != target) continue;
+
+      final idx = line.indexOf('=');
+      if (idx <= 0) continue;
+
+      final key = line.substring(0, idx).trim().toLowerCase();
+      final value = line.substring(idx + 1).trim();
+      map[key] = value;
+    }
+
+    return map;
+  }
 
   Future<PaymentResponse> requestPayment(String callback, String request) async {
     // URL을 직접 구성 - 인코딩 없이
+    final baseUrl = await _resolveBaseUrl();
     final url = '$baseUrl?callback=$callback&REQ=$request';
     logger.i('\n=== Raw Payment Request URL ===\n$url');
 
@@ -35,6 +94,7 @@ class PaymentApiClient {
 
   Future<KscatDeviceResponse> requestDeivce(String callback, String request) async {
     // URL을 직접 구성 - 인코딩 없이
+    final baseUrl = await _resolveBaseUrl();
     final url = '$baseUrl?callback=$callback&REQ=$request';
     logger.i('\n=== Raw KscatDevice Request URL ===\n$url');
 


### PR DESCRIPTION
## 📌 작업 개요
- 기존은 kscat 결제 요청 시 사용하는 포트가 27098로 고정.
- 만약 포트가 변경될 경우 다시 앱을 빌드 해야 하는 상황.
- C:\KSCAT\config.ini 파일에 현재 등록된 webport 값으로 결제 요청. 

## 🔍 변경 사항

### 🔧 버그 수정 및 개선
- C:\KSCAT\config.ini의 [daemon] webport 기반으로 127.0.0.1 포트 결정
- 읽기/파싱 실패 시 27098로 fallback
- 요청마다 재파싱하지 않도록 baseUrl 캐시

### 주의할 내용
- C:\KSCAT\config.ini 경로는 KSCAT 결제 프로그램 설치 시 Setup에서 해야 합니다.
    -> 자동으로 C 드라이브 KSCAT 에 설치 파일들을 생성해줍니다.
- 매번 webport 를 파싱해서 사용하면 비효율적이기 때문에 한번 읽은 webport 를 캐싱 해둡니다.
- 따라서 앱 사용 중 포트가 변경되었다면 다시 앱을 재 실행 해주시기 바랍니다.  