### PR TITLE
Spring 차세대 이관 작업 및 기존 기능 버그 수정 

### DIFF
--- a/lib/app.dart
+++ b/lib/app.dart
@@ -84,10 +84,7 @@ class _AppState extends ConsumerState<App> with WindowListener {
   }
 
   @override
-  void onWindowFocus() {
-    // 포커스를 받을 때마다 fullscreen 보장
-    // windowManager.setFullScreen(true);
-  }
+  void onWindowFocus() {}
 
   @override
   Widget build(BuildContext context) {

--- a/lib/core/data/datasources/remote/dio_client.dart
+++ b/lib/core/data/datasources/remote/dio_client.dart
@@ -54,7 +54,7 @@ final dioProvider = Provider.family<Dio, String>((ref, baseUrl) {
         sendHook: (log) {
           final formattedMessage = '*[MachineId : $machineId]*\n$log';
           if (statusCode >= 400 && statusCode < 500) {
-            SlackLogService().sendWarningLogToSlack(formattedMessage);
+            SlackLogService().sendErrorLogToSlack(formattedMessage);
           } else if (statusCode >= 500) {
             SlackLogService().sendErrorLogToSlack(formattedMessage);
             SlackLogService().sendBroadcastLogToSlack(ErrorKey.severError.key);

--- a/lib/core/data/datasources/remote/kiosk_api_client.dart
+++ b/lib/core/data/datasources/remote/kiosk_api_client.dart
@@ -94,12 +94,12 @@ abstract class KioskApiClient {
       @Path('machineId') required int machineId,
       @Query('remainingSingleSidedCount') required String remainingSingleSidedCount});
 
-  @POST('/v1/machine/unique-key/history')
+  @POST('/v1/machine/unique-key/register')
   Future<void> createUniqueKeyHistory({
     @Body() required Map<String, dynamic> body,
   });
 
-  @POST('/v1/qr/back-photo')
+  @POST('/v1/qr/back-photo-nominated')
   Future<BackPhotoCardResponse> getBackPhotoCardByQr({
     @Body() required Map<String, dynamic> body,
   });

--- a/lib/core/data/datasources/remote/slack_log_service.dart
+++ b/lib/core/data/datasources/remote/slack_log_service.dart
@@ -26,8 +26,6 @@ class SlackLogService {
 
   final slackWebhookRibbonFilmWarnUrl = dotenv.env['SLACK_WEBHOOK_RIBBON_FILM_WARN_URL'];
 
-  final slackWebhookWarningUrl = dotenv.env['SLACK_WEBHOOK_WARNING_URL'];
-
   final slackWebhookBroadcastUrl = dotenv.env['SLACK_WEBHOOK_BROADCAST_URL'];
 
   void init(ProviderContainer container) {
@@ -41,14 +39,6 @@ class SlackLogService {
 
   Future<void> sendLogToSlack(String message) async {
     await sendLog(slackWebhookUrl, message);
-  }
-
-  Future<void> sendRibbonFilmWarningLog(String message) async {
-    await sendLog(slackWebhookRibbonFilmWarnUrl, message);
-  }
-
-  Future<void> sendWarningLogToSlack(String message) async {
-    await sendLog(slackWebhookWarningUrl, message);
   }
 
   // 1) 객체 만드는 함수 LogState

--- a/lib/core/data/models/request/unique_key_request.dart
+++ b/lib/core/data/models/request/unique_key_request.dart
@@ -6,7 +6,7 @@ part 'unique_key_request.g.dart';
 @freezed
 class UniqueKeyRequest with _$UniqueKeyRequest {
   const factory UniqueKeyRequest({
-    required String kioskMachineId,
+    required String machineId,
     required String uniqueKey,
   }) = _UniqueKeyRequest;
 

--- a/lib/core/data/repositories/kiosk_repository.dart
+++ b/lib/core/data/repositories/kiosk_repository.dart
@@ -151,10 +151,12 @@ class _KioskRepository {
       final cardCount = _ref.read(cardCountProvider);
 
       await _apiClient.updatePrintLog(
-        body: {
-          ...request.toJson(),
-          'remainingSingleSidedCount': cardCount.remainingSingleSidedCount,
-        },
+        body: request
+            .copyWith(
+              remainingSingleSidedCountPre: cardCount.currentCount.toString(),
+              remainingSingleSidedCountPost: cardCount.initialCount.toString(),
+            )
+            .toJson(),
       );
     } catch (e) {
       rethrow;

--- a/lib/core/ui/widget/dialog_helper.dart
+++ b/lib/core/ui/widget/dialog_helper.dart
@@ -6,7 +6,6 @@ import 'package:flutter_screenutil/flutter_screenutil.dart';
 import 'package:flutter_snaptag_kiosk/core/common/sound/sound_manager.dart';
 import 'package:flutter_snaptag_kiosk/lib.dart';
 import 'package:flutter_svg/flutter_svg.dart';
-import 'package:go_router/go_router.dart';
 import 'package:flutter_snaptag_kiosk/core/ui/widget/code_keypad.dart';
 
 ///
@@ -98,153 +97,23 @@ class DialogHelper {
     );
   }
 
-  static Future<bool> showSetupOneButtonDialog(
+  /// 공통 확인/취소 다이얼로그. [showSetupDialog], [showKioskDialog]에서 사용.
+  static Future<bool> _showConfirmDialog(
     BuildContext context, {
     required String title,
-    String confirmButtonText = '확인',
-  }) async {
-    return await showDialog(
-      context: context,
-      barrierDismissible: false,
-      builder: (BuildContext context) {
-        return DefaultTextStyle(
-          style: TextStyle(
-            fontFamily: context.locale.languageCode == 'ja' ? 'MPLUSRounded' : 'Cafe24Ssurround2',
-          ),
-          child: AlertDialog(
-            backgroundColor: Colors.white,
-            insetPadding: EdgeInsets.symmetric(horizontal: 100.w),
-            shape: RoundedRectangleBorder(
-              borderRadius: BorderRadius.circular(20.r),
-            ),
-            titlePadding: EdgeInsets.zero,
-            actionsPadding: EdgeInsets.zero,
-            title: Center(
-              child: Padding(
-                padding: EdgeInsets.only(top: 60.h, bottom: 36.h, left: 40.w, right: 40.w),
-                child: Text(
-                  title,
-                  textAlign: TextAlign.center,
-                  style: context.typography.kioskAlert1B.copyWith(
-                    fontFamily: 'Pretendard',
-                    color: Colors.black,
-                  ),
-                ),
-              ),
-            ),
-            actions: [
-              Padding(
-                padding: EdgeInsets.only(bottom: 40.h, left: 40.w, right: 40.w),
-                child: Row(
-                  children: [
-                    Expanded(
-                      child: ElevatedButton(
-                        onPressed: () async {
-                          await SoundManager().playSound();
-                          Navigator.of(context).pop(true);
-                        },
-                        style: context.setupDialogConfirmButtonStyle,
-                        child: Text(
-                          confirmButtonText,
-                        ),
-                      ),
-                    ),
-                  ],
-                ),
-              )
-            ],
-          ),
-        );
-      },
-    );
-  }
-
-  static Future<bool> showSetupDialog(
-    BuildContext context, {
-    required String title,
+    String? content,
+    bool showCancelButton = false,
     String cancelButtonText = '취소',
-    String confirmButtonText = '확인',
+    required String confirmButtonText,
+    required ButtonStyle cancelButtonStyle,
+    required ButtonStyle confirmButtonStyle,
+    TextStyle? cancelTextStyle,
+    TextStyle? confirmTextStyle,
   }) async {
-    return await showDialog(
+    final result = await showDialog<bool>(
       context: context,
       barrierDismissible: false,
-      builder: (BuildContext context) {
-        return DefaultTextStyle(
-          style: TextStyle(
-            fontFamily: context.locale.languageCode == 'ja' ? 'MPLUSRounded' : 'Cafe24Ssurround2',
-          ),
-          child: AlertDialog(
-            backgroundColor: Colors.white,
-            insetPadding: EdgeInsets.symmetric(horizontal: 100.w),
-            shape: RoundedRectangleBorder(
-              borderRadius: BorderRadius.circular(20.r),
-            ),
-            titlePadding: EdgeInsets.zero,
-            actionsPadding: EdgeInsets.zero,
-            title: Center(
-              child: Padding(
-                padding: EdgeInsets.only(top: 60.h, bottom: 36.h, left: 40.w, right: 40.w),
-                child: Text(
-                  title,
-                  textAlign: TextAlign.center,
-                  style: context.typography.kioskAlert1B.copyWith(
-                    fontFamily: 'Pretendard',
-                    color: Colors.black,
-                  ),
-                ),
-              ),
-            ),
-            actions: [
-              Padding(
-                padding: EdgeInsets.only(bottom: 40.h, left: 40.w, right: 40.w),
-                child: Row(
-                  children: [
-                    Expanded(
-                      child: OutlinedButton(
-                        onPressed: () async {
-                          await SoundManager().playSound();
-                          Navigator.of(context).pop(false);
-                        },
-                        style: context.setupDialogCancelButtonStyle,
-                        child: Text(
-                          cancelButtonText,
-                        ),
-                      ),
-                    ),
-                    SizedBox(width: 12.w),
-                    Expanded(
-                      child: ElevatedButton(
-                        onPressed: () async {
-                          await SoundManager().playSound();
-                          Navigator.of(context).pop(true);
-                        },
-                        style: context.setupDialogConfirmButtonStyle,
-                        child: Text(
-                          confirmButtonText,
-                        ),
-                      ),
-                    ),
-                  ],
-                ),
-              )
-            ],
-          ),
-        );
-      },
-    );
-  }
-
-  static Future<bool> _showOneButtonKioskDialog(
-    BuildContext context, {
-    required String title,
-    required String message,
-    required String buttonText,
-    VoidCallback? onButtonPressed,
-  }) async {
-    await showDialog(
-      context: context,
-      barrierDismissible: false,
-      builder: (BuildContext context) {
+      builder: (BuildContext dialogContext) {
         return DefaultTextStyle(
           style: TextStyle(
             fontFamily: context.locale.languageCode == 'ja' ? 'MPLUSRounded' : 'Cafe24Ssurround2',
@@ -260,7 +129,7 @@ class DialogHelper {
             actionsPadding: EdgeInsets.zero,
             title: Center(
               child: Padding(
-                padding: EdgeInsets.only(top: 60.h, bottom: 20.h, left: 40.w, right: 40.w),
+                padding: EdgeInsets.only(top: 60.h, left: 40.w, right: 40.w),
                 child: Text(
                   title,
                   textAlign: TextAlign.center,
@@ -271,36 +140,44 @@ class DialogHelper {
                 ),
               ),
             ),
-            content: message.isNotEmpty
+            content: content != null
                 ? Padding(
-                    padding: EdgeInsets.only(left: 40.w, right: 40.w),
+                    padding: EdgeInsets.only(top: 20.h, left: 40.w, right: 40.w),
                     child: Text(
-                      message,
+                      content,
+                      textAlign: TextAlign.center,
                       style: context.typography.kioskAlert2M.copyWith(
                         color: Colors.black,
                         fontFamily: 'Pretendard',
                       ),
-                      textAlign: TextAlign.center,
                     ),
                   )
                 : null,
             actions: [
               Padding(
-                padding: EdgeInsets.only(bottom: 40.h, top: 36.h, left: 40.w, right: 40.w),
+                padding: EdgeInsets.only(top: 36.h, bottom: 40.h, left: 40.w, right: 40.w),
                 child: Row(
                   children: [
+                    if (showCancelButton)
+                      Expanded(
+                        child: OutlinedButton(
+                          onPressed: () async {
+                            await SoundManager().playSound();
+                            Navigator.of(dialogContext).pop(false);
+                          },
+                          style: cancelButtonStyle,
+                          child: Text(cancelButtonText, style: cancelTextStyle),
+                        ),
+                      ),
+                    if (showCancelButton) SizedBox(width: 12.w),
                     Expanded(
                       child: ElevatedButton(
-                        onPressed: () {
-                          context.pop();
-                          if (onButtonPressed != null) {
-                            onButtonPressed();
-                          }
+                        onPressed: () async {
+                          await SoundManager().playSound();
+                          Navigator.of(dialogContext).pop(true);
                         },
-                        style: context.dialogButtonStyle,
-                        child: Text(
-                          buttonText,
-                        ),
+                        style: confirmButtonStyle,
+                        child: Text(confirmButtonText, style: confirmTextStyle),
                       ),
                     ),
                   ],
@@ -311,98 +188,51 @@ class DialogHelper {
         );
       },
     );
-    return true;
+    return result ?? false;
   }
 
-  static Future<bool> showTwoButtonKioskDialog(
-    BuildContext context,
-    ButtonStyle? confirmButtonStyle, {
+  static Future<bool> showSetupDialog(
+    BuildContext context, {
     required String title,
-    required String contentText,
-    required String cancelButtonText,
-    required String confirmButtonText,
+    String? content,
+    bool showCancelButton = false,
+    String cancelButtonText = '취소',
+    String confirmButtonText = '확인',
   }) async {
-    return await showDialog(
-      context: context,
-      barrierDismissible: false,
-      builder: (BuildContext context) {
-        return DefaultTextStyle(
-          style: TextStyle(
-            fontFamily: context.locale.languageCode == 'ja' ? 'MPLUSRounded' : 'Cafe24Ssurround2',
-          ),
-          child: AlertDialog(
-            backgroundColor: Colors.white,
-            insetPadding: EdgeInsets.symmetric(horizontal: 100.h),
-            shape: RoundedRectangleBorder(
-              borderRadius: BorderRadius.circular(20.r),
-            ),
-            title: Center(
-              child: Text(
-                title,
-                textAlign: TextAlign.center,
-                style: context.typography.kioskAlert1B.copyWith(
-                  fontFamily: 'Pretendard',
-                  color: Colors.black,
-                ),
-              ),
-            ),
-            content: Text(
-              contentText,
-              textAlign: TextAlign.center,
-              style: context.typography.kioskAlert2M.copyWith(
-                fontFamily: 'Pretendard',
-                color: Color(0xFF414448),
-              ),
-            ),
-            actions: [
-              Row(
-                children: [
-                  Expanded(
-                    child: OutlinedButton(
-                      onPressed: () async {
-                        await SoundManager().playSound();
-                        Navigator.of(context).pop(false);
-                      },
-                      style: context.refundDialogCancelButtonStyle,
-                      child: Text(cancelButtonText, style: TextStyle(color: Color(0xFF999999))),
-                    ),
-                  ),
-                  SizedBox(width: 12.w),
-                  Expanded(
-                    child: ElevatedButton(
-                      onPressed: () async {
-                        await SoundManager().playSound();
-                        Navigator.of(context).pop(true);
-                      },
-                      style: context.dialogKioskStyle,
-                      child: Text(confirmButtonText, style: TextStyle(color: Color(0xFFFFFFFF))),
-                    ),
-                  ),
-                ],
-              )
-            ],
-          ),
-        );
-      },
-    );
-  }
-
-  //showCustomDialog
-  static Future<void> showCustomDialog(BuildContext context,
-      {required String title,
-      required String message,
-      required String buttonText,
-      VoidCallback? onButtonPressed}) async {
-    await _showOneButtonKioskDialog(
+    return await _showConfirmDialog(
       context,
       title: title,
-      message: message,
-      buttonText: buttonText,
-      onButtonPressed: onButtonPressed,
+      content: content,
+      showCancelButton: showCancelButton,
+      cancelButtonText: cancelButtonText,
+      confirmButtonText: confirmButtonText,
+      cancelButtonStyle: context.setupDialogCancelButtonStyle,
+      confirmButtonStyle: context.setupDialogConfirmButtonStyle,
     );
   }
 
-  //    2.3.0 이하 버전용
+  static Future<bool> showKioskDialog(
+    BuildContext context, {
+    required String title,
+    required String contentText,
+    String? cancelButtonText,
+    required String confirmButtonText,
+    ButtonStyle? confirmButtonStyle,
+  }) async {
+    return await _showConfirmDialog(
+      context,
+      title: title,
+      content: contentText,
+      showCancelButton: cancelButtonText != null,
+      cancelButtonText: cancelButtonText ?? '취소',
+      confirmButtonText: confirmButtonText,
+      cancelButtonStyle: context.refundDialogCancelButtonStyle,
+      confirmButtonStyle: confirmButtonStyle ?? context.dialogKioskStyle,
+      cancelTextStyle: const TextStyle(color: Color(0xFF999999)),
+      confirmTextStyle: const TextStyle(color: Color(0xFFFFFFFF)),
+    );
+  }
+
   static Future<void> showPrintCompleteDialog(
     //5초 후 자동으로 닫히고 QR 화면으로 이동
     BuildContext context, {
@@ -414,13 +244,16 @@ class DialogHelper {
         Navigator.of(context, rootNavigator: true).pop();
       }
     });
-    await _showOneButtonKioskDialog(
+    final result = await showKioskDialog(
       context,
       title: LocaleKeys.alert_title_print_complete.tr(),
-      message: LocaleKeys.alert_txt_print_complete.tr(),
-      buttonText: LocaleKeys.alert_btn_print_complete.tr(),
-      onButtonPressed: onButtonPressed,
+      contentText: LocaleKeys.alert_txt_print_complete.tr(),
+      confirmButtonText: LocaleKeys.alert_btn_print_complete.tr(),
     );
+
+    if (result) {
+      HomeRouteData().go(context);
+    }
   }
 
   /// 타임아웃 알럿 (실시간 카운트다운 표시)
@@ -454,177 +287,110 @@ class DialogHelper {
   }
 
   static Future<void> showCardLimitExceededDialog(BuildContext context) async {
-    await _showOneButtonKioskDialog(
+    await showKioskDialog(
       context,
       title: LocaleKeys.alert_title_purchase_failure.tr(),
-      message: LocaleKeys.alert_txt_card_limit_exceeded.tr(),
-      buttonText: LocaleKeys.alert_btn_paymentcard_failure.tr(),
+      contentText: LocaleKeys.alert_txt_card_limit_exceeded.tr(),
+      confirmButtonText: LocaleKeys.alert_btn_paymentcard_failure.tr(),
     );
   }
 
   static Future<void> showInsufficientBalanceDialog(BuildContext context) async {
-    await _showOneButtonKioskDialog(
+    await showKioskDialog(
       context,
       title: LocaleKeys.alert_title_purchase_failure.tr(),
-      message: LocaleKeys.alert_txt_insufficient_balance.tr(),
-      buttonText: LocaleKeys.alert_btn_paymentcard_failure.tr(),
+      contentText: LocaleKeys.alert_txt_insufficient_balance.tr(),
+      confirmButtonText: LocaleKeys.alert_btn_paymentcard_failure.tr(),
     );
   }
 
   static Future<void> showVerificationErrorDialog(BuildContext context) async {
-    await _showOneButtonKioskDialog(
+    await showKioskDialog(
       context,
       title: LocaleKeys.alert_title_purchase_failure.tr(),
-      message: LocaleKeys.alert_txt_verification_error.tr(),
-      buttonText: LocaleKeys.alert_btn_paymentcard_failure.tr(),
+      contentText: LocaleKeys.alert_txt_verification_error.tr(),
+      confirmButtonText: LocaleKeys.alert_btn_paymentcard_failure.tr(),
     );
   }
 
   static Future<void> showMerchantRestrictionDialog(BuildContext context) async {
-    await _showOneButtonKioskDialog(
+    await showKioskDialog(
       context,
       title: LocaleKeys.alert_title_purchase_failure.tr(),
-      message: LocaleKeys.alert_txt_merchant_restriction.tr(),
-      buttonText: LocaleKeys.alert_btn_paymentcard_failure.tr(),
+      contentText: LocaleKeys.alert_txt_merchant_restriction.tr(),
+      confirmButtonText: LocaleKeys.alert_btn_paymentcard_failure.tr(),
     );
   }
 
   static Future<void> showTimeoutPaymentDialog(BuildContext context) async {
-    await _showOneButtonKioskDialog(
+    await showKioskDialog(
       context,
       title: LocaleKeys.alert_title_purchase_failure.tr(),
-      message: LocaleKeys.alert_txt_timeout_payment.tr(),
-      buttonText: LocaleKeys.alert_btn_paymentcard_failure.tr(),
-    );
-  }
-
-  static Future<void> showPrintWaitingDialog(BuildContext context) async {
-    await _showOneButtonKioskDialog(
-      context,
-      title: "프린트가 준비중입니다.",
-      message: "",
-      buttonText: LocaleKeys.alert_btn_paymentcard_failure.tr(),
-    );
-  }
-
-  static Future<void> showNeedRibbonFilmDialog(BuildContext context, VoidCallback? onButtonPressed) async {
-    await _showOneButtonKioskDialog(
-      context,
-      title: LocaleKeys.alert_title_need_ribbon_film.tr(),
-      message: LocaleKeys.alert_txt_need_ribbon_film.tr(),
-      buttonText: LocaleKeys.alert_btn_paymentcard_failure.tr(),
-      onButtonPressed: onButtonPressed,
+      contentText: LocaleKeys.alert_txt_timeout_payment.tr(),
+      confirmButtonText: LocaleKeys.alert_btn_paymentcard_failure.tr(),
     );
   }
 
   static Future<void> showAuthNumReissueCompleteDialog(BuildContext context) async {
-    await _showOneButtonKioskDialog(
+    await showKioskDialog(
       context,
       title: LocaleKeys.alert_title_authNum_reissue_complete.tr(),
-      message: LocaleKeys.alert_txt_authNum_reissue_complete.tr(),
-      buttonText: LocaleKeys.alert_btn_authNum_reissue_complete.tr(),
-    );
-  }
-
-  static Future<void> showEmptyEventDialog(BuildContext context) async {
-    await _showOneButtonKioskDialog(
-      context,
-      title: LocaleKeys.alert_title_empty_event.tr(),
-      message: "",
-      buttonText: LocaleKeys.alert_btn_ok.tr(),
+      contentText: LocaleKeys.alert_txt_authNum_reissue_complete.tr(),
+      confirmButtonText: LocaleKeys.alert_btn_authNum_reissue_complete.tr(),
     );
   }
 
   static Future<void> showAuthNumReissueFailureDialog(BuildContext context) async {
-    await _showOneButtonKioskDialog(
+    await showKioskDialog(
       context,
       title: LocaleKeys.alert_title_authNum_reissue_failure.tr(),
-      message: LocaleKeys.alert_txt_authNum_reissue_failure.tr(),
-      buttonText: LocaleKeys.alert_btn_authNum_reissue_failure.tr(),
-    );
-  }
-
-  static Future<void> showCheckPrintStateDialog(BuildContext context) async {
-    await _showOneButtonKioskDialog(
-      context,
-      title: "프린트 기기 상태를 확인해주세요.",
-      message: "",
-      buttonText: LocaleKeys.alert_btn_paymentcard_failure.tr(),
+      contentText: LocaleKeys.alert_txt_authNum_reissue_failure.tr(),
+      confirmButtonText: LocaleKeys.alert_btn_authNum_reissue_failure.tr(),
     );
   }
 
   static Future<void> showErrorDialog(BuildContext context) async {
-    await _showOneButtonKioskDialog(
+    await showKioskDialog(
       context,
       title: LocaleKeys.alert_title_authNum_error.tr(),
-      message: LocaleKeys.alert_txt_authNum_error.tr(),
-      buttonText: LocaleKeys.alert_btn_authNum_error.tr(),
+      contentText: LocaleKeys.alert_txt_authNum_error.tr(),
+      confirmButtonText: LocaleKeys.alert_btn_authNum_error.tr(),
     );
   }
 
   static Future<void> showVerificationCodeExpriedDialog(BuildContext context) async {
-    await _showOneButtonKioskDialog(
+    await showKioskDialog(
       context,
       title: LocaleKeys.alert_title_verification_code_expried.tr(),
-      message: LocaleKeys.alert_txt_verification_code_expried.tr(),
-      buttonText: LocaleKeys.alert_btn_verification_code_expried.tr(),
+      contentText: LocaleKeys.alert_txt_verification_code_expried.tr(),
+      confirmButtonText: LocaleKeys.alert_btn_verification_code_expried.tr(),
     );
   }
 
   static Future<void> showPurchaseFailedDialog(BuildContext context) async {
-    await _showOneButtonKioskDialog(
+    await showKioskDialog(
       context,
       title: LocaleKeys.alert_title_purchase_failure.tr(),
-      message: LocaleKeys.alert_txt_purchase_failure.tr(),
-      buttonText: LocaleKeys.alert_btn_purchase_failure.tr(),
+      contentText: LocaleKeys.alert_txt_purchase_failure.tr(),
+      confirmButtonText: LocaleKeys.alert_btn_purchase_failure.tr(),
     );
   }
 
-  static Future<void> showPaymentCardFailedDialog(BuildContext context) async {
-    await _showOneButtonKioskDialog(
-      context,
-      title: LocaleKeys.alert_title_paymentcard_failure.tr(),
-      message: LocaleKeys.alert_txt_paymentcard_failure.tr(),
-      buttonText: LocaleKeys.alert_btn_paymentcard_failure.tr(),
-    );
-  }
-
-  static Future<void> showAutoRefundDescriptionDialog(
-    BuildContext context, {
-    VoidCallback? onButtonPressed,
-  }) async {
-    await _showOneButtonKioskDialog(
-      context,
-      title: LocaleKeys.alert_title_auto_refund_alert.tr(),
-      message: LocaleKeys.alert_txt_auto_refund_alert.tr(),
-      buttonText: LocaleKeys.alert_btn_paymentcard_failure.tr(),
-      onButtonPressed: onButtonPressed,
-    );
-  }
-
-  static Future<bool> showPrintErrorDialog(
-    BuildContext context, {
-    VoidCallback? onButtonPressed,
-  }) async {
-    return await _showOneButtonKioskDialog(
+  static Future<bool> showPrintErrorDialog(BuildContext context) async {
+    return await showKioskDialog(
       context,
       title: LocaleKeys.alert_title_print_failure.tr(),
-      message: LocaleKeys.alert_txt_print_failure.tr(),
-      buttonText: LocaleKeys.alert_btn_print_failure.tr(),
-      onButtonPressed: onButtonPressed,
+      contentText: LocaleKeys.alert_txt_print_failure.tr(),
+      confirmButtonText: LocaleKeys.alert_btn_print_failure.tr(),
     );
   }
 
-  static Future<bool> showPrintCardRefillDialog(
-    BuildContext context, {
-    VoidCallback? onButtonPressed,
-  }) async {
-    return await _showOneButtonKioskDialog(
+  static Future<bool> showPrintCardRefillDialog(BuildContext context) async {
+    return await showKioskDialog(
       context,
       title: LocaleKeys.alert_title_card_refill.tr(),
-      message: LocaleKeys.alert_txt_card_refill.tr(),
-      buttonText: LocaleKeys.alert_btn_card_refill.tr(),
-      onButtonPressed: onButtonPressed,
+      contentText: LocaleKeys.alert_txt_card_refill.tr(),
+      confirmButtonText: LocaleKeys.alert_btn_card_refill.tr(),
     );
   }
 
@@ -663,21 +429,6 @@ class DialogHelper {
     );
   }
 }
-
-/* Admin 패스워드 실패시 다이얼로그
-  static Future<void> showAdminFailDialog(
-      BuildContext context, {
-        VoidCallback? onButtonPressed,
-      }) async {
-    await _showOneButtonKioskDialog(
-      context,
-      title: '비밀번호 오류',
-      message: '비밀번호를 다시 입력해주세요',
-      buttonText: LocaleKeys.alert_btn_print_complete.tr(),
-      onButtonPressed: onButtonPressed,
-    );
-  }
-*/
 
 /// 타임아웃 다이얼로그 위젯 (실시간 카운트다운)
 class _TimeoutDialogWidget extends StatefulWidget {

--- a/lib/core/ui/widget/dialog_test_widget.dart
+++ b/lib/core/ui/widget/dialog_test_widget.dart
@@ -26,9 +26,6 @@ class DialogTestWidget extends StatelessWidget {
         ElevatedButton(
           onPressed: () => DialogHelper.showPrintErrorDialog(
             context,
-            onButtonPressed: () {
-              HomeRouteData().go(context);
-            },
           ),
           style: context.dialogButtonStyle,
           child: Text('Show Print Error Dialog'),

--- a/lib/flavors.dart
+++ b/lib/flavors.dart
@@ -33,7 +33,7 @@ class F {
   static String get kioskBaseUrl {
     switch (F.appFlavor) {
       case Flavor.dev:
-        return 'https://kiosk-dev-server.snaptag.co.kr';
+        return 'https://dev-api-spring-kiosk.snaptag.co.kr';
       case Flavor.prod:
         return 'https://kiosk-server.snaptag.co.kr';
       default:

--- a/lib/presentation/payment/payment_response_state.dart
+++ b/lib/presentation/payment/payment_response_state.dart
@@ -14,11 +14,7 @@ class PaymentResponseState extends _$PaymentResponseState {
       final approvalNo = response.approvalNo ?? '';
       if (response.res != '0000' || approvalNo.trim().isEmpty) {
         final orderResponse = ref.read(createOrderInfoProvider);
-        if (orderResponse == null) {
-          SlackLogService().sendWarningLogToSlack('No order response available: Null ApprovalNo');
-          // throw Exception('No order response available');
-        }
-        SlackLogService().sendWarningLogToSlack('OrderResponse : $orderResponse \n PaymentResponse: $response');
+        SlackLogService().sendLogToSlack('OrderResponse : $orderResponse');
       }
 
       SlackLogService().sendLogToSlack('PaymentResponse: $response');

--- a/lib/presentation/payment/payment_screen.dart
+++ b/lib/presentation/payment/payment_screen.dart
@@ -4,6 +4,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_screenutil/flutter_screenutil.dart';
 import 'package:flutter_snaptag_kiosk/core/common/sound/sound_manager.dart';
+import 'package:flutter_snaptag_kiosk/core/data/models/response/nominated_back_photo_card.dart';
 import 'package:flutter_snaptag_kiosk/presentation/kiosk_shell/kiosk_info_service.dart';
 import 'package:flutter_snaptag_kiosk/presentation/payment/payment_failed_type.dart';
 import 'package:flutter_snaptag_kiosk/presentation/home/back_photo_type_provider.dart';
@@ -52,345 +53,6 @@ class _PaymentScreenState extends ConsumerState<PaymentScreen> {
   SelectionDesignVariant _currentVariant = SelectionDesignVariant.animatedScaleOnUnselected;
   bool _showTabs = false;
 
-  /// 시안별 카드 빌더 라우터
-  Widget _buildFixedBackPhotoCard({
-    required int index,
-    required int? selectedIndex,
-    required String? imageUrl,
-    required VoidCallback onTap,
-  }) {
-    switch (_currentVariant) {
-      case SelectionDesignVariant.opacityWithBottomRadio:
-        return _buildVariant1OpacityWithBottomRadio(
-          index: index,
-          selectedIndex: selectedIndex,
-          imageUrl: imageUrl,
-          onTap: onTap,
-        );
-      case SelectionDesignVariant.opacityWithTopRightCheck:
-        return _buildVariant2OpacityWithTopRightCheck(
-          index: index,
-          selectedIndex: selectedIndex,
-          imageUrl: imageUrl,
-          onTap: onTap,
-        );
-      case SelectionDesignVariant.opacityWithBoldBorder:
-        return _buildVariant3OpacityWithBoldBorder(
-          index: index,
-          selectedIndex: selectedIndex,
-          imageUrl: imageUrl,
-          onTap: onTap,
-        );
-      case SelectionDesignVariant.opacityWithCenterOverlay:
-        return _buildVariant4OpacityWithCenterOverlay(
-          index: index,
-          selectedIndex: selectedIndex,
-          imageUrl: imageUrl,
-          onTap: onTap,
-        );
-      case SelectionDesignVariant.opacityWithTopCheckAndBottomRadio:
-        return _buildVariant5OpacityWithTopCheckAndBottomRadio(
-          index: index,
-          selectedIndex: selectedIndex,
-          imageUrl: imageUrl,
-          onTap: onTap,
-        );
-      case SelectionDesignVariant.animatedScaleOnUnselected:
-        return _buildVariant6AnimatedScaleOnUnselected(
-          index: index,
-          selectedIndex: selectedIndex,
-          imageUrl: imageUrl,
-          onTap: onTap,
-        );
-    }
-  }
-
-  /// 시안 1: 투명도 + 카드 아래 체크 라디오 버튼
-  Widget _buildVariant1OpacityWithBottomRadio({
-    required int index,
-    required int? selectedIndex,
-    required String? imageUrl,
-    required VoidCallback onTap,
-  }) {
-    final isSelected = selectedIndex == index;
-    final kioskColors = Theme.of(context).extension<KioskColors>();
-    final buttonColor = kioskColors?.buttonColor ?? const Color(0xFF1B5E4F);
-
-    return GestureDetector(
-      onTap: onTap,
-      child: Column(
-        mainAxisSize: MainAxisSize.min,
-        children: [
-          Opacity(
-            opacity: selectedIndex == null ? 1.2 : (isSelected ? 1.2 : 0.7),
-            child: Container(
-              width: 226.w,
-              height: 355.h,
-              clipBehavior: Clip.antiAlias,
-              decoration: ShapeDecoration(
-                color: Colors.grey[200],
-                shape: RoundedRectangleBorder(
-                  borderRadius: BorderRadius.circular(10.r),
-                ),
-              ),
-              child: imageUrl != null ? _buildNetworkImage(imageUrl) : _buildEmptyImagePlaceholder(),
-            ),
-          ),
-          SizedBox(height: 12.h),
-          // 체크 라디오 버튼
-          Container(
-            width: 40.w,
-            height: 40.w,
-            decoration: BoxDecoration(
-              shape: BoxShape.circle,
-              color: isSelected ? buttonColor : Colors.grey[300],
-              border: Border.all(
-                color: isSelected ? buttonColor : (Colors.grey[400] ?? Colors.grey),
-                width: 2.w,
-              ),
-            ),
-            child: isSelected
-                ? Icon(
-                    Icons.check,
-                    color: Colors.white,
-                    size: 24.sp,
-                  )
-                : null,
-          ),
-        ],
-      ),
-    );
-  }
-
-  /// 시안 2: 투명도 + 카드 위 우측 상단 체크 아이콘
-  Widget _buildVariant2OpacityWithTopRightCheck({
-    required int index,
-    required int? selectedIndex,
-    required String? imageUrl,
-    required VoidCallback onTap,
-  }) {
-    final isSelected = selectedIndex == index;
-    final kioskColors = Theme.of(context).extension<KioskColors>();
-    final buttonColor = kioskColors?.buttonColor ?? const Color(0xFF1B5E4F);
-
-    return GestureDetector(
-      onTap: onTap,
-      child: Stack(
-        children: [
-          Opacity(
-            opacity: selectedIndex == null ? 1.0 : (isSelected ? 1.0 : 0.3),
-            child: Container(
-              width: 226.w,
-              height: 355.h,
-              clipBehavior: Clip.antiAlias,
-              decoration: ShapeDecoration(
-                color: Colors.grey[200],
-                shape: RoundedRectangleBorder(
-                  borderRadius: BorderRadius.circular(10.r),
-                ),
-              ),
-              child: imageUrl != null ? _buildNetworkImage(imageUrl) : _buildEmptyImagePlaceholder(),
-            ),
-          ),
-          // 우측 상단 체크 아이콘
-          if (isSelected)
-            Positioned(
-              top: 8.h,
-              right: 8.w,
-              child: Container(
-                width: 48.w,
-                height: 48.w,
-                decoration: BoxDecoration(
-                  shape: BoxShape.circle,
-                  color: buttonColor,
-                  boxShadow: [
-                    BoxShadow(
-                      color: Colors.black.withOpacity(0.3),
-                      blurRadius: 8.r,
-                      offset: Offset(0, 2.h),
-                    ),
-                  ],
-                ),
-                child: Icon(
-                  Icons.check,
-                  color: Colors.white,
-                  size: 28.sp,
-                ),
-              ),
-            ),
-        ],
-      ),
-    );
-  }
-
-  /// 시안 3: 투명도 + 두꺼운 테두리 강조
-  Widget _buildVariant3OpacityWithBoldBorder({
-    required int index,
-    required int? selectedIndex,
-    required String? imageUrl,
-    required VoidCallback onTap,
-  }) {
-    final isSelected = selectedIndex == index;
-    final kioskColors = Theme.of(context).extension<KioskColors>();
-    final buttonColor = kioskColors?.buttonColor ?? const Color(0xFF1B5E4F);
-
-    return GestureDetector(
-      onTap: onTap,
-      child: Opacity(
-        opacity: selectedIndex == null ? 1.0 : (isSelected ? 1.0 : 0.3),
-        child: Container(
-          width: 226.w,
-          height: 355.h,
-          clipBehavior: Clip.antiAlias,
-          decoration: BoxDecoration(
-            color: Colors.grey[200],
-            borderRadius: BorderRadius.circular(10.r),
-            border: Border.all(
-              color: isSelected ? buttonColor : Colors.transparent,
-              width: isSelected ? 4.w : 0,
-            ),
-            boxShadow: isSelected
-                ? [
-                    BoxShadow(
-                      color: buttonColor.withOpacity(0.4),
-                      blurRadius: 12.r,
-                      spreadRadius: 2.r,
-                      offset: Offset(0, 4.h),
-                    ),
-                  ]
-                : null,
-          ),
-          child: imageUrl != null ? _buildNetworkImage(imageUrl) : _buildEmptyImagePlaceholder(),
-        ),
-      ),
-    );
-  }
-
-  /// 시안 4: 투명도 + 중앙 오버레이 + 체크 아이콘
-  Widget _buildVariant4OpacityWithCenterOverlay({
-    required int index,
-    required int? selectedIndex,
-    required String? imageUrl,
-    required VoidCallback onTap,
-  }) {
-    final isSelected = selectedIndex == index;
-    final kioskColors = Theme.of(context).extension<KioskColors>();
-    final buttonColor = kioskColors?.buttonColor ?? const Color(0xFF1B5E4F);
-
-    return GestureDetector(
-      onTap: onTap,
-      child: Stack(
-        children: [
-          Opacity(
-            opacity: selectedIndex == null ? 1.0 : (isSelected ? 1.0 : 0.3),
-            child: Container(
-              width: 226.w,
-              height: 355.h,
-              clipBehavior: Clip.antiAlias,
-              decoration: ShapeDecoration(
-                color: Colors.grey[200],
-                shape: RoundedRectangleBorder(
-                  borderRadius: BorderRadius.circular(10.r),
-                ),
-              ),
-              child: imageUrl != null ? _buildNetworkImage(imageUrl) : _buildEmptyImagePlaceholder(),
-            ),
-          ),
-          // 중앙 오버레이 + 체크 아이콘
-          if (isSelected)
-            Positioned.fill(
-              child: Container(
-                decoration: BoxDecoration(
-                  borderRadius: BorderRadius.circular(10.r),
-                  color: buttonColor.withOpacity(0.25),
-                ),
-                child: Center(
-                  child: Container(
-                    width: 64.w,
-                    height: 64.w,
-                    decoration: BoxDecoration(
-                      shape: BoxShape.circle,
-                      color: buttonColor,
-                      boxShadow: [
-                        BoxShadow(
-                          color: Colors.black.withOpacity(0.3),
-                          blurRadius: 12.r,
-                          offset: Offset(0, 4.h),
-                        ),
-                      ],
-                    ),
-                    child: Icon(
-                      Icons.check,
-                      color: Colors.white,
-                      size: 36.sp,
-                    ),
-                  ),
-                ),
-              ),
-            ),
-        ],
-      ),
-    );
-  }
-
-  /// 시안 5: 투명도 + 카드 위 체크 라디오 버튼 (1번 시안의 대칭)
-  Widget _buildVariant5OpacityWithTopCheckAndBottomRadio({
-    required int index,
-    required int? selectedIndex,
-    required String? imageUrl,
-    required VoidCallback onTap,
-  }) {
-    final isSelected = selectedIndex == index;
-    final kioskColors = Theme.of(context).extension<KioskColors>();
-    final buttonColor = kioskColors?.buttonColor ?? const Color(0xFF1B5E4F);
-
-    return GestureDetector(
-      onTap: onTap,
-      child: Column(
-        mainAxisSize: MainAxisSize.min,
-        children: [
-          // 체크 라디오 버튼 (카드 위)
-          Container(
-            width: 40.w,
-            height: 40.w,
-            decoration: BoxDecoration(
-              shape: BoxShape.circle,
-              color: isSelected ? buttonColor : Colors.grey[300],
-              border: Border.all(
-                color: isSelected ? buttonColor : (Colors.grey[400] ?? Colors.grey),
-                width: 2.w,
-              ),
-            ),
-            child: isSelected
-                ? Icon(
-                    Icons.check,
-                    color: Colors.white,
-                    size: 24.sp,
-                  )
-                : null,
-          ),
-          SizedBox(height: 12.h),
-          // 카드
-          Opacity(
-            opacity: selectedIndex == null ? 1.0 : (isSelected ? 1.0 : 0.5),
-            child: Container(
-              width: 226.w,
-              height: 355.h,
-              clipBehavior: Clip.antiAlias,
-              decoration: ShapeDecoration(
-                color: Colors.grey[200],
-                shape: RoundedRectangleBorder(
-                  borderRadius: BorderRadius.circular(10.r),
-                ),
-              ),
-              child: imageUrl != null ? _buildNetworkImage(imageUrl) : _buildEmptyImagePlaceholder(),
-            ),
-          ),
-        ],
-      ),
-    );
-  }
-
   /// 시안 6: 선택되지 않은 카드 크기 축소 + 애니메이션
   Widget _buildVariant6AnimatedScaleOnUnselected({
     required int index,
@@ -416,34 +78,46 @@ class _PaymentScreenState extends ConsumerState<PaymentScreen> {
           opacity: opacity,
           duration: const Duration(milliseconds: 300),
           curve: Curves.easeOutCubic,
-          child: Container(
-            width: 226.w,
-            height: 355.h,
-            clipBehavior: Clip.antiAlias,
-            decoration: BoxDecoration(
-              color: Colors.grey[200],
-              borderRadius: BorderRadius.circular(10.r),
-              border: null,
-              boxShadow: isSelected
-                  ? [
-                      BoxShadow(
-                        color: buttonColor.withOpacity(0.4),
-                        blurRadius: 12.r,
-                        spreadRadius: 2.r,
-                        offset: Offset(0, 4.h),
-                      ),
-                    ]
-                  : [
-                      BoxShadow(
-                        color: Colors.black.withOpacity(0.1),
-                        blurRadius: 4.r,
-                        offset: Offset(0, 2.h),
-                      ),
-                    ],
-            ),
-            child: imageUrl != null ? _buildNetworkImage(imageUrl) : _buildEmptyImagePlaceholder(),
+          child: _buildFixedBackPhotoCard(
+            boxShadow: isSelected
+                ? [
+                    BoxShadow(
+                      color: buttonColor.withOpacity(0.4),
+                      blurRadius: 12.r,
+                      spreadRadius: 2.r,
+                      offset: Offset(0, 4.h),
+                    ),
+                  ]
+                : [
+                    BoxShadow(
+                      color: Colors.black.withOpacity(0.1),
+                      blurRadius: 4.r,
+                      offset: Offset(0, 2.h),
+                    ),
+                  ],
+            imageUrl: imageUrl,
           ),
         ),
+      ),
+    );
+  }
+
+  Widget _buildFixedBackPhotoCard({
+    required List<BoxShadow>? boxShadow,
+    required String? imageUrl,
+  }) {
+    return Container(
+      width: 226.w,
+      height: 355.h,
+      clipBehavior: Clip.antiAlias,
+      decoration: BoxDecoration(
+        borderRadius: BorderRadius.circular(10.r),
+        border: null,
+        boxShadow: boxShadow,
+      ),
+      child: ClipRRect(
+        borderRadius: BorderRadius.circular(10.r),
+        child: imageUrl != null && imageUrl.isNotEmpty ? _buildNetworkImage(imageUrl) : _buildEmptyImagePlaceholder(),
       ),
     );
   }
@@ -487,115 +161,54 @@ class _PaymentScreenState extends ConsumerState<PaymentScreen> {
     );
   }
 
-  /// 탭 토글 버튼
-  Widget _buildTabToggleButton() {
-    return GestureDetector(
-      onTap: () {
-        setState(() {
-          _showTabs = !_showTabs;
-        });
-      },
-      child: Container(
-        width: 48.w,
-        height: 48.w,
-        decoration: BoxDecoration(
-          color: Colors.transparent, // 투명하게
-          shape: BoxShape.circle,
-        ),
-        child: Icon(
-          _showTabs ? Icons.close : Icons.tune,
-          color: Colors.transparent, // 투명하게
-          size: 24.sp,
-        ),
-      ),
-    );
-  }
-
-  /// 시안 선택 탭 UI
-  Widget _buildDesignVariantTabs() {
-    final kioskColors = Theme.of(context).extension<KioskColors>();
-    final buttonColor = kioskColors?.buttonColor ?? const Color(0xFF1B5E4F);
-
-    return Container(
-      padding: EdgeInsets.symmetric(horizontal: 20.w, vertical: 8.h),
-      decoration: BoxDecoration(
-        color: Colors.transparent, // 투명하게
-        borderRadius: BorderRadius.circular(12.r),
-        border: Border.all(color: Colors.transparent, width: 1.w), // 투명하게
-      ),
-      child: Row(
-        mainAxisSize: MainAxisSize.min,
-        children: [
-          _buildVariantTab(
-            label: '시안 1',
-            variant: SelectionDesignVariant.opacityWithBottomRadio,
-            buttonColor: buttonColor,
-          ),
-          SizedBox(width: 8.w),
-          _buildVariantTab(
-            label: '시안 2',
-            variant: SelectionDesignVariant.opacityWithTopRightCheck,
-            buttonColor: buttonColor,
-          ),
-          SizedBox(width: 8.w),
-          _buildVariantTab(
-            label: '시안 3',
-            variant: SelectionDesignVariant.opacityWithBoldBorder,
-            buttonColor: buttonColor,
-          ),
-          SizedBox(width: 8.w),
-          _buildVariantTab(
-            label: '시안 4',
-            variant: SelectionDesignVariant.opacityWithCenterOverlay,
-            buttonColor: buttonColor,
-          ),
-          SizedBox(width: 8.w),
-          _buildVariantTab(
-            label: '시안 5',
-            variant: SelectionDesignVariant.opacityWithTopCheckAndBottomRadio,
-            buttonColor: buttonColor,
-          ),
-          SizedBox(width: 8.w),
-          _buildVariantTab(
-            label: '시안 6',
-            variant: SelectionDesignVariant.animatedScaleOnUnselected,
-            buttonColor: buttonColor,
-          ),
-        ],
-      ),
-    );
-  }
-
-  /// 개별 시안 탭 버튼
-  Widget _buildVariantTab({
-    required String label,
-    required SelectionDesignVariant variant,
-    required Color buttonColor,
+  Widget _buildFixedBackPhotoCardList({
+    required KioskMachineInfo? kiosk,
+    required bool isFixed,
+    required int? selectedIndex,
   }) {
-    final isSelected = _currentVariant == variant;
+    final nominatedBackPhotoCardList = kiosk?.nominatedBackPhotoCardList ?? [];
+    if (kiosk == null || nominatedBackPhotoCardList.isEmpty) return _buildEmptyImagePlaceholder();
 
-    return GestureDetector(
-      onTap: () {
-        setState(() {
-          _currentVariant = variant;
-        });
-      },
-      child: Container(
-        padding: EdgeInsets.symmetric(horizontal: 16.w, vertical: 8.h),
-        decoration: BoxDecoration(
-          color: isSelected ? buttonColor : Colors.transparent,
-          borderRadius: BorderRadius.circular(8.r),
-        ),
-        child: Text(
-          label,
-          style: TextStyle(
-            fontSize: 14.sp,
-            fontWeight: FontWeight.w600,
-            color: Colors.transparent, // 투명하게
-          ),
-        ),
-      ),
-    );
+    return isFixed
+        ? Row(
+            mainAxisAlignment: MainAxisAlignment.center,
+            children: [
+              if (nominatedBackPhotoCardList.length == 1)
+                _buildFixedBackPhotoCard(boxShadow: null, imageUrl: nominatedBackPhotoCardList[0].originUrl)
+              else
+                _buildVariant6AnimatedScaleOnUnselected(
+                  index: 0,
+                  selectedIndex: selectedIndex,
+                  imageUrl: nominatedBackPhotoCardList[0].originUrl,
+                  onTap: () {
+                    ref.read(backPhotoTypeProvider.notifier).selectFixed(0);
+                  },
+                ),
+              if (nominatedBackPhotoCardList.length > 1) SizedBox(width: 100.w),
+              if (nominatedBackPhotoCardList.length > 1)
+                _buildVariant6AnimatedScaleOnUnselected(
+                  index: 1,
+                  selectedIndex: selectedIndex,
+                  imageUrl: nominatedBackPhotoCardList[1].originUrl,
+                  onTap: () {
+                    ref.read(backPhotoTypeProvider.notifier).selectFixed(1);
+                  },
+                ),
+            ],
+          )
+        : ref.watch(verifyPhotoCardProvider).when(
+              data: (data) {
+                final imageUrl = data?.formattedBackPhotoCardUrl ?? '';
+                return imageUrl.isNotEmpty
+                    ? _buildFixedBackPhotoCard(boxShadow: null, imageUrl: imageUrl)
+                    : _buildEmptyImagePlaceholder();
+              },
+              loading: () => const CircularProgressIndicator(),
+              error: (error, stack) => GeneralErrorWidget(
+                exception: error as Exception,
+                onRetry: () => ref.refresh(verifyPhotoCardProvider),
+              ),
+            );
   }
 
   @override
@@ -690,57 +303,16 @@ class _PaymentScreenState extends ConsumerState<PaymentScreen> {
               crossAxisAlignment: CrossAxisAlignment.center,
               children: [
                 Text(
-                  isFixed ? LocaleKeys.choice_select_recommended_image.tr() : LocaleKeys.sub02_txt_01.tr(),
+                  isFixed &&
+                          kiosk?.nominatedBackPhotoCardList.length != null &&
+                          kiosk!.nominatedBackPhotoCardList.length > 1
+                      ? LocaleKeys.choice_select_recommended_image.tr()
+                      : LocaleKeys.sub02_txt_01.tr(),
                   textAlign: TextAlign.center,
                   style: context.typography.kioskBtn1B.copyWith(fontSize: 53.sp, color: mainTextColor),
                 ),
                 SizedBox(height: 50.h),
-                if (isFixed)
-                  Row(
-                    mainAxisAlignment: MainAxisAlignment.center,
-                    children: [
-                      _buildFixedBackPhotoCard(
-                        index: 0,
-                        selectedIndex: selectedIndex,
-                        imageUrl: kiosk?.nominatedBackPhotoCardList.isNotEmpty == true &&
-                                (kiosk!.nominatedBackPhotoCardList.isNotEmpty)
-                            ? kiosk.nominatedBackPhotoCardList[0].originUrl
-                            : null,
-                        onTap: () {
-                          ref.read(backPhotoTypeProvider.notifier).selectFixed(0);
-                        },
-                      ),
-                      SizedBox(width: 100.w),
-                      _buildFixedBackPhotoCard(
-                        index: 1,
-                        selectedIndex: selectedIndex,
-                        imageUrl: kiosk?.nominatedBackPhotoCardList.isNotEmpty == true &&
-                                (kiosk!.nominatedBackPhotoCardList.length > 1)
-                            ? kiosk.nominatedBackPhotoCardList[1].originUrl
-                            : null,
-                        onTap: () {
-                          ref.read(backPhotoTypeProvider.notifier).selectFixed(1);
-                        },
-                      ),
-                    ],
-                  )
-                else
-                  GradientContainer(
-                    content: ClipRRect(
-                      borderRadius: BorderRadius.circular(10.r),
-                      child: ref.watch(verifyPhotoCardProvider).when(
-                            data: (data) {
-                              final imageUrl = data?.formattedBackPhotoCardUrl ?? '';
-                              return imageUrl.isNotEmpty ? _buildNetworkImage(imageUrl) : _buildEmptyImagePlaceholder();
-                            },
-                            loading: () => const CircularProgressIndicator(),
-                            error: (error, stack) => GeneralErrorWidget(
-                              exception: error as Exception,
-                              onRetry: () => ref.refresh(verifyPhotoCardProvider),
-                            ),
-                          ),
-                    ),
-                  ),
+                _buildFixedBackPhotoCardList(kiosk: kiosk, isFixed: isFixed, selectedIndex: selectedIndex),
                 SizedBox(height: 50.h),
                 Row(
                   mainAxisAlignment: MainAxisAlignment.center,
@@ -760,45 +332,7 @@ class _PaymentScreenState extends ConsumerState<PaymentScreen> {
                               : () async {
                                   await SoundManager().playSound();
 
-                                  // // 선택된 뒷면 이미지 타입 확인
-                                  final selection = ref.read(backPhotoTypeProvider);
-
-                                  if (selection?.type == BackPhotoType.fixed && selection?.fixedIndex != null) {
-                                    // 고정 뒷면 이미지 결제 처리
-                                    final kiosk = ref.read(kioskInfoServiceProvider);
-                                    final selectedIndex = selection!.fixedIndex!;
-
-                                    if (kiosk != null && selectedIndex < kiosk.nominatedBackPhotoCardList.length) {
-                                      final selectedCard = kiosk.nominatedBackPhotoCardList[selectedIndex];
-
-                                      final response = await ref.read(kioskRepositoryProvider).getBackPhotoCardByQr(
-                                            GetBackPhotoByQrRequest(
-                                              kioskEventId: kiosk.kioskEventId,
-                                              nominatedBackPhotoCardId: selectedCard.id,
-                                            ),
-                                          );
-
-                                      ref.read(verifyPhotoCardProvider.notifier).updateState(BackPhotoCardResponse(
-                                          kioskEventId: kiosk.kioskEventId,
-                                          backPhotoCardId: response.backPhotoCardId,
-                                          backPhotoCardOriginUrl: selectedCard.originUrl,
-                                          photoAuthNumber: response.photoAuthNumber,
-                                          formattedBackPhotoCardUrl: response.formattedBackPhotoCardUrl));
-                                    }
-                                  }
-
-                                  final timeoutNotifier = ref.read(homeTimeoutNotifierProvider.notifier);
-                                  timeoutNotifier.cancelTimerWithCallback();
-
                                   await ref.read(photoCardPreviewScreenProviderProvider.notifier).payment();
-                                  final isPaymentFailed = ref.read(paymentFailureProvider);
-                                  if (isPaymentFailed) {
-                                    ref.read(paymentFailureProvider.notifier).reset();
-                                    DialogHelper.showPaymentCardFailedDialog(
-                                      context,
-                                    );
-                                    HomeRouteData().go(context);
-                                  }
                                 },
                           child: Text(LocaleKeys.sub02_btn_pay.tr()),
                         );
@@ -817,25 +351,6 @@ class _PaymentScreenState extends ConsumerState<PaymentScreen> {
               ],
             ),
           ),
-          // 오른쪽 상단 탭 토글 버튼 및 탭 UI (캡처를 위해 투명 처리, 클릭은 가능)
-          if (isFixed)
-            Positioned(
-              top: 0,
-              right: 0,
-              child: Container(
-                color: Colors.transparent, // 투명 배경
-                child: Column(
-                  crossAxisAlignment: CrossAxisAlignment.end,
-                  children: [
-                    // _buildTabToggleButton(),
-                    // if (_showTabs) ...[
-                    //   SizedBox(height: 8.h),
-                    //   _buildDesignVariantTabs(),
-                    // ],
-                  ],
-                ),
-              ),
-            ),
         ],
       ),
     );

--- a/lib/presentation/payment/payment_service.dart
+++ b/lib/presentation/payment/payment_service.dart
@@ -106,8 +106,6 @@ class PaymentService extends _$PaymentService {
   Future<void> _handleEmptyApprovalNumber(PaymentResponse paymentResponse, String machineId) async {
     final backPhoto = ref.watch(verifyPhotoCardProvider).value!;
 
-    SlackLogService().sendWarningLogToSlack('*[MachineId: $machineId]*\nNull approvalNo Card');
-
     await ref.read(kioskRepositoryProvider).updateBackPhotoStatus(UpdateBackPhotoRequest(
           photoAuthNumber: backPhoto.photoAuthNumber,
           status: "STARTED",
@@ -274,7 +272,7 @@ class PaymentService extends _$PaymentService {
       ref.read(paymentResponseStateProvider.notifier).update(paymentResponse);
       isSuccess = paymentResponse.isSuccess;
     } catch (e) {
-      SlackLogService().sendWarningLogToSlack('error409 refund fail error : $e');
+      SlackLogService().sendLogToSlack('error409 refund fail error : $e');
       logger.e('Refund failed', error: e);
       rethrow;
     } finally {
@@ -363,7 +361,7 @@ class PaymentService extends _$PaymentService {
 
       return await ref.read(kioskRepositoryProvider).updateOrderStatus(orderId.toInt(), request);
     } catch (e) {
-      SlackLogService().sendWarningLogToSlack('update order error: $e');
+      SlackLogService().sendLogToSlack('update order error: $e');
       rethrow;
     }
   }

--- a/lib/presentation/payment/photo_card_preview_screen_provider.dart
+++ b/lib/presentation/payment/photo_card_preview_screen_provider.dart
@@ -1,7 +1,11 @@
 import 'package:flutter_snaptag_kiosk/lib.dart';
 import 'package:flutter_snaptag_kiosk/presentation/core/card_count_provider.dart';
+import 'package:flutter_snaptag_kiosk/presentation/home/back_photo_type_provider.dart';
+import 'package:flutter_snaptag_kiosk/presentation/kiosk_shell/home_timeout_provider.dart';
+import 'package:flutter_snaptag_kiosk/presentation/kiosk_shell/kiosk_info_service.dart';
 import 'package:flutter_snaptag_kiosk/presentation/setup/page_print_provider.dart';
 import 'package:flutter_snaptag_kiosk/presentation/payment/payment_service.dart';
+import 'package:flutter_snaptag_kiosk/presentation/verification/verify_photo_card_provider.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
 
 part 'photo_card_preview_screen_provider.g.dart';
@@ -20,14 +24,46 @@ class PhotoCardPreviewScreenProvider extends _$PhotoCardPreviewScreenProvider {
     state = const AsyncValue.loading();
 
     try {
+      // // 선택된 뒷면 이미지 타입 확인
+      final selection = ref.read(backPhotoTypeProvider);
+
+      if (selection?.type == BackPhotoType.fixed && selection?.fixedIndex != null) {
+        // 고정 뒷면 이미지 결제 처리
+        final kiosk = ref.read(kioskInfoServiceProvider);
+        final selectedIndex = selection!.fixedIndex!;
+
+        if (kiosk != null && selectedIndex < kiosk.nominatedBackPhotoCardList.length) {
+          final selectedCard = kiosk.nominatedBackPhotoCardList[selectedIndex];
+
+          final response = await ref.read(kioskRepositoryProvider).getBackPhotoCardByQr(
+                GetBackPhotoByQrRequest(
+                  kioskEventId: kiosk.kioskEventId,
+                  nominatedBackPhotoCardId: selectedCard.id,
+                ),
+              );
+
+          ref.read(verifyPhotoCardProvider.notifier).updateState(BackPhotoCardResponse(
+              kioskEventId: kiosk.kioskEventId,
+              backPhotoCardId: response.backPhotoCardId,
+              backPhotoCardOriginUrl: selectedCard.originUrl,
+              photoAuthNumber: response.photoAuthNumber,
+              formattedBackPhotoCardUrl: response.formattedBackPhotoCardUrl));
+        }
+      }
+
+      final timeoutNotifier = ref.read(homeTimeoutNotifierProvider.notifier);
+      timeoutNotifier.cancelTimerWithCallback();
+
       await ref.read(paymentServiceProvider.notifier).processPayment();
+
       state = const AsyncValue.data(null);
     } catch (e, stack) {
       if (e is! OrderCreationException && e is! PreconditionFailedException) {
         try {
           await ref.read(paymentServiceProvider.notifier).refund();
-          if (ref.read(pagePrintProvider) == PagePrintType.single)
+          if (ref.read(pagePrintProvider) == PagePrintType.single) {
             await ref.read(cardCountProvider.notifier).increase();
+          }
         } catch (refundError) {
           logger.e('Payment and refund failed', error: refundError);
         }

--- a/lib/presentation/print/card_printer.dart
+++ b/lib/presentation/print/card_printer.dart
@@ -71,6 +71,7 @@ class PrinterService extends _$PrinterService {
         final log = printerLog.copyWith(kioskMachineId: machineId);
         if (machineId != 0) {
           await ref.read(kioskRepositoryProvider).updatePrintLog(request: log);
+          ref.read(printerLogProvider.notifier).update(log);
           SlackLogService().sendLogToSlack('PrintState : $log');
         }
       }

--- a/lib/presentation/print/luca/binding/printer_bindings.dart
+++ b/lib/presentation/print/luca/binding/printer_bindings.dart
@@ -356,16 +356,6 @@ class PrinterBindings {
     }
   }
 
-  // 이미지 회전 기능 추가
-  Uint8List flipImage180(Uint8List imageBytes) {
-    final originalImage = img.decodeImage(imageBytes);
-    if (originalImage != null) {
-      final flippedImage = img.copyRotate(originalImage, angle: 180);
-      return Uint8List.fromList(img.encodePng(flippedImage));
-    }
-    return imageBytes;
-  }
-
   // commitCanvas 메서드 추가
   int commitCanvas(Pointer<Utf8> strPtr, Pointer<Int32> lenPtr) {
     final result = _commitCanvas(strPtr, lenPtr);

--- a/lib/presentation/print/luca/state/printer_log.dart
+++ b/lib/presentation/print/luca/state/printer_log.dart
@@ -20,6 +20,8 @@ class PrinterLog with _$PrinterLog {
     @Default(null) bool? isPrintingNow,
     @Default(null) bool? isFeederEmpty,
     @Default(null) String? sdkErrorMessage,
+    @Default(null) String? remainingSingleSidedCountPre,
+    @Default(null) String? remainingSingleSidedCountPost,
   }) = _PrinterLog;
 
   factory PrinterLog.fromJson(Map<String, dynamic> json) => _$PrinterLogFromJson(json);

--- a/lib/presentation/print/luca/state/ribbon_warning_provider.dart
+++ b/lib/presentation/print/luca/state/ribbon_warning_provider.dart
@@ -205,8 +205,6 @@ class RibbonWarning extends _$RibbonWarning {
       SlackLogService().sendBroadcastLogToSlack(ErrorKey.printerRibonEmpty.key);
       SlackLogService().sendErrorLogToSlack(
           '*[MachineId : $machineId]* ERROR: Ribbon level is ${ribbonLevel.toInt()}% (under 1%), please replace immediately!');
-      SlackLogService().sendRibbonFilmWarningLog(
-          '*[MachineId : $machineId]* ERROR: Ribbon level is ${ribbonLevel.toInt()}% (under 1%), please replace immediately!');
       setRibbonUnder20Sent(ribbonLevel); // 5% 미만이므로 20% 경고도 함께 설정
       setRibbonUnder10Sent(ribbonLevel); // 5% 미만이므로 10% 경고도 함께 설정
       setRibbonUnder5Sent(ribbonLevel);
@@ -217,8 +215,6 @@ class RibbonWarning extends _$RibbonWarning {
       SlackLogService().sendBroadcastLogToSlack(ErrorKey.printerFilmEmpty.key);
       SlackLogService().sendErrorLogToSlack(
           '*[MachineId : $machineId]* ERROR: Film level is ${filmLevel.toInt()}% (under 1%), please replace immediately!');
-      SlackLogService().sendRibbonFilmWarningLog(
-          '*[MachineId : $machineId]* ERROR: Film level is ${filmLevel.toInt()}% (under 1%), please replace immediately!');
       setFilmUnder20Sent(filmLevel); // 5% 미만이므로 20% 경고도 함께 설정
       setFilmUnder10Sent(filmLevel); // 5% 미만이므로 10% 경고도 함께 설정
       setFilmUnder5Sent(filmLevel);
@@ -228,8 +224,6 @@ class RibbonWarning extends _$RibbonWarning {
     // 5% 미만 체크
     if (ribbonLevel <= 5 && !state.isSentUnder5Ribbon) {
       SlackLogService().sendBroadcastLogToSlack(WarningKey.printerRibonR5.key);
-      SlackLogService().sendRibbonFilmWarningLog(
-          '*[MachineId : $machineId]* CRITICAL: Ribbon level is ${ribbonLevel.toInt()}% (under 5%), please replace immediately!');
       setRibbonUnder20Sent(ribbonLevel); // 5% 미만이므로 20% 경고도 함께 설정
       setRibbonUnder10Sent(ribbonLevel); // 5% 미만이므로 10% 경고도 함께 설정
       setRibbonUnder5Sent(ribbonLevel);
@@ -237,8 +231,6 @@ class RibbonWarning extends _$RibbonWarning {
 
     if (filmLevel <= 5 && !state.isSentUnder5Film) {
       SlackLogService().sendBroadcastLogToSlack(WarningKey.printerFilmR5.key);
-      SlackLogService().sendRibbonFilmWarningLog(
-          '*[MachineId : $machineId]* CRITICAL: Film level is ${filmLevel.toInt()}% (under 5%), please replace immediately!');
       setFilmUnder20Sent(filmLevel); // 5% 미만이므로 20% 경고도 함께 설정
       setFilmUnder10Sent(filmLevel); // 5% 미만이므로 10% 경고도 함께 설정
       setFilmUnder5Sent(filmLevel);
@@ -247,16 +239,12 @@ class RibbonWarning extends _$RibbonWarning {
     // 10% 미만 체크 (5% 경고와 독립적으로 실행)
     if (ribbonLevel <= 10 && !state.isSentUnder10Ribbon) {
       SlackLogService().sendBroadcastLogToSlack(WarningKey.printerRibonR10.key);
-      SlackLogService().sendRibbonFilmWarningLog(
-          '*[MachineId : $machineId]* WARNING: Ribbon level is ${ribbonLevel.toInt()}% (under 10%), please check the printer');
       setRibbonUnder20Sent(ribbonLevel); // 10% 미만이므로 20% 경고도 함께 설정
       setRibbonUnder10Sent(ribbonLevel);
     }
 
     if (filmLevel <= 10 && !state.isSentUnder10Film) {
       SlackLogService().sendBroadcastLogToSlack(WarningKey.printerFilmR10.key);
-      SlackLogService().sendRibbonFilmWarningLog(
-          '*[MachineId : $machineId]* WARNING: Film level is ${filmLevel.toInt()}% (under 10%), please check the printer');
       setFilmUnder20Sent(filmLevel); // 10% 미만이므로 20% 경고도 함께 설정
       setFilmUnder10Sent(filmLevel);
     }
@@ -264,15 +252,11 @@ class RibbonWarning extends _$RibbonWarning {
     // 20% 미만 체크 (다른 경고와 독립적으로 실행)
     if (ribbonLevel <= 20 && !state.isSentUnder20Ribbon) {
       SlackLogService().sendBroadcastLogToSlack(WarningKey.printerRibonR20.key);
-      SlackLogService().sendRibbonFilmWarningLog(
-          '*[MachineId : $machineId]* INFO: Ribbon level is ${ribbonLevel.toInt()}% (under 20%), please check the printer');
       setRibbonUnder20Sent(ribbonLevel);
     }
 
     if (filmLevel <= 20 && !state.isSentUnder20Film) {
       SlackLogService().sendBroadcastLogToSlack(WarningKey.printerFilmR20.key);
-      SlackLogService().sendRibbonFilmWarningLog(
-          '*[MachineId : $machineId]* INFO: Film level is ${filmLevel.toInt()}% (under 20%), please check the printer');
       setFilmUnder20Sent(filmLevel);
     }
   }

--- a/lib/presentation/print/print_process_screen.dart
+++ b/lib/presentation/print/print_process_screen.dart
@@ -129,8 +129,14 @@ class _PrintProcessScreenState extends ConsumerState<PrintProcessScreen> with Si
               return;
             }
 
-            // 환불 알럿
-            await DialogHelper.showAutoRefundDescriptionDialog(context, onButtonPressed: () async {
+            final result = await DialogHelper.showKioskDialog(
+              context,
+              title: LocaleKeys.alert_title_auto_refund_alert.tr(),
+              contentText: LocaleKeys.alert_txt_auto_refund_alert.tr(),
+              confirmButtonText: LocaleKeys.alert_btn_paymentcard_failure.tr(),
+            );
+
+            if (result) {
               // 에러 발생 시 환불 처리
               await refund();
 
@@ -141,19 +147,19 @@ class _PrintProcessScreenState extends ConsumerState<PrintProcessScreen> with Si
               if (checkCardFeederIsEmpty(errorMessage)) {
                 await DialogHelper.showPrintCardRefillDialog(
                   context,
-                  onButtonPressed: () {
-                    HomeRouteData().go(context);
-                  },
                 );
+                if (result) {
+                  HomeRouteData().go(context);
+                }
               } else {
-                await DialogHelper.showPrintErrorDialog(
+                final result = await DialogHelper.showPrintErrorDialog(
                   context,
-                  onButtonPressed: () {
-                    HomeRouteData().go(context);
-                  },
                 );
+                if (result) {
+                  HomeRouteData().go(context);
+                }
               }
-            });
+            }
           },
           loading: () => null,
           data: (_) async {

--- a/lib/presentation/print/print_process_screen.dart
+++ b/lib/presentation/print/print_process_screen.dart
@@ -39,7 +39,8 @@ class _PrintProcessScreenState extends ConsumerState<PrintProcessScreen> with Si
 
     // 단면(약 30초) / 양면(약 60초) 기준으로 99%까지 부드럽게 증가
     final pagePrintType = ref.read(pagePrintProvider);
-    final seconds = pagePrintType == PagePrintType.double ? 60 : 30;
+    final isMetal = ref.read(kioskInfoServiceProvider)?.isMetal ?? false;
+    final seconds = pagePrintType == PagePrintType.double ? (isMetal ? 68 : 60) : (isMetal ? 35 : 30);
     _progressController.duration = Duration(seconds: seconds);
 
     // 0% -> 99% (0.99)까지 선형으로 진행

--- a/lib/presentation/setup/kiosk_info_screen.dart
+++ b/lib/presentation/setup/kiosk_info_screen.dart
@@ -26,6 +26,7 @@ class KioskInfoScreen extends ConsumerWidget {
             final result = await DialogHelper.showSetupDialog(
               context,
               title: '메인페이지로 이동합니다.',
+              showCancelButton: true,
             );
             if (result) {
               Navigator.pop(context);
@@ -39,22 +40,30 @@ class KioskInfoScreen extends ConsumerWidget {
         actions: [
           IconButton(
             onPressed: () async {
+              // NOTE: ref는 build 동안에만 안전하게 사용할 수 있으므로,
+              // 비동기 갭(첫 await) 이전에 필요한 의존성을 모두 read 해둔다.
+              final deviceUuidFuture = ref.read(deviceUuidProvider.future);
+              final kioskInfoNotifier = ref.read(kioskInfoServiceProvider.notifier);
+              final kioskRepository = ref.read(kioskRepositoryProvider);
+
               String? value = await DialogHelper.showKeypadDialog(context, mode: ModeType.event);
 
               if (value == null || value.isEmpty) return; // 값이 없으면 종료
 
-              final result = await DialogHelper.showSetupDialog(context, title: '최신 이벤트로 새로고침 됩니다.');
+              final result =
+                  await DialogHelper.showSetupDialog(context, title: '최신 이벤트로 새로고침 됩니다.', showCancelButton: true);
               if (result == true) {
                 final machineId = int.parse(value);
-                final deviceUUID = await ref.read(deviceUuidProvider.future);
-                await ref.read(kioskInfoServiceProvider.notifier).refreshWithMachineId(machineId);
+                final deviceUUID = await deviceUuidFuture;
 
-                await ref.read(kioskRepositoryProvider).createUniqueKeyHistory(
-                      request: UniqueKeyRequest(
-                        machineId: machineId.toString(),
-                        uniqueKey: deviceUUID,
-                      ),
-                    );
+                await kioskInfoNotifier.refreshWithMachineId(machineId);
+
+                await kioskRepository.createUniqueKeyHistory(
+                  request: UniqueKeyRequest(
+                    machineId: machineId.toString(),
+                    uniqueKey: deviceUUID,
+                  ),
+                );
 
                 SlackLogService().sendBroadcastLogToSlack(InfoKey.inspectionStart.key);
               }

--- a/lib/presentation/setup/kiosk_info_screen.dart
+++ b/lib/presentation/setup/kiosk_info_screen.dart
@@ -1,10 +1,12 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_screenutil/flutter_screenutil.dart';
+import 'package:flutter_snaptag_kiosk/core/data/models/request/unique_key_request.dart';
 import 'package:flutter_snaptag_kiosk/lib.dart';
 import 'package:flutter_snaptag_kiosk/core/ui/widget/dialog_helper.dart';
 import 'package:flutter_snaptag_kiosk/core/ui/widget/kiosk_info_widget.dart';
 import 'package:flutter_snaptag_kiosk/presentation/kiosk_shell/kiosk_info_service.dart';
+import 'package:flutter_snaptag_kiosk/presentation/setup/uuid_provider.dart';
 import 'package:flutter_svg/flutter_svg.dart';
 
 class KioskInfoScreen extends ConsumerWidget {
@@ -43,7 +45,17 @@ class KioskInfoScreen extends ConsumerWidget {
 
               final result = await DialogHelper.showSetupDialog(context, title: '최신 이벤트로 새로고침 됩니다.');
               if (result == true) {
-                await ref.read(kioskInfoServiceProvider.notifier).refreshWithMachineId(int.parse(value));
+                final machineId = int.parse(value);
+                final deviceUUID = await ref.read(deviceUuidProvider.future);
+                await ref.read(kioskInfoServiceProvider.notifier).refreshWithMachineId(machineId);
+
+                await ref.read(kioskRepositoryProvider).createUniqueKeyHistory(
+                      request: UniqueKeyRequest(
+                        machineId: machineId.toString(),
+                        uniqueKey: deviceUUID,
+                      ),
+                    );
+
                 SlackLogService().sendBroadcastLogToSlack(InfoKey.inspectionStart.key);
               }
             },

--- a/lib/presentation/setup/payment_history_screen.dart
+++ b/lib/presentation/setup/payment_history_screen.dart
@@ -67,6 +67,7 @@ class _PaymentHistoryScreenState extends ConsumerState<PaymentHistoryScreen> {
                 final result = await DialogHelper.showSetupDialog(
                   context,
                   title: '메인페이지로 이동합니다.',
+                  showCancelButton: true,
                 );
                 if (result) {
                   Navigator.pop(context);
@@ -318,6 +319,7 @@ class _PaymentHistoryScreenState extends ConsumerState<PaymentHistoryScreen> {
                 final result1 = await DialogHelper.showSetupDialog(
                   context,
                   title: '환불을 진행합니다.',
+                  showCancelButton: true,
                 );
                 if (!result1) {
                   context.loaderOverlay.hide();
@@ -361,6 +363,7 @@ class _PaymentHistoryScreenState extends ConsumerState<PaymentHistoryScreen> {
                 final result1 = await DialogHelper.showSetupDialog(
                   context,
                   title: '환불을 진행합니다.',
+                  showCancelButton: true,
                 );
                 if (!result1) {
                   context.loaderOverlay.hide();

--- a/lib/presentation/setup/payment_history_screen.dart
+++ b/lib/presentation/setup/payment_history_screen.dart
@@ -330,6 +330,7 @@ class _PaymentHistoryScreenState extends ConsumerState<PaymentHistoryScreen> {
                   title: '결제한 카드를 삽입해 주세요.',
                   cancelButtonText: '환불 취소',
                   confirmButtonText: '환불 진행',
+                  showCancelButton: true,
                 );
                 if (result2) {
                   await ref.read(setupRefundProcessProvider.notifier).startRefund(order);
@@ -374,6 +375,7 @@ class _PaymentHistoryScreenState extends ConsumerState<PaymentHistoryScreen> {
                   title: '결제한 카드를 삽입해 주세요.',
                   cancelButtonText: '환불 취소',
                   confirmButtonText: '환불 진행',
+                  showCancelButton: true,
                 );
                 if (result2) {
                   await ref.read(setupRefundProcessProvider.notifier).startRefund(order);

--- a/lib/presentation/setup/setup_main_screen.dart
+++ b/lib/presentation/setup/setup_main_screen.dart
@@ -158,8 +158,6 @@ class _SetupMainScreenState extends ConsumerState<SetupMainScreen> {
     final machineId = ref.read(kioskInfoServiceProvider)?.kioskMachineId ?? 0;
     final kioskEventId = ref.read(kioskInfoServiceProvider)?.kioskEventId ?? 0;
     final cardCountState = ref.read(cardCountProvider);
-    final deviceUUID = await ref.read(deviceUuidProvider.future);
-    final getInfoByKey = ref.read(kioskInfoServiceProvider.notifier).getInfoByKey;
 
     await ref.read(printerServiceProvider.notifier).printerStateLog();
 
@@ -168,15 +166,6 @@ class _SetupMainScreenState extends ConsumerState<SetupMainScreen> {
           machineId: machineId,
           remainingSingleSidedCount: cardCountState.remainingSingleSidedCount,
         );
-
-    if (!getInfoByKey) {
-      await ref.read(kioskRepositoryProvider).createUniqueKeyHistory(
-            request: UniqueKeyRequest(
-              machineId: machineId.toString(),
-              uniqueKey: deviceUUID,
-            ),
-          );
-    }
 
     SlackLogService()
         .sendLogToSlack('machineId:$machineId, currentVersion:$currentVersion, latestVersion:$latestVersion');

--- a/lib/presentation/setup/setup_main_screen.dart
+++ b/lib/presentation/setup/setup_main_screen.dart
@@ -172,7 +172,7 @@ class _SetupMainScreenState extends ConsumerState<SetupMainScreen> {
     if (!getInfoByKey) {
       await ref.read(kioskRepositoryProvider).createUniqueKeyHistory(
             request: UniqueKeyRequest(
-              kioskMachineId: machineId.toString(),
+              machineId: machineId.toString(),
               uniqueKey: deviceUUID,
             ),
           );

--- a/lib/presentation/setup/setup_main_screen.dart
+++ b/lib/presentation/setup/setup_main_screen.dart
@@ -77,7 +77,6 @@ class _SetupMainScreenState extends ConsumerState<SetupMainScreen> {
     if (!isReady) return;
 
     final isPaymentDeviceReady = await _checkPaymentDevice();
-
     if (!isPaymentDeviceReady) return;
 
     final kioskInfo = ref.read(kioskInfoServiceProvider);
@@ -185,17 +184,17 @@ class _SetupMainScreenState extends ConsumerState<SetupMainScreen> {
     }
 
     HomeRouteData().go(context);
+
+    SlackLogService().sendInspectionEndBroadcastLogToSlack(InfoKey.inspectionEnd.key, isPaymentOn: true);
   }
 
   Future<bool> _checkPaymentDevice() async {
     try {
       final response = await ref.read(paymentRepositoryProvider).check();
-      SlackLogService().sendInspectionEndBroadcastLogToSlack(InfoKey.inspectionEnd.key, isPaymentOn: true);
       SlackLogService().sendLogToSlack("Payment Device check: $response");
 
       return true;
     } catch (e) {
-      SlackLogService().sendInspectionEndBroadcastLogToSlack(InfoKey.inspectionEnd.key, isPaymentOn: false);
       SlackLogService().sendErrorLogToSlack("Payment Device check: $e");
 
       DialogHelper.showSetupDialog(
@@ -559,11 +558,13 @@ class _SetupMainScreenState extends ConsumerState<SetupMainScreen> {
                         buttonName: '업데이트',
                         isActive: isUpdateAvailable,
                         onUpdatePressed: () async {
-                          final result = await DialogHelper.showKioskDialog(context, null,
-                              title: '업데이트 하시겠습니까?',
-                              contentText: '업데이트 시 앱이 재시작 됩니다.',
-                              cancelButtonText: '취소',
-                              confirmButtonText: '완료');
+                          final result = await DialogHelper.showKioskDialog(
+                            context,
+                            title: '업데이트 하시겠습니까?',
+                            contentText: '업데이트 시 앱이 재시작 됩니다.',
+                            cancelButtonText: '취소',
+                            confirmButtonText: '완료',
+                          );
                           if (result) {
                             try {
                               final launcherPath = await LauncherPathUtil.getLauncherPath();

--- a/lib/presentation/verification/code_verification_screen.dart
+++ b/lib/presentation/verification/code_verification_screen.dart
@@ -103,11 +103,14 @@ class CodeVerificationScreen extends ConsumerWidget {
       case 409:
         //KioskBackPhotoCardStatus.REFUNDED_FAILED_BEFORE_PRINTED
         final orderDto = data?['res']['order'];
-        final result = await DialogHelper.showTwoButtonKioskDialog(context, context.dialogButtonStyle,
-            title: LocaleKeys.alert_title_refund_info.tr(),
-            contentText: LocaleKeys.alert_txt_refund_info.tr(),
-            cancelButtonText: LocaleKeys.alert_btn_cancel.tr(),
-            confirmButtonText: LocaleKeys.alert_btn_ok.tr());
+        final result = await DialogHelper.showKioskDialog(
+          context,
+          title: LocaleKeys.alert_title_refund_info.tr(),
+          contentText: LocaleKeys.alert_txt_refund_info.tr(),
+          cancelButtonText: LocaleKeys.alert_btn_cancel.tr(),
+          confirmButtonText: LocaleKeys.alert_btn_ok.tr(),
+          confirmButtonStyle: context.dialogButtonStyle,
+        );
         if (result) {
           if (orderDto != null) {
             final order = OrderErrorEntity.fromJson(orderDto);


### PR DESCRIPTION
## 📌 작업 개요
- 결제/환불 및 설정 화면의 다이얼로그 공통화 및 안정성 개선
- KSCAT 결제 포트 설정을 `config.ini` 기반으로 자동 인식하도록 수정
- 환불 이력/키오스크 설정 화면에서 비정상 `context` 접근으로 인한 크래시 방지

## 🔍 변경 사항

### ✨ 주요 기능 추가
- `C:\KSCAT\config.ini`의 `[daemon] webport`를 읽어 결제 요청용 `baseUrl`을 자동 설정하도록 구현  
  - `PaymentApiClient`가 최초 1회 INI를 읽고, 실패 시 기본 포트(27098)로 fallback

- 장애인 접근성 대응 정리를 위한 문서 추가  
  - `docs/장차법_키오스크_접근성_체크리스트.md`: 장차법 시행령/과기부 검증기준 기반 키오스크 접근성 체크리스트

### 🔧 버그 수정 및 개선
- **다이얼로그 공통화 및 안정성**
  - `DialogHelper`  
    - `showSetupDialog`, `showKioskDialog`의 중복 레이아웃을 `_showConfirmDialog`로 공통화  
    - 다이얼로그 builder에서 `context.locale` 대신 `dialogContext.locale`을 사용하여 deactivated 위젯 조상 조회 에러 방지  
    - `Navigator.of(dialogContext).pop(true/false)`로 일관되게 다이얼로그 종료 & 결과 반환

- **결제/환불 흐름 안정화**
  - `PaymentHistoryScreen`  
    - `ref.listen(setupRefundProcessProvider, …)` 콜백에서 `context.loaderOverlay` / 다이얼로그 호출 전 `if (!mounted) return;` 가드 추가  
    - 화면이 닫힌 뒤 들어오는 응답으로 인한 “Looking up a deactivated widget's ancestor” 크래시 방지
  - `SetupRefundProcess`  
    - 환불 요청 시 `originalApprovalDate`는 `order.completedAt`을 `DateFormat('yyMMdd')`로 포맷만 하도록 유지 (별도 시간 조작 없음, 로직 명확화)

- **설정/키오스크 화면 개선**
  - `KioskInfoScreen`  
    - `onPressed` 콜백 내에서 첫 `await` 이전에 `deviceUuidFuture`, `kioskInfoNotifier`, `kioskRepository`를 미리 `ref.read`  
    - 위젯 dispose 이후 `ref` 사용으로 인한 `Bad state: Cannot use "ref" after the widget was disposed` 에러 방지
  - `SetupMainScreen`  
    - 업데이트 다이얼로그 호출 시 `DialogHelper.showKioskDialog`에 잘못 전달되던 두 번째 위치 인자 제거 (`context`만 위치 인자로 사용)

- **기타 정리**
  - `DialogHelper`에서 사용하지 않는 `go_router` import 제거

### 📝 다국어 지원 추가
- 공통 뒤로가기 버튼 문구 키 추가 (다른 브랜치 작업과 함께 쓰일 가능성 있어 포함)
  - `LocaleKeys.common_btn_back`
    - ko: `뒤로가기`
    - en: `back`
    - ja: `後戻り`
    - zh: `返回`

### 📦 의존성 추가/변경
- 신규 패키지 추가/변경 없음

## 🧪 테스트 방법

### 1. 설정 > 출력 내역 화면 환불 플로우
1. 키오스크 설정 메뉴에서 **출력 내역(PaymentHistoryScreen)** 진입
2. 환불 가능한 내역 선택 후 관리자가 환불 진행
   - 정상 환불 시: 성공 다이얼로그 → 닫은 뒤 크래시/경고 없는지 확인
   - 실패/에러 시: 실패 다이얼로그 → 화면 전환/뒤로가기 후에도 추가 크래시 없는지 확인

### 2. 설정 > 이벤트/버전 새로고침 & 업데이트 플로우
1. `KioskInfoScreen`에서 이벤트 새로고침 버튼 실행  
   - 다이얼로그 확인 후 **화면을 빠르게 닫은 뒤**에도 에러/크래시 없는지 확인
2. `SetupMainScreen`에서 **업데이트 카드**의 업데이트 버튼 클릭  
   - “업데이트 하시겠습니까?” 다이얼로그 정상 표시  
   - 취소/확인 각각 눌렀을 때 예외 없이 정상 동작하는지 확인

### 3. KSCAT 결제 포트 자동 인식
1. `C:\KSCAT\config.ini`의 `[daemon] webport` 값을 27098 → 27015 등으로 변경
2. 키오스크 앱 재실행 후 결제 시도
   - 설정된 `webport`로 결제 요청이 정상 전송되는지 (KSCAT 로그 또는 툴로 확인)
   - INI 파일 삭제/손상 시 기본 포트(27098)로 fallback 되는지 확인

## 📎 기타 참고 사항

### 브랜치 정보
- **Source Branch**: `feature/spring`
- **Target Branch**: `develop`

### 커밋 히스토리 요약
- fix: KSCAT webport INI 기반 baseUrl 자동 설정
- refactor: DialogHelper 공통 확인/취소 다이얼로그 추출 및 context 사용 안전화
- fix: refund/설정 화면에서 disposed 위젯 context 사용으로 인한 크래시 방지

## 🙏 리뷰 요청 포인트

1. **DialogHelper 리팩터링이 기존 다이얼로그 UX와 완전히 동일하게 동작하는지**
   - 버튼 스타일/여백/문구, 다이얼로그 닫힐 때 반환값(true/false) 흐름 확인 부탁드립니다.

2. **KSCAT INI(webport) 기반 baseUrl 설정 로직**
   - `config.ini` 포맷이 변경되었을 때를 대비한 예외 처리/로그 수준이 적절한지,
   - 운영 환경에서 추가로 고려해야 할 케이스(다른 섹션/키 이름 등)가 있는지 봐주시면 좋겠습니다.

