### PR TITLE
fix: 네트워크 에러 발생 시 프린트 완료 다이얼로그 처리 개선

### DIFF
--- a/assets/lang/en-US.json
+++ b/assets/lang/en-US.json
@@ -70,5 +70,6 @@
   "currency_won": "KRW",
   "common_btn_back": "Back",
   "alert_title_network_error": "Network Connection Error",
-  "alert_txt_network_error": "Unable to load the event\ndue to a network error.\nCheck your connection and try again."
+  "alert_txt_network_error": "Unable to load the event\ndue to a network error.\nCheck your connection and try again.",
+  "alert_txt_print_network_error": "A network error occurred during printing.\nPlease contact the administrator."
 }

--- a/assets/lang/ja-JP.json
+++ b/assets/lang/ja-JP.json
@@ -70,5 +70,6 @@
   "currency_won": "ウォン",
   "common_btn_back": "戻る",
   "alert_title_network_error": "ネットワーク接続エラー",
-  "alert_txt_network_error": "ネットワークエラーのため\nイベントを読み込めません。\n接続を確認して再試行してください。"
+  "alert_txt_network_error": "ネットワークエラーのため\nイベントを読み込めません。\n接続を確認して再試行してください。",
+  "alert_txt_print_network_error": "印刷中にネットワークエラーが発生しました。\n管理者にお問い合わせください。"
 }

--- a/assets/lang/ko-KR.json
+++ b/assets/lang/ko-KR.json
@@ -70,5 +70,6 @@
   "currency_won": "원",
   "common_btn_back": "뒤로가기",
   "alert_title_network_error": "네트워크 연결 실패",
-  "alert_txt_network_error": "네트워크 오류로 이벤트를 불러올 수 없습니다.\n인터넷 연결을 확인 후 다시 시도해 주세요."
+  "alert_txt_network_error": "네트워크 오류로 이벤트를 불러올 수 없습니다.\n인터넷 연결을 확인 후 다시 시도해 주세요.",
+  "alert_txt_print_network_error": "네트워크 중 문제가 발생했습니다.\n관리자에게 문의해주세요."
 }

--- a/assets/lang/zh-CN.json
+++ b/assets/lang/zh-CN.json
@@ -68,5 +68,6 @@
   "currency_won": "韩元",
   "common_btn_back": "返回",
   "alert_title_network_error": "Network Connection Error",
-  "alert_txt_network_error": "The network connection is unstable, so the event could not be loaded. Please check your internet connection and run the app again."
+  "alert_txt_network_error": "The network connection is unstable, so the event could not be loaded. Please check your internet connection and run the app again.",
+  "alert_txt_print_network_error": "打印过程中发生网络错误。\n请联系管理员。"
 }

