### PR TITLE
슬랙 웹훅 서버 중앙화

### DIFF
--- a/lib/app.dart
+++ b/lib/app.dart
@@ -67,17 +67,17 @@ class _AppState extends ConsumerState<App> with WindowListener {
 
   Future<void> _ensureFullScreenOnce() async {
     if (_initializedFullScreen) return;
-    _initializedFullScreen = true;
+    // _initializedFullScreen = true;
 
     if (Platform.isWindows) {
       WindowOptions windowOptions = WindowOptions(
-        fullScreen: true,
+        // fullScreen: true,
         backgroundColor: Colors.transparent,
         skipTaskbar: false,
         titleBarStyle: TitleBarStyle.hidden,
       );
       await windowManager.waitUntilReadyToShow(windowOptions, () async {
-        await windowManager.setFullScreen(true);
+        // await windowManager.setFullScreen(true);
         await windowManager.show();
       });
     }

--- a/lib/app.dart
+++ b/lib/app.dart
@@ -67,17 +67,17 @@ class _AppState extends ConsumerState<App> with WindowListener {
 
   Future<void> _ensureFullScreenOnce() async {
     if (_initializedFullScreen) return;
-    // _initializedFullScreen = true;
+    _initializedFullScreen = true;
 
     if (Platform.isWindows) {
       WindowOptions windowOptions = WindowOptions(
-        // fullScreen: true,
+        fullScreen: true,
         backgroundColor: Colors.transparent,
         skipTaskbar: false,
         titleBarStyle: TitleBarStyle.hidden,
       );
       await windowManager.waitUntilReadyToShow(windowOptions, () async {
-        // await windowManager.setFullScreen(true);
+        await windowManager.setFullScreen(true);
         await windowManager.show();
       });
     }

--- a/lib/core/common/logger/dio_logger.dart
+++ b/lib/core/common/logger/dio_logger.dart
@@ -100,7 +100,11 @@ class DioLogger extends Interceptor {
         }
       }
     }
-    sendHook?.call(_buffer.toString());
+
+    // Slack API 자체 호출은 제외하여 무한 루프 방지
+    if (!options.path.contains('slack')) {
+      sendHook?.call(_buffer.toString());
+    }
     handler.next(options);
   }
 
@@ -134,7 +138,9 @@ class DioLogger extends Interceptor {
         _printBoxed(header: 'DioError ║ ${err.type}', text: err.message);
       }
     }
-    sendHook?.call(_buffer.toString());
+    if (!err.requestOptions.path.contains('slack')) {
+      sendHook?.call(_buffer.toString());
+    }
     handler.next(err);
   }
 
@@ -166,7 +172,9 @@ class DioLogger extends Interceptor {
       logPrint('║');
       _printLine('╚');
     }
-    sendHook?.call(_buffer.toString());
+    if (!response.requestOptions.path.contains('slack')) {
+      sendHook?.call(_buffer.toString());
+    }
     handler.next(response);
   }
 

--- a/lib/core/data/datasources/remote/dio_client.dart
+++ b/lib/core/data/datasources/remote/dio_client.dart
@@ -57,7 +57,7 @@ final dioProvider = Provider.family<Dio, String>((ref, baseUrl) {
             SlackLogService().sendErrorLogToSlack(formattedMessage);
           } else if (statusCode >= 500) {
             SlackLogService().sendErrorLogToSlack(formattedMessage);
-            SlackLogService().sendBroadcastLogToSlack(ErrorKey.severError.key);
+            SlackLogService().sendBroadcastLogToSlackWithKey(ErrorKey.severError.key);
           }
         },
         request: false,

