### PR TITLE
feat: 단면 모드 카드 수량 0장 시 양면 모드 전환 및 안정성 개선

### DIFF
--- a/lib/core/common/logger/dio_logger.dart
+++ b/lib/core/common/logger/dio_logger.dart
@@ -92,21 +92,20 @@ class DioLogger extends Interceptor {
     if (requestBody && options.method != 'GET') {
       final dynamic data = options.data;
       if (data != null) {
+        logPrint('╔ Body');
+        logPrint('║');
         if (data is Map) {
-          logPrint('╔ Body');
-          logPrint('║');
-          _printPrettyMap(options.data as Map);
-          logPrint('║');
-          _printLine('╚');
-        }
-        if (data is FormData) {
+          _printPrettyMap(data);
+        } else if (data is FormData) {
           final formDataMap = <String, dynamic>{}
             ..addEntries(data.fields)
             ..addEntries(data.files);
-          _printMapAsTable(formDataMap, header: 'Form data | ${data.boundary}');
+          _printPrettyMap(formDataMap);
         } else {
           _printBlock(data.toString());
         }
+        logPrint('║');
+        _printLine('╚');
       }
     }
 

--- a/lib/core/common/logger/dio_logger.dart
+++ b/lib/core/common/logger/dio_logger.dart
@@ -40,6 +40,8 @@ class DioLogger extends Interceptor {
 
   final bool enabled;
 
+  final int? Function()? machineIdProvider;
+
   DioLogger({
     this.request = true,
     this.requestHeader = false,
@@ -52,6 +54,7 @@ class DioLogger extends Interceptor {
     this.filter,
     this.enabled = true,
     this.sendHook,
+    this.machineIdProvider,
   });
 
   @override
@@ -89,7 +92,13 @@ class DioLogger extends Interceptor {
     if (requestBody && options.method != 'GET') {
       final dynamic data = options.data;
       if (data != null) {
-        if (data is Map) _printMapAsTable(options.data as Map?, header: 'Body');
+        if (data is Map) {
+          logPrint('╔ Body');
+          logPrint('║');
+          _printPrettyMap(options.data as Map);
+          logPrint('║');
+          _printLine('╚');
+        }
         if (data is FormData) {
           final formDataMap = <String, dynamic>{}
             ..addEntries(data.fields)
@@ -101,8 +110,10 @@ class DioLogger extends Interceptor {
       }
     }
 
-    // Slack API 자체 호출은 제외하여 무한 루프 방지
-    if (!options.path.contains('slack')) {
+    if (!options.path.contains('slack') &&
+        !options.path.contains('machine/maintenance') &&
+        !options.path.contains('polling') &&
+        !options.path.contains('error-code')) {
       sendHook?.call(_buffer.toString());
     }
     handler.next(options);
@@ -138,7 +149,10 @@ class DioLogger extends Interceptor {
         _printBoxed(header: 'DioError ║ ${err.type}', text: err.message);
       }
     }
-    if (!err.requestOptions.path.contains('slack')) {
+    if (!err.requestOptions.path.contains('slack') &&
+        !err.requestOptions.path.contains('machine/maintenance') &&
+        !err.requestOptions.path.contains('polling') &&
+        !err.requestOptions.path.contains('error-code')) {
       sendHook?.call(_buffer.toString());
     }
     handler.next(err);
@@ -172,7 +186,10 @@ class DioLogger extends Interceptor {
       logPrint('║');
       _printLine('╚');
     }
-    if (!response.requestOptions.path.contains('slack')) {
+    if (!response.requestOptions.path.contains('slack') &&
+        !response.requestOptions.path.contains('machine/maintenance') &&
+        !response.requestOptions.path.contains('polling') &&
+        !response.requestOptions.path.contains('error-code')) {
       sendHook?.call(_buffer.toString());
     }
     handler.next(response);
@@ -206,16 +223,20 @@ class DioLogger extends Interceptor {
   void _printResponseHeader(Response response, int responseTime) {
     final uri = response.requestOptions.uri;
     final method = response.requestOptions.method;
+    final machineId = machineIdProvider?.call();
+    final machineIdSuffix = machineId != null ? ' ║ machineId : $machineId' : '';
     _printBoxed(
         header:
-            'Response ║ $method ║ Status: ${response.statusCode} ${response.statusMessage}  ║ Time: $responseTime ms',
+            'Response ║ $method ║ Status: ${response.statusCode} ${response.statusMessage}  ║ Time: $responseTime ms$machineIdSuffix',
         text: uri.toString());
   }
 
   void _printRequestHeader(RequestOptions options) {
     final uri = options.uri;
     final method = options.method;
-    _printBoxed(header: 'Request ║ $method ', text: uri.toString());
+    final machineId = machineIdProvider?.call();
+    final machineIdSuffix = machineId != null ? ' ║ machineId : $machineId' : '';
+    _printBoxed(header: 'Request ║ $method$machineIdSuffix', text: uri.toString());
   }
 
   void _printLine([String pre = '', String suf = '╝']) => logPrint('$pre${'═' * maxWidth}$suf');

--- a/lib/core/data/datasources/remote/dio_client.dart
+++ b/lib/core/data/datasources/remote/dio_client.dart
@@ -13,6 +13,7 @@ final dioProvider = Provider.family<Dio, String>((ref, baseUrl) {
       sendHook: (log) {
         SlackLogService().sendLogToSlack(log);
       },
+      machineIdProvider: () => ref.read(kioskInfoServiceProvider)?.kioskMachineId,
       request: true,
       requestBody: true));
   dio.interceptors.add(

--- a/lib/core/data/datasources/remote/dio_client.dart
+++ b/lib/core/data/datasources/remote/dio_client.dart
@@ -10,11 +10,11 @@ final dioProvider = Provider.family<Dio, String>((ref, baseUrl) {
     ..options.connectTimeout = const Duration(seconds: 30)
     ..options.receiveTimeout = const Duration(seconds: 30);
   dio.interceptors.add(DioLogger(
-    sendHook: (log) {
-      SlackLogService().sendLogToSlack(log);
-    },
-    request: false,
-  ));
+      sendHook: (log) {
+        SlackLogService().sendLogToSlack(log);
+      },
+      request: true,
+      requestBody: true));
   dio.interceptors.add(
     PrettyDioLogger(
       requestHeader: true,

--- a/lib/core/data/datasources/remote/dio_client.dart
+++ b/lib/core/data/datasources/remote/dio_client.dart
@@ -65,7 +65,8 @@ final dioProvider = Provider.family<Dio, String>((ref, baseUrl) {
       );
 
       // DioLogger를 실제로 실행시켜서 sendHook이 호출되도록 함
-      errorLogger.onError(err, handler);
+      // 로깅 전용 핸들러를 별도로 넘겨서 실제 handler가 중복 호출되는 버그 방지
+      errorLogger.onError(err, ErrorInterceptorHandler());
 
       if (err.response?.data != null) {
         try {

--- a/lib/presentation/payment/payment_service.dart
+++ b/lib/presentation/payment/payment_service.dart
@@ -163,7 +163,7 @@ class PaymentService extends _$PaymentService {
 
   /// 취소된 결제 처리
   Future<void> _handleCancelledPayment(BackPhotoCardResponse backPhoto, PaymentResponse paymentResponse) async {
-    // final response = await _updateOrder(isRefund: false, description: "고객취소");
+    await _updateOrder(isRefund: false, description: "고객취소");
     // SlackLogService().sendLogToSlack("paymentResponse1000 : $response");
 
     // SlackLogService().sendPaymentBroadcastLogToSlak(InfoKey.paymentFail.key,
@@ -331,38 +331,48 @@ class PaymentService extends _$PaymentService {
 
   Future<UpdateOrderResponse> _updateOrder(
       {required bool isRefund, int? orderid, String? photoAuthNumber, String? description}) async {
-    try {
-      final settings = ref.read(kioskInfoServiceProvider);
-      final backPhotoAuthNumber = photoAuthNumber ?? ref.read(verifyPhotoCardProvider).value?.photoAuthNumber; //여기서 예외
-      final approval = ref.read(paymentResponseStateProvider);
-      final orderId = orderid ?? ref.read(createOrderInfoProvider)?.orderId;
-      if (orderId == null) {
-        throw Exception('No order id available');
-      }
-      logger.i(
-          'respCode: ${approval?.respCode} \trespCode: ${approval?.respCode} \nORDER STATUS: ${approval?.orderState}');
-      final OrderStatus defaultStatus = isRefund ? OrderStatus.refunded_failed : OrderStatus.failed;
-      final OrderStatus orderStatus = (isRefund && approval?.orderState == OrderStatus.failed)
-          ? OrderStatus.refunded_failed
-          : approval?.orderState ?? defaultStatus;
-      final request = UpdateOrderRequest(
-        kioskEventId: settings!.kioskEventId,
-        kioskMachineId: settings.kioskMachineId,
-        photoAuthNumber: backPhotoAuthNumber ?? '-',
-        amount: settings.photoCardPrice,
-        status: orderStatus,
-        approvalNumber: approval?.approvalNo ?? '-',
-        purchaseAuthNumber: approval?.approvalNo ?? '-',
-        authSeqNumber: approval?.approvalNo ?? '-',
-        detail: approval?.KSNET ?? '{}',
-        description: description,
-      );
+    const maxRetries = 3;
+    const retryDelay = Duration(milliseconds: 500);
 
-      return await ref.read(kioskRepositoryProvider).updateOrderStatus(orderId.toInt(), request);
-    } catch (e) {
-      SlackLogService().sendLogToSlack('update order error: $e');
-      rethrow;
+    final settings = ref.read(kioskInfoServiceProvider);
+    final backPhotoAuthNumber = photoAuthNumber ?? ref.read(verifyPhotoCardProvider).value?.photoAuthNumber; //여기서 예외
+    final approval = ref.read(paymentResponseStateProvider);
+    final orderId = orderid ?? ref.read(createOrderInfoProvider)?.orderId;
+    if (orderId == null) {
+      throw Exception('No order id available');
     }
+    logger
+        .i('respCode: ${approval?.respCode} \trespCode: ${approval?.respCode} \nORDER STATUS: ${approval?.orderState}');
+    final OrderStatus defaultStatus = isRefund ? OrderStatus.refunded_failed : OrderStatus.failed;
+    final OrderStatus orderStatus = (isRefund && approval?.orderState == OrderStatus.failed)
+        ? OrderStatus.refunded_failed
+        : approval?.orderState ?? defaultStatus;
+    final request = UpdateOrderRequest(
+      kioskEventId: settings!.kioskEventId,
+      kioskMachineId: settings.kioskMachineId,
+      photoAuthNumber: backPhotoAuthNumber ?? '-',
+      amount: settings.photoCardPrice,
+      status: orderStatus,
+      approvalNumber: approval?.approvalNo ?? '-',
+      purchaseAuthNumber: approval?.approvalNo ?? '-',
+      authSeqNumber: approval?.approvalNo ?? '-',
+      detail: approval?.KSNET ?? '{}',
+      description: description,
+    );
+
+    for (int attempt = 1; attempt <= maxRetries; attempt++) {
+      try {
+        return await ref.read(kioskRepositoryProvider).updateOrderStatus(orderId.toInt(), request);
+      } catch (e) {
+        if (attempt == maxRetries) {
+          SlackLogService().sendLogToSlack('update order error (attempt $attempt/$maxRetries): $e');
+          rethrow;
+        }
+        logger.w('update order attempt $attempt failed, retrying in ${retryDelay.inMilliseconds}ms... $e');
+        await Future.delayed(retryDelay);
+      }
+    }
+    throw Exception('unreachable');
   }
 
   Future<UpdateOrderResponse> _updateFailOrder({required String description}) async {

--- a/lib/presentation/payment/payment_service.dart
+++ b/lib/presentation/payment/payment_service.dart
@@ -1,4 +1,3 @@
-import 'package:flutter_snaptag_kiosk/core/data/models/request/update_back_photo_request.dart';
 import 'package:flutter_snaptag_kiosk/lib.dart';
 import 'package:flutter_snaptag_kiosk/presentation/core/card_count_provider.dart';
 import 'package:flutter_snaptag_kiosk/presentation/kiosk_shell/kiosk_info_service.dart';
@@ -106,10 +105,10 @@ class PaymentService extends _$PaymentService {
   Future<void> _handleEmptyApprovalNumber(PaymentResponse paymentResponse, String machineId) async {
     final backPhoto = ref.watch(verifyPhotoCardProvider).value!;
 
-    await ref.read(kioskRepositoryProvider).updateBackPhotoStatus(UpdateBackPhotoRequest(
-          photoAuthNumber: backPhoto.photoAuthNumber,
-          status: "STARTED",
-        ));
+    // await ref.read(kioskRepositoryProvider).updateBackPhotoStatus(UpdateBackPhotoRequest(
+    //       photoAuthNumber: backPhoto.photoAuthNumber,
+    //       status: "STARTED",
+    //     ));
 
     await _updateFailOrder(description: _formatPaymentMessages(paymentResponse));
 

--- a/lib/presentation/print/card_printer.dart
+++ b/lib/presentation/print/card_printer.dart
@@ -43,9 +43,13 @@ class PrinterService extends _$PrinterService {
   }
 
   Future<void> checkFeeder() async {
-    final printerManager = await PrinterManager.getInstance();
-    // await printerManager.initLibrary();
-    await printerManager.checkFeeder();
+    try {
+      final printerManager = await PrinterManager.getInstance();
+      // await printerManager.initLibrary();
+      await printerManager.checkFeeder();
+    } catch (e) {
+      rethrow;
+    }
   }
 
   Future<RibbonStatus> getRibbonStatus() async {

--- a/lib/presentation/print/isolate/printer_manager.dart
+++ b/lib/presentation/print/isolate/printer_manager.dart
@@ -295,7 +295,7 @@ class PrinterManager {
 
       return isConnected;
     } catch (e) {
-      SlackLogService().sendBroadcastLogToSlack('[PRINTER] checkConnectedPrint 오류: $e');
+      SlackLogService().sendErrorLogToSlack('[PRINTER] checkConnectedPrint 오류: $e');
       return false;
     }
   }
@@ -321,19 +321,25 @@ class PrinterManager {
   }
 
   Future<bool> checkSettingPrinter() async {
-    final response = await _sendAndResponse(SettingPrinterMessage());
-    final isReady = response['isReady'] as bool;
-    final errorMsg = response['errorMsg'] as String;
-
-    if (errorMsg.isNotEmpty) {
-      throw Exception(errorMsg);
+    try {
+      final response = await _sendAndResponse(SettingPrinterMessage());
+      final isReady = response['isReady'] as bool? ?? false;
+      final errorMsg = response['errorMsg'] as String? ?? '';
+      if (errorMsg.isNotEmpty) throw Exception(errorMsg);
+      return isReady;
+    } catch (e) {
+      SlackLogService().sendErrorLogToSlack('[PRINTER] checkSettingPrinter 오류: $e');
+      return false;
     }
-
-    return isReady;
   }
 
   Future<void> checkFeeder() async {
-    await _sendAndHandleResponse(CheckFeederMessage());
+    try {
+      await _sendAndHandleResponse(CheckFeederMessage());
+    } catch (e) {
+      SlackLogService().sendErrorLogToSlack('[PRINTER] checkFeeder 오류: $e');
+      rethrow;
+    }
   }
 
   bool _checkSettingPrinter(PrinterBindings bindings) {
@@ -424,13 +430,14 @@ class PrinterManager {
   }
 
   Future<Map<String, dynamic>> _sendAndResponse(Object object) async {
-    final responsePort = ReceivePort();
-
-    _sendPort.send({'object': object, 'replyPort': responsePort.sendPort});
-
-    final response = await responsePort.first as Map<String, dynamic>;
-
-    return response;
+    try {
+      final responsePort = ReceivePort();
+      _sendPort.send({'object': object, 'replyPort': responsePort.sendPort});
+      final response = await responsePort.first.timeout(const Duration(seconds: 30)) as Map<String, dynamic>;
+      return response;
+    } catch (e) {
+      rethrow;
+    }
   }
 
   Future<String?> _imageBufferResponse(Object object) async {
@@ -512,27 +519,29 @@ class PrinterManager {
   }
 
   Future<PrinterLog?> startLog() async {
-    final response = await _sendAndResponse(PrintStateMessage());
-    final printerLog = response['printerLog'] as PrinterLog;
-    final errorMsg = response['errorMsg'] as String;
-
-    if (errorMsg.isNotEmpty) {
-      throw Exception(errorMsg);
+    try {
+      final response = await _sendAndResponse(PrintStateMessage());
+      final printerLog = response['printerLog'] as PrinterLog?;
+      final errorMsg = response['errorMsg'] as String? ?? '';
+      if (errorMsg.isNotEmpty) throw Exception(errorMsg);
+      return printerLog;
+    } catch (e) {
+      SlackLogService().sendBroadcastLogToSlack('[PRINTER] startLog 오류: $e');
+      rethrow;
     }
-
-    return printerLog;
   }
 
   Future<RibbonStatus> getRibbonStatus() async {
-    final response = await _sendAndResponse(PrintRibbonStatusMessage());
-    final ribbonStatus = response['ribbonStatus'] as RibbonStatus?;
-    final errorMsg = response['errorMsg'] as String;
-
-    if (errorMsg.isNotEmpty) {
-      throw Exception(errorMsg);
+    try {
+      final response = await _sendAndResponse(PrintRibbonStatusMessage());
+      final ribbonStatus = response['ribbonStatus'] as RibbonStatus?;
+      final errorMsg = response['errorMsg'] as String? ?? '';
+      if (errorMsg.isNotEmpty) throw Exception(errorMsg);
+      return ribbonStatus ?? RibbonStatus(rbnRemaining: 0, filmRemaining: 0);
+    } catch (e) {
+      SlackLogService().sendBroadcastLogToSlack('[PRINTER] getRibbonStatus 오류: $e');
+      rethrow;
     }
-
-    return ribbonStatus ?? RibbonStatus(rbnRemaining: 0, filmRemaining: 0);
   }
 
   RibbonStatus _getRibbonStatus(PrinterBindings bindings) {
@@ -572,14 +581,16 @@ class PrinterManager {
   }
 
   Future<String> _rearImage({required File file}) async {
-    final rearImage = await file.readAsBytes();
-    final rotatedRearImage = _flipImage180(rearImage);
-    // 임시 파일로 저장
-    final temp = DateTime.now().millisecondsSinceEpoch.toString();
-    final rotatedRearPath = '${temp}_rotated.png';
-    await File(rotatedRearPath).writeAsBytes(rotatedRearImage);
-
-    return rotatedRearPath;
+    try {
+      final rearImage = await file.readAsBytes();
+      final rotatedRearImage = _flipImage180(rearImage);
+      final temp = DateTime.now().millisecondsSinceEpoch.toString();
+      final rotatedRearPath = '${temp}_rotated.png';
+      await File(rotatedRearPath).writeAsBytes(rotatedRearImage);
+      return rotatedRearPath;
+    } catch (e) {
+      throw Exception('[_rearImage] 뒷면 이미지 준비 실패: $e');
+    }
   }
 
   // 이미지 회전 기능 추가

--- a/lib/presentation/print/isolate/printer_manager.dart
+++ b/lib/presentation/print/isolate/printer_manager.dart
@@ -295,7 +295,7 @@ class PrinterManager {
 
       return isConnected;
     } catch (e) {
-      SlackLogService().sendErrorLogToSlack('[PRINTER] checkConnectedPrint 오류: $e');
+      SlackLogService().sendBroadcastLogToSlack('[PRINTER] checkConnectedPrint 오류: $e');
       return false;
     }
   }
@@ -526,7 +526,7 @@ class PrinterManager {
       if (errorMsg.isNotEmpty) throw Exception(errorMsg);
       return printerLog;
     } catch (e) {
-      SlackLogService().sendBroadcastLogToSlack('[PRINTER] startLog 오류: $e');
+      SlackLogService().sendErrorLogToSlack('[PRINTER] startLog 오류: $e');
       rethrow;
     }
   }
@@ -539,7 +539,7 @@ class PrinterManager {
       if (errorMsg.isNotEmpty) throw Exception(errorMsg);
       return ribbonStatus ?? RibbonStatus(rbnRemaining: 0, filmRemaining: 0);
     } catch (e) {
-      SlackLogService().sendBroadcastLogToSlack('[PRINTER] getRibbonStatus 오류: $e');
+      SlackLogService().sendErrorLogToSlack('[PRINTER] getRibbonStatus 오류: $e');
       rethrow;
     }
   }

--- a/lib/presentation/print/luca/binding/printer_bindings.dart
+++ b/lib/presentation/print/luca/binding/printer_bindings.dart
@@ -1,12 +1,10 @@
 import 'dart:ffi';
 import 'dart:io';
-import 'dart:typed_data';
 
 import 'package:ffi/ffi.dart';
+import 'package:flutter_snaptag_kiosk/lib.dart';
 import 'package:flutter_snaptag_kiosk/presentation/print/luca/state/printer_status.dart';
 import 'package:flutter_snaptag_kiosk/presentation/print/luca/state/ribbon_status.dart';
-import 'package:flutter_snaptag_kiosk/lib.dart';
-import 'package:image/image.dart' as img;
 
 part 'printer_bindings.typedef.dart';
 
@@ -80,8 +78,12 @@ class PrinterBindings {
     _ribbonSettingsSW = _dll.lookupFunction<R600RibbonSettingsRWNative, R600RibbonSettingsRW>('R600RibbonSettingsRW');
   }
 
-  int initLibrary() {
-    return _libInit();
+  void initLibrary() {
+    final result = _libInit();
+    if (result != 0) {
+      final error = getErrorInfo(result);
+      throw Exception('[R600LibInit] 라이브러리 초기화 실패: $error (code: $result)');
+    }
   }
 
   String getErrorInfo(int errorCode) {
@@ -434,7 +436,11 @@ class PrinterBindings {
   }
 
   void clearLibrary() {
-    _libClear();
+    final result = _libClear();
+    if (result != 0) {
+      logger.w('[R600LibClear] 라이브러리 해제 실패 (code: $result) — 계속 진행');
+      // throw 하지 않음: clear 실패는 치명적이지 않으므로 경고만
+    }
   }
 
   /// 현재 에러 클리어. 캐시는 지우지 않음. (SDK `R600PrtReset`)

--- a/lib/presentation/setup/setup_main_screen.dart
+++ b/lib/presentation/setup/setup_main_screen.dart
@@ -92,9 +92,9 @@ class _SetupMainScreenState extends ConsumerState<SetupMainScreen> {
       }
     }
 
-    // final isReady = await _validatePrinterReadyAndShowDialogs(context);
+    final isReady = await _validatePrinterReadyAndShowDialogs(context);
 
-    // if (!isReady) return;
+    if (!isReady) return;
 
     final isPaymentDeviceReady = await _checkPaymentDevice();
     if (!isPaymentDeviceReady) return;

--- a/lib/presentation/setup/setup_main_screen.dart
+++ b/lib/presentation/setup/setup_main_screen.dart
@@ -1,26 +1,22 @@
 import 'dart:async';
 import 'dart:io';
 
-import 'package:dio/dio.dart';
-import 'package:easy_localization/easy_localization.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_screenutil/flutter_screenutil.dart';
+import 'package:flutter_snaptag_kiosk/core/common/launcher/launcher_service.dart';
 import 'package:flutter_snaptag_kiosk/core/common/sound/sound_manager.dart';
-import 'package:flutter_snaptag_kiosk/core/data/models/request/unique_key_request.dart';
+import 'package:flutter_snaptag_kiosk/core/data/datasources/local/id_writer.dart';
+import 'package:flutter_snaptag_kiosk/core/providers/version_notifier.dart';
+import 'package:flutter_snaptag_kiosk/core/ui/widget/dialog_helper.dart';
+import 'package:flutter_snaptag_kiosk/lib.dart';
+import 'package:flutter_snaptag_kiosk/presentation/core/card_count_provider.dart';
 import 'package:flutter_snaptag_kiosk/presentation/kiosk_shell/kiosk_info_service.dart';
 import 'package:flutter_snaptag_kiosk/presentation/print/card_printer.dart';
 import 'package:flutter_snaptag_kiosk/presentation/print/luca/state/printer_connect_state.dart';
-import 'package:flutter_snaptag_kiosk/lib.dart';
-import 'package:flutter_snaptag_kiosk/presentation/core/card_count_provider.dart';
-import 'package:flutter_snaptag_kiosk/presentation/setup/page_print_provider.dart';
-import 'package:flutter_snaptag_kiosk/presentation/setup/uuid_provider.dart';
 import 'package:flutter_snaptag_kiosk/presentation/setup/alert_definition_provider.dart';
-import 'package:flutter_snaptag_kiosk/core/ui/widget/dialog_helper.dart';
+import 'package:flutter_snaptag_kiosk/presentation/setup/page_print_provider.dart';
 import 'package:flutter_svg/flutter_svg.dart';
-import 'package:flutter_snaptag_kiosk/core/providers/version_notifier.dart';
-import 'package:flutter_snaptag_kiosk/core/common/launcher/launcher_service.dart';
-import 'package:flutter_snaptag_kiosk/core/data/datasources/local/id_writer.dart';
 
 class SetupMainScreen extends ConsumerStatefulWidget {
   const SetupMainScreen({super.key});
@@ -82,9 +78,23 @@ class _SetupMainScreenState extends ConsumerState<SetupMainScreen> {
       return;
     }
 
-    final isReady = await _validatePrinterReadyAndShowDialogs(context);
+    if (pagePrintType == PagePrintType.single) {
+      final cardCountState = ref.read(cardCountProvider);
+      if (cardCountState.currentCount == 0) {
+        if (!context.mounted) return;
+        final confirmed = await DialogHelper.showSetupDialog(
+          context,
+          title: '단면 카드 수량이 0장입니다.\n양면 모드로 변경하시겠습니까?',
+          showCancelButton: true,
+        );
+        if (!confirmed) return;
+        ref.read(pagePrintProvider.notifier).set(PagePrintType.double);
+      }
+    }
 
-    if (!isReady) return;
+    // final isReady = await _validatePrinterReadyAndShowDialogs(context);
+
+    // if (!isReady) return;
 
     final isPaymentDeviceReady = await _checkPaymentDevice();
     if (!isPaymentDeviceReady) return;
@@ -100,9 +110,7 @@ class _SetupMainScreenState extends ConsumerState<SetupMainScreen> {
       kioskInfo = ref.read(kioskInfoServiceProvider);
     }
 
-    if (kioskInfo == null ||
-        kioskInfo.kioskEventId == 0 ||
-        kioskInfo.kioskMachineId == 0) {
+    if (kioskInfo == null || kioskInfo.kioskEventId == 0 || kioskInfo.kioskMachineId == 0) {
       if (!context.mounted) return;
       await DialogHelper.showSetupDialog(
         context,

--- a/lib/presentation/setup/setup_main_screen.dart
+++ b/lib/presentation/setup/setup_main_screen.dart
@@ -84,7 +84,8 @@ class _SetupMainScreenState extends ConsumerState<SetupMainScreen> {
         if (!context.mounted) return;
         final confirmed = await DialogHelper.showSetupDialog(
           context,
-          title: '단면 카드 수량이 0장입니다.\n양면 모드로 변경하시겠습니까?',
+          title: '양면 인쇄 전환',
+          content: '단면 카드 수량이 0장으로 설정되었습니다.\n양면 인쇄로 전환하시겠습니까?',
           showCancelButton: true,
         );
         if (!confirmed) return;


### PR DESCRIPTION
## Summary
- 단면 모드에서 카드 수량이 0장일 때 양면 모드 전환 알림 추가
- 프린터 메소드 예외 처리 강화 및 isolate 통신 타임아웃 추가
- dio_client 이중 핸들러 버그 수정 및 _updateOrder retry 로직 추가
- [JKLI-65] dio_logger Slack 로그 개선 및 requestBody if/else 구조 버그 수정
- Slack 로그 메소드 정리 (sendBroadcastLogToSlack → sendErrorLogToSlack)

## Changes
- feat: 단면 모드 카드 수량 0장 시 양면 모드 전환 알림 추가
- fix: 단면 0장 알림 타이틀/내용 분리 및 문구 수정
- fix: 프린터 메소드 예외 처리 강화 및 isolate 통신 타임아웃 추가
- fix: startLog, getRibbonStatus Slack 로그 sendBroadcastLogToSlack → sendErrorLogToSlack 변경
- fix: [JKLI-65] dio_logger 슬랙 로그 개선
- fix: [JKLI-65] requestBody if/else 구조 버그 수정
- fix: updateBackPhotoStatus 호출 임시 주석 처리 및 미사용 import 제거
- fix: dio_client 이중 핸들러 버그 수정 및 _updateOrder retry 추가

## Test plan
- [ ] 단면 모드에서 카드 수량 0장일 때 양면 모드 전환 다이얼로그 확인
- [ ] 프린터 예외 상황에서 앱 크래시 없이 정상 처리 확인
- [ ] Slack 로그 채널 수신 확인 (error_log / log / service)
- [ ] 출력 상태 업데이트 API 실패 시 retry 동작 확인


[JKLI-65]: https://snaptag-team.atlassian.net/browse/JKLI-65?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[JKLI-65]: https://snaptag-team.atlassian.net/browse/JKLI-65?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[JKLI-65]: https://snaptag-team.atlassian.net/browse/JKLI-65?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