--- a/lib/app.dart
+++ b/lib/app.dart
@@ -218,6 +218,7 @@ class _ErrorApp extends ConsumerWidget {
 /// 라우트 체크 헬퍼 클래스
 class _RouteChecker {
   static bool isPrintProcessScreen(String location) => location.contains('/print-process');
+  static bool isPreviewScreen(String location) => location.contains('/preview');
   static bool isHomeScreen(String location) => location.contains('/home');
   static bool isKioskRoute(String location) => location.contains('/kiosk');
   static bool shouldListenToTouch(String location) =>
@@ -280,8 +281,10 @@ class _NetworkStatusAlertWrapperState extends ConsumerState<_NetworkStatusAlertW
     final router = widget.ref.read(routerProvider);
     final currentLocation = router.routerDelegate.currentConfiguration.uri.toString();
     final isPrintProcessScreen = _RouteChecker.isPrintProcessScreen(currentLocation);
+    final isPreviewScreen = _RouteChecker.isPreviewScreen(currentLocation);
 
     final shouldShowAlert = !isPrintProcessScreen &&
+        !isPreviewScreen &&
         (networkState.status == NetworkStatus.unstable || networkState.status == NetworkStatus.disconnected);
 
     if (shouldShowAlert && !_isAlertShowing) {

--- a/lib/locale_keys.dart
+++ b/lib/locale_keys.dart
@@ -60,6 +60,8 @@ abstract class LocaleKeys {
 
   static const alert_title_auto_refund_alert = 'alert_title_auto_refund_alert';
   static const alert_txt_auto_refund_alert = 'alert_txt_auto_refund_alert';
+  static const alert_title_network_error = 'alert_title_network_error';
+  static const alert_txt_print_network_error = 'alert_txt_print_network_error';
   static const choice_recommended_images = 'choice_recommended_images';
   static const choice_select_recommended_image = 'choice_select_recommended_image';
   static const choice_upload_my_photo = 'choice_upload_my_photo';

--- a/lib/presentation/payment/payment_screen.dart
+++ b/lib/presentation/payment/payment_screen.dart
@@ -46,6 +46,7 @@ class PaymentScreen extends ConsumerStatefulWidget {
 }
 
 class _PaymentScreenState extends ConsumerState<PaymentScreen> {
+  bool _isNetworkErrorHandled = false;
   /// 시안 6: 선택되지 않은 카드 크기 축소 + 애니메이션
   Widget _buildVariant6AnimatedScaleOnUnselected({
     required int index,
@@ -206,6 +207,32 @@ class _PaymentScreenState extends ConsumerState<PaymentScreen> {
 
   @override
   Widget build(BuildContext context) {
+    ref.listen<NetworkState>(networkStatusNotifierProvider, (previous, next) {
+      if (_isNetworkErrorHandled) return;
+      if (previous?.status == next.status) return;
+
+      final isNetworkDown =
+          next.status == NetworkStatus.disconnected || next.status == NetworkStatus.unstable;
+      if (!isNetworkDown) return;
+      if (!ref.read(photoCardPreviewScreenProviderProvider).isLoading) return;
+
+      _isNetworkErrorHandled = true;
+
+      if (!mounted) return;
+      if (context.loaderOverlay.visible) {
+        context.loaderOverlay.hide();
+      }
+
+      DialogHelper.showKioskDialog(
+        context,
+        title: LocaleKeys.alert_title_network_error.tr(),
+        contentText: LocaleKeys.alert_txt_print_network_error.tr(),
+        confirmButtonText: LocaleKeys.alert_btn_print_failure.tr(),
+      ).then((_) {
+        if (mounted) HomeRouteData().go(context);
+      });
+    });
+
     ref.listen<AsyncValue<void>>(
       photoCardPreviewScreenProviderProvider,
       (previous, next) async {
@@ -227,6 +254,8 @@ class _PaymentScreenState extends ConsumerState<PaymentScreen> {
         // 에러/성공 처리
         await next.when(
           error: (error, stack) async {
+            if (_isNetworkErrorHandled) return;
+
             if (mounted) {
               timeoutNotifier.resumeTimer();
             }

--- a/lib/presentation/print/isolate/printer_manager.dart
+++ b/lib/presentation/print/isolate/printer_manager.dart
@@ -433,7 +433,8 @@ class PrinterManager {
     try {
       final responsePort = ReceivePort();
       _sendPort.send({'object': object, 'replyPort': responsePort.sendPort});
-      final response = await responsePort.first.timeout(const Duration(seconds: 30)) as Map<String, dynamic>;
+      final timeout = object is PrintMessage ? const Duration(seconds: 90) : const Duration(seconds: 30);
+      final response = await responsePort.first.timeout(timeout) as Map<String, dynamic>;
       return response;
     } catch (e) {
       rethrow;

--- a/lib/presentation/print/print_process_screen.dart
+++ b/lib/presentation/print/print_process_screen.dart
@@ -9,6 +9,7 @@ import 'package:flutter_snaptag_kiosk/presentation/kiosk_shell/kiosk_info_servic
 import 'package:flutter_snaptag_kiosk/presentation/setup/page_print_provider.dart';
 import 'package:flutter_snaptag_kiosk/core/ui/widget/dialog_helper.dart';
 import 'package:flutter_snaptag_kiosk/presentation/print/print_process_screen_provider.dart';
+import 'package:flutter_snaptag_kiosk/presentation/print/card_printer.dart';
 import 'package:flutter_snaptag_kiosk/presentation/payment/payment_response_state.dart';
 
 import 'dart:io';
@@ -34,18 +35,13 @@ class _PrintProcessScreenState extends ConsumerState<PrintProcessScreen> with Si
 
     _progressController = AnimationController(
       vsync: this,
-      duration: const Duration(seconds: 30), // 초기값(단면) - 아래에서 실제 duration 설정
+      duration: const Duration(seconds: 10),
     );
 
-    // 단면(약 30초) / 양면(약 60초) 기준으로 99%까지 부드럽게 증가
-    final pagePrintType = ref.read(pagePrintProvider);
-    final isMetal = ref.read(kioskInfoServiceProvider)?.isMetal ?? false;
-    final seconds = pagePrintType == PagePrintType.double ? (isMetal ? 68 : 60) : (isMetal ? 35 : 30);
-    _progressController.duration = Duration(seconds: seconds);
-
-    // 0% -> 99% (0.99)까지 선형으로 진행
+    // API 호출 단계: 0% → 10% 천천히
     _progressController.animateTo(
-      0.99,
+      0.10,
+      duration: const Duration(seconds: 10),
       curve: Curves.linear,
     );
   }
@@ -60,6 +56,20 @@ class _PrintProcessScreenState extends ConsumerState<PrintProcessScreen> with Si
   Widget build(BuildContext context) {
     final randomAdImage = getRandomAdImageFilePath(ref);
     final isHwe = ref.read(kioskInfoServiceProvider)?.isHwe == true;
+
+    // 실제 프린트 시작 시점 감지: 10% → 99% 애니메이션
+    ref.listen(printerServiceProvider, (previous, next) {
+      if (next.isLoading && !_progressCompleted && !_progressFrozen) {
+        final pagePrintType = ref.read(pagePrintProvider);
+        final isMetal = ref.read(kioskInfoServiceProvider)?.isMetal ?? false;
+        final seconds = pagePrintType == PagePrintType.double ? (isMetal ? 68 : 60) : (isMetal ? 35 : 30);
+        _progressController.animateTo(
+          0.99,
+          duration: Duration(seconds: seconds),
+          curve: Curves.linear,
+        );
+      }
+    });
 
     // listen 부분에서는 로딩 오버레이 처리를 제거
     ref.listen(printProcessScreenProviderProvider, (previous, next) async {
@@ -93,17 +103,15 @@ class _PrintProcessScreenState extends ConsumerState<PrintProcessScreen> with Si
             // 네트워크 오류인지 체크
             final isNetworkError = ref.read(networkStatusNotifierProvider.notifier).isNetworkError(error);
 
-            // 네트워크 오류라면 카드 단일 카드 수량 확인 후 완료 알럿 표시
             if (isNetworkError) {
-              // 카드 단일 카드 수량 확인
               checkCardSingleCardCount();
-
-              await DialogHelper.showPrintCompleteDialog(
+              await DialogHelper.showKioskDialog(
                 context,
-                onButtonPressed: () {
-                  HomeRouteData().go(context);
-                },
+                title: LocaleKeys.alert_title_network_error.tr(),
+                contentText: LocaleKeys.alert_txt_print_network_error.tr(),
+                confirmButtonText: LocaleKeys.alert_btn_print_failure.tr(),
               );
+              HomeRouteData().go(context);
               return;
             }
 

--- a/lib/presentation/print/print_process_screen.dart
+++ b/lib/presentation/print/print_process_screen.dart
@@ -29,7 +29,6 @@ class _PrintProcessScreenState extends ConsumerState<PrintProcessScreen> with Si
   bool _progressCompleted = false;
   bool _progressFrozen = false;
   bool _networkErrorHandled = false;
-  bool _pendingNetworkError = false;
 
   @override
   void initState() {
@@ -69,10 +68,7 @@ class _PrintProcessScreenState extends ConsumerState<PrintProcessScreen> with Si
       if (!isNetworkDown) return;
       if (_progressCompleted || _progressFrozen) return;
       // 프린터가 이미 실행 중이면 네트워크 에러 무시 (프린트 완료 후 홈에서 처리)
-      if (ref.read(printerServiceProvider).isLoading) {
-        _pendingNetworkError = true;
-        return;
-      }
+      if (ref.read(printerServiceProvider).isLoading) return;
 
       _networkErrorHandled = true;
       _progressFrozen = true;
@@ -202,14 +198,25 @@ class _PrintProcessScreenState extends ConsumerState<PrintProcessScreen> with Si
 
             ref.read(paymentResponseStateProvider.notifier).reset();
 
+            final networkStatus = ref.read(networkStatusNotifierProvider).status;
+            final isNetworkDown = networkStatus == NetworkStatus.disconnected ||
+                networkStatus == NetworkStatus.unstable;
+
             await DialogHelper.showPrintCompleteDialog(
               context,
             );
 
-            if (_pendingNetworkError) {
-              final notifier = ref.read(networkStatusNotifierProvider.notifier);
+            if (isNetworkDown) {
               Future.delayed(const Duration(milliseconds: 300), () {
-                notifier.refresh();
+                final rootContext = rootNavigatorKey.currentContext;
+                if (rootContext != null) {
+                  DialogHelper.showKioskDialog(
+                    rootContext,
+                    title: LocaleKeys.alert_title_network_error.tr(),
+                    contentText: LocaleKeys.alert_txt_print_network_error.tr(),
+                    confirmButtonText: LocaleKeys.alert_btn_print_failure.tr(),
+                  );
+                }
               });
             }
           },

--- a/lib/presentation/print/print_process_screen.dart
+++ b/lib/presentation/print/print_process_screen.dart
@@ -76,18 +76,13 @@ class _PrintProcessScreenState extends ConsumerState<PrintProcessScreen> with Si
 
       if (!mounted) return;
 
-      // 프린터 시작 전 네트워크 에러 → 자동 환불 후 에러 다이얼로그
-      refund().then((_) {
-        if (!mounted) return;
-        checkCardSingleCardCount();
-        DialogHelper.showKioskDialog(
-          context,
-          title: LocaleKeys.alert_title_network_error.tr(),
-          contentText: LocaleKeys.alert_txt_print_network_error.tr(),
-          confirmButtonText: LocaleKeys.alert_btn_print_failure.tr(),
-        ).then((_) {
-          if (mounted) HomeRouteData().go(context);
-        });
+      DialogHelper.showKioskDialog(
+        context,
+        title: LocaleKeys.alert_title_network_error.tr(),
+        contentText: LocaleKeys.alert_txt_print_network_error.tr(),
+        confirmButtonText: LocaleKeys.alert_btn_print_failure.tr(),
+      ).then((_) {
+        if (mounted) HomeRouteData().go(context);
       });
     });
 

--- a/lib/presentation/print/print_process_screen.dart
+++ b/lib/presentation/print/print_process_screen.dart
@@ -28,6 +28,8 @@ class _PrintProcessScreenState extends ConsumerState<PrintProcessScreen> with Si
   late final AnimationController _progressController;
   bool _progressCompleted = false;
   bool _progressFrozen = false;
+  bool _networkErrorHandled = false;
+  bool _pendingNetworkError = false;
 
   @override
   void initState() {
@@ -57,6 +59,42 @@ class _PrintProcessScreenState extends ConsumerState<PrintProcessScreen> with Si
     final randomAdImage = getRandomAdImageFilePath(ref);
     final isHwe = ref.read(kioskInfoServiceProvider)?.isHwe == true;
 
+    // 네트워크 끊김 즉시 감지: Dio 타임아웃 없이 바로 에러 처리
+    ref.listen<NetworkState>(networkStatusNotifierProvider, (previous, next) {
+      if (_networkErrorHandled) return;
+      if (previous?.status == next.status) return;
+
+      final isNetworkDown =
+          next.status == NetworkStatus.disconnected || next.status == NetworkStatus.unstable;
+      if (!isNetworkDown) return;
+      if (_progressCompleted || _progressFrozen) return;
+      // 프린터가 이미 실행 중이면 네트워크 에러 무시 (프린트 완료 후 홈에서 처리)
+      if (ref.read(printerServiceProvider).isLoading) {
+        _pendingNetworkError = true;
+        return;
+      }
+
+      _networkErrorHandled = true;
+      _progressFrozen = true;
+      _progressController.stop();
+
+      if (!mounted) return;
+
+      // 프린터 시작 전 네트워크 에러 → 자동 환불 후 에러 다이얼로그
+      refund().then((_) {
+        if (!mounted) return;
+        checkCardSingleCardCount();
+        DialogHelper.showKioskDialog(
+          context,
+          title: LocaleKeys.alert_title_network_error.tr(),
+          contentText: LocaleKeys.alert_txt_print_network_error.tr(),
+          confirmButtonText: LocaleKeys.alert_btn_print_failure.tr(),
+        ).then((_) {
+          if (mounted) HomeRouteData().go(context);
+        });
+      });
+    });
+
     // 실제 프린트 시작 시점 감지: 10% → 99% 애니메이션
     ref.listen(printerServiceProvider, (previous, next) {
       if (next.isLoading && !_progressCompleted && !_progressFrozen) {
@@ -77,6 +115,8 @@ class _PrintProcessScreenState extends ConsumerState<PrintProcessScreen> with Si
         // 로딩이 아닐 때만 처리
         await next.when(
           error: (error, stack) async {
+            if (_networkErrorHandled) return;
+
             // 오류 발생 시: 현재 진행률에서 멈춤 (요구사항)
             if (!_progressCompleted && !_progressFrozen) {
               _progressFrozen = true;
@@ -166,6 +206,12 @@ class _PrintProcessScreenState extends ConsumerState<PrintProcessScreen> with Si
               context,
               onButtonPressed: () {
                 HomeRouteData().go(context);
+                if (_pendingNetworkError) {
+                  final notifier = ref.read(networkStatusNotifierProvider.notifier);
+                  Future.delayed(const Duration(milliseconds: 300), () {
+                    notifier.refresh();
+                  });
+                }
               },
             );
           },

--- a/lib/presentation/print/print_process_screen.dart
+++ b/lib/presentation/print/print_process_screen.dart
@@ -204,16 +204,14 @@ class _PrintProcessScreenState extends ConsumerState<PrintProcessScreen> with Si
 
             await DialogHelper.showPrintCompleteDialog(
               context,
-              onButtonPressed: () {
-                HomeRouteData().go(context);
-                if (_pendingNetworkError) {
-                  final notifier = ref.read(networkStatusNotifierProvider.notifier);
-                  Future.delayed(const Duration(milliseconds: 300), () {
-                    notifier.refresh();
-                  });
-                }
-              },
             );
+
+            if (_pendingNetworkError) {
+              final notifier = ref.read(networkStatusNotifierProvider.notifier);
+              Future.delayed(const Duration(milliseconds: 300), () {
+                notifier.refresh();
+              });
+            }
           },
         );
       }


### PR DESCRIPTION
## 📌 작업 개요
- 결제 화면 네트워크 끊김 시 화면 동결 없이 즉시 에러 다이얼로그 표시
- 프린트 진행 중 네트워크 상태에 따라 처리 분기 (프린터 시작 전/후 구분)
- 프린트 완료 후 네트워크 에러 알림 미표시 버그 수정
- 프린터 시작 전 네트워크 에러 시 자동 환불 로직 제거

## 🔍 변경 사항

### ✨ 주요 기능 추가
- 결제 화면(`payment_screen.dart`): `ref.listen<NetworkState>` 추가로 네트워크 끊김 즉시 감지 → 에러 다이얼로그 → 홈 이동
- 프린트 화면(`print_process_screen.dart`): 프로그레스바를 실제 프린터 시작 시점에 연동 (API 단계 0→10%, 프린터 시작 후 10→99%)
- 프린트 화면: 프린터가 아직 시작 전인 경우 네트워크 끊김 즉시 감지 → 에러 다이얼로그 → 홈 이동
- 프린트 완료 후 네트워크가 끊긴 상태라면 완료 다이얼로그 닫힌 뒤 네트워크 에러 다이얼로그 추가 표시 (`rootNavigatorKey` 활용)

### 🔧 버그 수정 및 개선
- 프린트 완료 후 네트워크 에러 알림이 표시되지 않던 버그 수정
- 프린트 완료 후 네트워크 에러 시 `showPrintCompleteDialog` → `showKioskDialog`로 변경 (완료 다이얼로그와 에러 다이얼로그 분리)
- 프린터 시작 전 네트워크 에러 시 자동 환불 로직 제거 → 에러 안내만 표시
- `PrintMessage` isolate 응답 타임아웃 30초 → 90초로 증가 (프린트 소요 시간 대응)
- 이중 에러 처리 방지: `_isNetworkErrorHandled` / `_networkErrorHandled` 플래그로 네트워크/일반 에러 핸들러 충돌 방지

### 📝 다국어 지원 추가
- `LocaleKeys.alert_title_network_error` (기존 키 재사용)
- `LocaleKeys.alert_txt_print_network_error` — 프린트 중 네트워크 에러 전용 문구 추가
  - ko: "네트워크 중 문제가 발생했습니다.\n관리자에게 문의해주세요."
  - en / ja / zh-CN 동일 적용

### 📦 의존성 추가/변경
- 없음

### 🗂️ 파일 구조 변경
- 없음

## 🧪 테스트 방법

### 1. 결제 화면 네트워크 에러
1. 결제 진행 중(이미지 로딩 중) 네트워크를 차단
   - 화면이 동결되지 않고 즉시 네트워크 에러 다이얼로그 표시되는지 확인
   - 다이얼로그 확인 후 홈 화면으로 이동되는지 확인

### 2. 프린트 시작 전 네트워크 에러
1. 프린트 화면 진입 직후(프린터 시작 전) 네트워크를 차단
   - 프로그레스바가 10% 근처에서 멈추는지 확인
   - 에러 다이얼로그 표시 후 홈으로 이동되는지 확인
   - 자동 환불이 발생하지 않는지 확인

### 3. 프린트 진행 중 네트워크 에러 (프린터 동작 중)
1. 프린터가 실제 출력을 시작한 후 네트워크를 차단
   - 프린트가 중단되지 않고 완료까지 진행되는지 확인
   - 프린트 완료 다이얼로그 표시 확인
   - 완료 다이얼로그 닫힌 후 네트워크 에러 다이얼로그 추가 표시되는지 확인

### 4. 정상 프린트 플로우 회귀 확인
1. 네트워크 정상 상태에서 전체 결제 → 프린트 → 완료 플로우 진행
   - 프로그레스바가 0→10%(API 단계) → 10→99%(프린트 단계)로 자연스럽게 진행되는지 확인
   - 완료 다이얼로그만 표시되고 에러 다이얼로그는 표시되지 않는지 확인

## 📎 기타 참고 사항

### 주요 변경 파일 목록
- `lib/presentation/payment/payment_screen.dart`
- `lib/presentation/print/print_process_screen.dart`
- `lib/presentation/print/isolate/printer_manager.dart`
- `lib/app.dart`
- `lib/locale_keys.dart`
- `assets/lang/ko-KR.json`, `en-US.json`, `ja-JP.json`, `zh-CN.json`

### 브랜치 정보
- **Source Branch**: `fix/network-error-print-complete-dialog`
- **Target Branch**: `develop`

### 커밋 히스토리 요약
- fix: 결제 중 네트워크 에러 발생 시 화면 동결 해소
- fix: 프린트 중 네트워크 에러 즉시 감지 및 상황별 처리 분기
- fix: 프린트 완료 후 네트워크 에러 알림 미표시 버그 수정
- fix: 프린트 완료 후 네트워크 에러 알림 방식 변경
- fix: 프린터 시작 전 네트워크 에러 시 자동 환불 로직 제거
- fix: PrintMessage isolate 타임아웃 30초 → 90초로 증가
- fix: 프린트 네트워크 에러 처리 개선 및 프로그레스바 실제 출력 시점 연동

## 🙏 리뷰 요청 포인트

1. **프린터 동작 중 네트워크 에러 무시 로직**
   - `ref.read(printerServiceProvider).isLoading` 으로 프린터 동작 여부를 판단
   - 프린터가 실행 중이면 네트워크 에러를 무시하고 완료 후 처리 — 이 판단 기준이 적절한지 확인 요청

2. **완료 다이얼로그 후 네트워크 에러 다이얼로그 표시 방식**
   - `Future.delayed(300ms)` + `rootNavigatorKey.currentContext` 사용
   - 다이얼로그 스택 처리 타이밍이 안정적인지 확인 요청