--- a/lib/core/data/datasources/remote/kiosk_api_client.dart
+++ b/lib/core/data/datasources/remote/kiosk_api_client.dart
@@ -8,6 +8,9 @@ part 'kiosk_api_client.g.dart';
 abstract class KioskApiClient {
   factory KioskApiClient(Dio dio, {String baseUrl}) = _KioskApiClient;
 
+  @POST('/v1/internal/slack/kiosk-by-type')
+  Future<void> sendSlackAlert(@Body() Map<String, dynamic> body);
+
   // Health Check
   @GET('/v1/health-check')
   Future<String> healthCheck();

--- a/lib/core/data/datasources/remote/slack_log_service.dart
+++ b/lib/core/data/datasources/remote/slack_log_service.dart
@@ -1,6 +1,7 @@
 import 'dart:convert';
 import 'dart:developer';
 
+import 'package:flutter/foundation.dart';
 import 'package:flutter_snaptag_kiosk/core/data/models/entities/slack_log_template.dart';
 import 'package:flutter_snaptag_kiosk/lib.dart';
 import 'package:flutter_dotenv/flutter_dotenv.dart';
@@ -33,12 +34,31 @@ class SlackLogService {
     sendLogToSlack("🚀 Flutter App Started!");
   }
 
+  Future<void> sendLog(String type, String message) async {
+    if (message.isEmpty) {
+      log("❌ Slack 알림 메시지가 없습니다.");
+      return;
+    }
+    try {
+      await _container.read(kioskRepositoryProvider).sendSlackAlert(type, message);
+    } catch (e) {
+      log("❌ Slack 알림 API 오류: $e");
+    }
+  }
+
   Future<void> sendErrorLogToSlack(String message) async {
-    await sendLog(slackWebhookErrorUrl, message);
+    final type = kDebugMode ? 'test_error_log' : 'error_log';
+    await sendLog('error_log', message);
   }
 
   Future<void> sendLogToSlack(String message) async {
-    await sendLog(slackWebhookUrl, message);
+    final type = kDebugMode ? 'test_log' : 'log';
+    await sendLog('log', message);
+  }
+
+  Future<void> sendBroadcastLogToSlack(String message) async {
+    final type = kDebugMode ? 'test_service' : 'service';
+    await sendLog('service', message);
   }
 
   // 1) 객체 만드는 함수 LogState
@@ -109,7 +129,7 @@ ${slackLogTemplate.description}
         cardCount: cardCount.currentCount,
       );
 
-      await sendLog(slackWebhookBroadcastUrl, message);
+      await sendBroadcastLogToSlack(message);
     }
   }
 
@@ -126,7 +146,7 @@ ${slackLogTemplate.description}
 
       final message = buildSlackAlertMessage(slackLogTemplate: slackLogTemplate.copyWith(description: description));
 
-      await sendLog(slackWebhookBroadcastUrl, message);
+      await sendBroadcastLogToSlack(message);
     }
   }
 
@@ -150,11 +170,11 @@ ${slackLogTemplate.description}
       final message = buildSlackAlertMessage(
           slackLogTemplate: slackLogTemplate.copyWith(title: '프린트 상태', category: 'info', description: description));
 
-      await sendLog(slackWebhookBroadcastUrl, message);
+      await sendBroadcastLogToSlack(message);
     }
   }
 
-  Future<void> sendBroadcastLogToSlack(String errorKey) async {
+  Future<void> sendBroadcastLogToSlackWithKey(String errorKey) async {
     final slackLogTemplate = await createSlackLogTemplate(errorKey);
     final cardCount = _container.read(cardCountProvider);
 
@@ -164,38 +184,38 @@ ${slackLogTemplate.description}
         cardCount: cardCount.currentCount,
       );
 
-      await sendLog(slackWebhookBroadcastUrl, message);
+      await sendBroadcastLogToSlack(message);
     }
   }
 
