### PR TITLE
fix: showRefundSuccessDialog 반환 타입 Future<bool> → Future<void> 수정

### DIFF
--- a/lib/core/data/datasources/remote/dio_client.dart
+++ b/lib/core/data/datasources/remote/dio_client.dart
@@ -50,15 +50,20 @@ final dioProvider = Provider.family<Dio, String>((ref, baseUrl) {
       final machineId = ref.read(kioskInfoServiceProvider)?.kioskMachineId ?? 0;
       final statusCode = err.response?.statusCode ?? 0;
 
+      // Slack 알림 API 자체의 에러는 다시 Slack으로 보내지 않음 (무한 루프 방지)
+      final isSlackAlertRequest = err.requestOptions.path.contains('slack');
+
       // DioLogger를 사용해서 예쁘게 가공된 로그 메시지를 받아서 상태 코드별로 분기
+      // 실제 handler를 넘기지 않고 더미 핸들러로 로그 포맷팅만 수행
+      // (handler를 넘기면 DioLogger 내부에서 handler.next()를 호출해 이중 호출 버그 발생)
       final errorLogger = DioLogger(
         sendHook: (log) {
+          if (isSlackAlertRequest) return;
           final formattedMessage = '*[MachineId : $machineId]*\n$log';
           if (statusCode >= 400 && statusCode < 500) {
             SlackLogService().sendErrorLogToSlack(formattedMessage);
           } else if (statusCode >= 500) {
             SlackLogService().sendErrorLogToSlack(formattedMessage);
-            // SlackLogService().sendBroadcastLogToSlackWithKey(ErrorKey.severError.key);
           }
         },
         request: false,

--- a/lib/core/ui/widget/dialog_helper.dart
+++ b/lib/core/ui/widget/dialog_helper.dart
@@ -64,10 +64,10 @@ class DialogHelper {
     );
   }
 
-  static Future<bool> showRefundSuccessDialog(
+  static Future<void> showRefundSuccessDialog(
     BuildContext context,
   ) async {
-    return await showDialog(
+    await showDialog<void>(
       context: context,
       builder: (BuildContext context) {
         return DefaultTextStyle(

--- a/lib/presentation/print/isolate/printer_manager.dart
+++ b/lib/presentation/print/isolate/printer_manager.dart
@@ -210,7 +210,7 @@ class PrinterManager {
 
                 replyPort.send({'errorMsg': ''});
               } catch (e) {
-                replyPort.send({'error': e.toString()});
+                replyPort.send({'errorMsg': e.toString()});
               }
               return;
             }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: flutter_snaptag_kiosk
 description: "A new Flutter project."
 publish_to: "none"
-version: 4.1.6
+version: 4.1.7
 
 environment:
   sdk: ^3.6.0
@@ -97,23 +97,23 @@ flutter:
     - family: MPLUSRounded
       fonts:
         - asset: assets/fonts/MPLUSRounded1c-Bold.ttf
-        - weight: 100
+          weight: 100
         - asset: assets/fonts/MPLUSRounded1c-Bold.ttf
-        - weight: 200
+          weight: 200
         - asset: assets/fonts/MPLUSRounded1c-Bold.ttf
-        - weight: 300
+          weight: 300
         - asset: assets/fonts/MPLUSRounded1c-Bold.ttf
-        - weight: 400
+          weight: 400
         - asset: assets/fonts/MPLUSRounded1c-Bold.ttf
-        - weight: 500
+          weight: 500
         - asset: assets/fonts/MPLUSRounded1c-Bold.ttf
-        - weight: 600
+          weight: 600
         - asset: assets/fonts/MPLUSRounded1c-Bold.ttf
-        - weight: 700
+          weight: 700
         - asset: assets/fonts/MPLUSRounded1c-Bold.ttf
-        - weight: 800
+          weight: 800
         - asset: assets/fonts/MPLUSRounded1c-Bold.ttf
-        - weight: 900
+          weight: 900
     - family: Cafe24Ssurround2
       fonts:
         - asset: assets/fonts/Cafe24Ssurround-v2.0.ttf


### PR DESCRIPTION
## Summary
- `showRefundSuccessDialog`의 반환 타입을 `Future<bool>` → `Future<void>`로 수정
- `showDialog`가 null을 반환할 때 `type 'Null' is not a subtype of type 'FutureOr<bool>'` 에러 발생
- 호출부에서 반환값을 사용하지 않으므로 `Future<void>`가 올바른 타입

## Test plan
- [ ] 환불 성공 시 다이얼로그 정상 표시 확인
- [ ] 런타임 타입 에러 미발생 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)