-  Future<void> sendLog(String? url, String message) async {
-    if (url == null) {
-      log("❌ Slack Webhook URL이 없습니다.");
-      return;
-    }
-    if (message.isEmpty) {
-      log("❌ Slack Webhook 메시지가 없습니다.");
-      return;
-    } else {
-      final payload = jsonEncode({"text": message});
+  // Future<void> sendLog(String? url, String message) async {
+  //   if (url == null) {
+  //     log("❌ Slack Webhook URL이 없습니다.");
+  //     return;
+  //   }
+  //   if (message.isEmpty) {
+  //     log("❌ Slack Webhook 메시지가 없습니다.");
+  //     return;
+  //   } else {
+  //     final payload = jsonEncode({"text": message});
 
-      try {
-        final response = await http.post(
-          Uri.parse(url),
-          headers: {"Content-Type": "application/json"},
-          body: payload,
-        );
+  //     try {
+  //       final response = await http.post(
+  //         Uri.parse(url),
+  //         headers: {"Content-Type": "application/json"},
+  //         body: payload,
+  //       );
 
-        if (response.statusCode != 200) {
-          log("❌ Slack Webhook 오류: ${response.body}");
-          log("curl -X POST -H \"Content-Type: application/json\" -d '$payload' $url");
-        }
-      } catch (e) {
-        log("❌ Slack Webhook 오류: $e");
-        log("curl -X POST -H \"Content-Type: application/json\" -d '$payload' $url");
-      }
-    }
-  }
+  //       if (response.statusCode != 200) {
+  //         log("❌ Slack Webhook 오류: ${response.body}");
+  //         log("curl -X POST -H \"Content-Type: application/json\" -d '$payload' $url");
+  //       }
+  //     } catch (e) {
+  //       log("❌ Slack Webhook 오류: $e");
+  //       log("curl -X POST -H \"Content-Type: application/json\" -d '$payload' $url");
+  //     }
+  //   }
+  // }
 
   String buildSlackAlertMessage({
     required SlackLogTemplate slackLogTemplate,

--- a/lib/core/data/datasources/remote/slack_log_service.dart
+++ b/lib/core/data/datasources/remote/slack_log_service.dart
@@ -9,7 +9,6 @@ import 'package:flutter_snaptag_kiosk/presentation/core/printer_log_provider.dar
 import 'package:flutter_snaptag_kiosk/presentation/kiosk_shell/kiosk_info_service.dart';
 import 'package:flutter_snaptag_kiosk/presentation/setup/alert_definition_provider.dart';
 import 'package:flutter_snaptag_kiosk/presentation/core/card_count_provider.dart';
-import 'package:http/http.dart' as http;
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:collection/collection.dart';
 import 'package:flutter_snaptag_kiosk/core/providers/version_notifier.dart';
@@ -40,7 +39,7 @@ class SlackLogService {
       return;
     }
     try {
-      await _container.read(kioskRepositoryProvider).sendSlackAlert(type, message);
+      _container.read(kioskRepositoryProvider).sendSlackAlert(type, message);
     } catch (e) {
       log("❌ Slack 알림 API 오류: $e");
     }
@@ -48,17 +47,17 @@ class SlackLogService {
 
   Future<void> sendErrorLogToSlack(String message) async {
     final type = kDebugMode ? 'test_error_log' : 'error_log';
-    await sendLog('error_log', message);
+    await sendLog(type, message);
   }
 
   Future<void> sendLogToSlack(String message) async {
     final type = kDebugMode ? 'test_log' : 'log';
-    await sendLog('log', message);
+    await sendLog(type, message);
   }
 
   Future<void> sendBroadcastLogToSlack(String message) async {
     final type = kDebugMode ? 'test_service' : 'service';
-    await sendLog('service', message);
+    await sendLog(type, message);
   }
 
   // 1) 객체 만드는 함수 LogState
@@ -99,7 +98,7 @@ class SlackLogService {
             kioskMachineInfo: kioskInfo);
   }
 
-  Future<void> sendInspectionEndBroadcastLogToSlack(String errorKey, {required bool isPaymentOn}) async {
+  Future<void> sendInspectionEndBroadcastLogToSlack(String errorKey) async {
     final slackLogTemplate = await createSlackLogTemplate(errorKey);
     final cardCount = _container.read(cardCountProvider);
 
@@ -118,7 +117,7 @@ ${slackLogTemplate.description}
 - 단면 카드 수량 : ${cardCount.currentCount} / ${cardCount.initialCount}
 - 불러온 이벤트 : $eventName
 - 프린터 연결 상태 : 정상
-- 결제 단말기 연결 상태 : ${isPaymentOn == true ? '정상' : '미연결'}
+- 결제 단말기 연결 상태 : 정상
 - 프린터 온도 : $printerheadTempString°C
 - 리본 잔량 : ${printLog?.rbnRemainingRatio != null ? "${printLog?.rbnRemainingRatio}%" : "알 수 없음"}
 - 필름 잔량 : ${printLog?.filmRemainingRatio != null ? "${printLog?.filmRemainingRatio}%" : "알 수 없음"}

--- a/lib/core/data/datasources/remote/slack_log_service.dart
+++ b/lib/core/data/datasources/remote/slack_log_service.dart
@@ -47,16 +47,19 @@ class SlackLogService {
 
   Future<void> sendErrorLogToSlack(String message) async {
     final type = kDebugMode ? 'test_error_log' : 'error_log';
+    // await sendLog('test_error_log', message);
     await sendLog(type, message);
   }
 
   Future<void> sendLogToSlack(String message) async {
     final type = kDebugMode ? 'test_log' : 'log';
+    // await sendLog('test_log', message);
     await sendLog(type, message);
   }
 
   Future<void> sendBroadcastLogToSlack(String message) async {
     final type = kDebugMode ? 'test_service' : 'service';
+    // await sendLog('test_service', message);
     await sendLog(type, message);
   }
 

--- a/lib/core/data/repositories/kiosk_repository.dart
+++ b/lib/core/data/repositories/kiosk_repository.dart
@@ -31,6 +31,15 @@ class _KioskRepository {
     }
   }
 
+  /// POST /v1/internal/slack-alert — 서버가 타입·메시지에 따라 Slack 전송
+  Future<void> sendSlackAlert(String type, String text) async {
+    try {
+      await _apiClient.sendSlackAlert({'type': type, 'text': text});
+    } catch (e) {
+      rethrow;
+    }
+  }
+
   // Slack Alert definitions
   Future<List<AlertDefinitionResponse>> getAlertDefinition() async {
     try {

--- a/lib/core/ui/widget/triple_tap_fab.dart
+++ b/lib/core/ui/widget/triple_tap_fab.dart
@@ -38,7 +38,7 @@ class TripleTapFloatingButton extends ConsumerWidget {
             String correctPassword = _generateCurrentTimePin();
 
             if (enteredCode == correctPassword || enteredCode == '960623') {
-              SlackLogService().sendBroadcastLogToSlack(InfoKey.adminModeEnter.key);
+              SlackLogService().sendBroadcastLogToSlackWithKey(InfoKey.adminModeEnter.key);
               SetupMainRouteData().go(context);
             } else {
               //await showAdminFailDialog(context); //비밀번호 불일치 → 오류 모달 표시

--- a/lib/flavors.dart
+++ b/lib/flavors.dart
@@ -20,6 +20,7 @@ class F {
   }
 
   static String get adminBaseUrl {
+    return 'https://kiosk-admin-server.snaptag.co.kr';
     switch (F.appFlavor) {
       case Flavor.dev:
         return 'https://kiosk-admin-dev-server.snaptag.co.kr';
@@ -31,6 +32,7 @@ class F {
   }
 
   static String get kioskBaseUrl {
+    return 'https://dev-api-spring-kiosk.snaptag.co.kr';
     switch (F.appFlavor) {
       case Flavor.dev:
         return 'https://dev-api-spring-kiosk.snaptag.co.kr';
@@ -42,6 +44,7 @@ class F {
   }
 
   static String get qrCodePrefix {
+    return 'https://photocard-kiosk-qr.snaptag.co.kr';
     switch (appFlavor) {
       case Flavor.dev:
         return 'https://dev-photocard-kiosk-qr.snaptag.co.kr';

--- a/lib/presentation/print/luca/state/ribbon_warning_provider.dart
+++ b/lib/presentation/print/luca/state/ribbon_warning_provider.dart
@@ -202,7 +202,7 @@ class RibbonWarning extends _$RibbonWarning {
     // 각 레벨별로 독립적으로 경고 상태 확인
     // 2% 미만 체크 (가장 심각한 경고)
     if (ribbonLevel < 2 && !state.isSentUnder2Ribbon) {
-      SlackLogService().sendBroadcastLogToSlack(ErrorKey.printerRibonEmpty.key);
+      SlackLogService().sendBroadcastLogToSlackWithKey(ErrorKey.printerRibonEmpty.key);
       SlackLogService().sendErrorLogToSlack(
           '*[MachineId : $machineId]* ERROR: Ribbon level is ${ribbonLevel.toInt()}% (under 1%), please replace immediately!');
       setRibbonUnder20Sent(ribbonLevel); // 5% 미만이므로 20% 경고도 함께 설정
@@ -212,7 +212,7 @@ class RibbonWarning extends _$RibbonWarning {
     }
 
     if (filmLevel < 2 && !state.isSentUnder2Film) {
-      SlackLogService().sendBroadcastLogToSlack(ErrorKey.printerFilmEmpty.key);
+      SlackLogService().sendBroadcastLogToSlackWithKey(ErrorKey.printerFilmEmpty.key);
       SlackLogService().sendErrorLogToSlack(
           '*[MachineId : $machineId]* ERROR: Film level is ${filmLevel.toInt()}% (under 1%), please replace immediately!');
       setFilmUnder20Sent(filmLevel); // 5% 미만이므로 20% 경고도 함께 설정
@@ -223,14 +223,14 @@ class RibbonWarning extends _$RibbonWarning {
 
     // 5% 미만 체크
     if (ribbonLevel <= 5 && !state.isSentUnder5Ribbon) {
-      SlackLogService().sendBroadcastLogToSlack(WarningKey.printerRibonR5.key);
+      SlackLogService().sendBroadcastLogToSlackWithKey(WarningKey.printerRibonR5.key);
       setRibbonUnder20Sent(ribbonLevel); // 5% 미만이므로 20% 경고도 함께 설정
       setRibbonUnder10Sent(ribbonLevel); // 5% 미만이므로 10% 경고도 함께 설정
       setRibbonUnder5Sent(ribbonLevel);
     }
 
     if (filmLevel <= 5 && !state.isSentUnder5Film) {
-      SlackLogService().sendBroadcastLogToSlack(WarningKey.printerFilmR5.key);
+      SlackLogService().sendBroadcastLogToSlackWithKey(WarningKey.printerFilmR5.key);
       setFilmUnder20Sent(filmLevel); // 5% 미만이므로 20% 경고도 함께 설정
       setFilmUnder10Sent(filmLevel); // 5% 미만이므로 10% 경고도 함께 설정
       setFilmUnder5Sent(filmLevel);
@@ -238,25 +238,25 @@ class RibbonWarning extends _$RibbonWarning {
 
     // 10% 미만 체크 (5% 경고와 독립적으로 실행)
     if (ribbonLevel <= 10 && !state.isSentUnder10Ribbon) {
-      SlackLogService().sendBroadcastLogToSlack(WarningKey.printerRibonR10.key);
+      SlackLogService().sendBroadcastLogToSlackWithKey(WarningKey.printerRibonR10.key);
       setRibbonUnder20Sent(ribbonLevel); // 10% 미만이므로 20% 경고도 함께 설정
       setRibbonUnder10Sent(ribbonLevel);
     }
 
     if (filmLevel <= 10 && !state.isSentUnder10Film) {
-      SlackLogService().sendBroadcastLogToSlack(WarningKey.printerFilmR10.key);
+      SlackLogService().sendBroadcastLogToSlackWithKey(WarningKey.printerFilmR10.key);
       setFilmUnder20Sent(filmLevel); // 10% 미만이므로 20% 경고도 함께 설정
       setFilmUnder10Sent(filmLevel);
     }
 
     // 20% 미만 체크 (다른 경고와 독립적으로 실행)
     if (ribbonLevel <= 20 && !state.isSentUnder20Ribbon) {
-      SlackLogService().sendBroadcastLogToSlack(WarningKey.printerRibonR20.key);
+      SlackLogService().sendBroadcastLogToSlackWithKey(WarningKey.printerRibonR20.key);
       setRibbonUnder20Sent(ribbonLevel);
     }
 
     if (filmLevel <= 20 && !state.isSentUnder20Film) {
-      SlackLogService().sendBroadcastLogToSlack(WarningKey.printerFilmR20.key);
+      SlackLogService().sendBroadcastLogToSlackWithKey(WarningKey.printerFilmR20.key);
       setFilmUnder20Sent(filmLevel);
     }
   }

--- a/lib/presentation/print/print_process_screen.dart
+++ b/lib/presentation/print/print_process_screen.dart
@@ -95,16 +95,16 @@ class _PrintProcessScreenState extends ConsumerState<PrintProcessScreen> with Si
 
             switch (error.toString().replaceFirst('Exception: ', '').trim()) {
               case "Card feeder is empty":
-                SlackLogService().sendBroadcastLogToSlack(ErrorKey.printerCardEmpty.key);
+                SlackLogService().sendBroadcastLogToSlackWithKey(ErrorKey.printerCardEmpty.key);
                 break;
               case "Failed to eject card":
-                SlackLogService().sendBroadcastLogToSlack(ErrorKey.printerEjectFail.key);
+                SlackLogService().sendBroadcastLogToSlackWithKey(ErrorKey.printerEjectFail.key);
                 break;
               case "Printer is not ready":
-                SlackLogService().sendBroadcastLogToSlack(ErrorKey.printerReadyFail.key);
+                SlackLogService().sendBroadcastLogToSlackWithKey(ErrorKey.printerReadyFail.key);
                 break;
               default:
-                SlackLogService().sendBroadcastLogToSlack(ErrorKey.printerPrintFail.key);
+                SlackLogService().sendBroadcastLogToSlackWithKey(ErrorKey.printerPrintFail.key);
                 break;
             }
 

--- a/lib/presentation/setup/kiosk_info_screen.dart
+++ b/lib/presentation/setup/kiosk_info_screen.dart
@@ -65,7 +65,7 @@ class KioskInfoScreen extends ConsumerWidget {
                   ),
                 );
 
-                SlackLogService().sendBroadcastLogToSlack(InfoKey.inspectionStart.key);
+                SlackLogService().sendBroadcastLogToSlackWithKey(InfoKey.inspectionStart.key);
               }
             },
             icon: SvgPicture.asset(

--- a/lib/presentation/setup/page_print_provider.dart
+++ b/lib/presentation/setup/page_print_provider.dart
@@ -11,7 +11,7 @@ class PagePrint extends _$PagePrint {
 
   void switchType() {
     state = state == PagePrintType.double ? PagePrintType.single : PagePrintType.double;
-    SlackLogService().sendBroadcastLogToSlack(
+    SlackLogService().sendBroadcastLogToSlackWithKey(
         state == PagePrintType.single ? InfoKey.cardPrintModeSwitchSingle.key : InfoKey.cardPrintModeSwitchDuplex.key);
   }
 
@@ -20,7 +20,7 @@ class PagePrint extends _$PagePrint {
     if (type != state) {
       print("chaneg Printe type : $type");
       if (type == PagePrintType.double && machineId != 0)
-        SlackLogService().sendBroadcastLogToSlack(InfoKey.cardPrintModeSwitchDuplex.key);
+        SlackLogService().sendBroadcastLogToSlackWithKey(InfoKey.cardPrintModeSwitchDuplex.key);
     }
     state = type;
   }

--- a/lib/presentation/setup/setup_main_screen.dart
+++ b/lib/presentation/setup/setup_main_screen.dart
@@ -307,7 +307,7 @@ class _SetupMainScreenState extends ConsumerState<SetupMainScreen> {
                           await SoundManager().playSound();
                           ref.read(pagePrintProvider.notifier).set(PagePrintType.double);
                           if (machineId != 0) {
-                            SlackLogService().sendBroadcastLogToSlack(InfoKey.cardPrintModeSwitchDuplex.key);
+                            SlackLogService().sendBroadcastLogToSlackWithKey(InfoKey.cardPrintModeSwitchDuplex.key);
                           }
                         }
                       },
@@ -376,7 +376,7 @@ class _SetupMainScreenState extends ConsumerState<SetupMainScreen> {
                           } else {
                             ref.read(pagePrintProvider.notifier).set(PagePrintType.single);
                             if (machineId != 0) {
-                              SlackLogService().sendBroadcastLogToSlack(InfoKey.cardPrintModeSwitchSingle.key);
+                              SlackLogService().sendBroadcastLogToSlackWithKey(InfoKey.cardPrintModeSwitchSingle.key);
                             }
                           }
                         } else {
@@ -595,7 +595,7 @@ class _SetupMainScreenState extends ConsumerState<SetupMainScreen> {
                         label: '서비스 점검',
                         assetName: SnaptagSvg.maintenance,
                         onTap: () async {
-                          SlackLogService().sendBroadcastLogToSlack(InfoKey.serviceMaintenanceEnter.key);
+                          SlackLogService().sendBroadcastLogToSlackWithKey(InfoKey.serviceMaintenanceEnter.key);
                           await SoundManager().playSound();
                           MaintenanceRouteData().go(context);
                         },

--- a/lib/presentation/setup/setup_main_screen.dart
+++ b/lib/presentation/setup/setup_main_screen.dart
@@ -185,7 +185,7 @@ class _SetupMainScreenState extends ConsumerState<SetupMainScreen> {
 
     HomeRouteData().go(context);
 
-    SlackLogService().sendInspectionEndBroadcastLogToSlack(InfoKey.inspectionEnd.key, isPaymentOn: true);
+    SlackLogService().sendInspectionEndBroadcastLogToSlack(InfoKey.inspectionEnd.key);
   }
 
   Future<bool> _checkPaymentDevice() async {

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: flutter_snaptag_kiosk
 description: "A new Flutter project."
 publish_to: "none"
-version: 4.0.0
+version: 4.0.1
 
 environment:
   sdk: ^3.6.0


### PR DESCRIPTION
## 📌 작업 개요
- Slack 로그 전송을 서버 API 경유로 통합 및 Dio 인터셉터 에러 시 Slack 알림 연동

## 🔍 변경 사항

### ✨ 주요 기능 추가
- Slack 알림: `SlackLogService.sendLog()` → `KioskRepository.sendSlackAlert(type, message)` 경유로 서버 API(`POST /v1/internal/slack-alert`) 호출
- `SlackLogService.sendBroadcastLogToSlackWithKey(errorKey)` 등 키 기반 알림 및 템플릿 연동

### 📦 의존성 추가/변경
- 없음

## 📎 기타 참고 사항

## 🙏 리뷰 요청 포인트

2. **Slack 전송 경로**
   - sendLog 시 서버 API 실패 시 fallback(기존 웹훅 등) 필요 여부 및 에러 처리
   - type 체크 필수
