### PR TITLE
feat: 뒷면 추천이미지 단일 항목 시 네온 테두리 효과 추가

### DIFF
--- a/lib/presentation/payment/payment_screen.dart
+++ b/lib/presentation/payment/payment_screen.dart
@@ -99,6 +99,7 @@ class _PaymentScreenState extends ConsumerState<PaymentScreen> {
   Widget _buildFixedBackPhotoCard({
     required List<BoxShadow>? boxShadow,
     required String? imageUrl,
+    bool hasBorder = false,
   }) {
     return Container(
       width: 226.w,
@@ -106,8 +107,26 @@ class _PaymentScreenState extends ConsumerState<PaymentScreen> {
       clipBehavior: Clip.antiAlias,
       decoration: BoxDecoration(
         borderRadius: BorderRadius.circular(10.r),
-        border: null,
-        boxShadow: boxShadow,
+        border: hasBorder ? Border.all(color: Colors.white, width: 1.w) : null,
+        boxShadow: hasBorder
+            ? [
+                BoxShadow(
+                  color: Colors.white.withValues(alpha: 0.8),
+                  blurRadius: 4.r,
+                  spreadRadius: 1.r,
+                ),
+                BoxShadow(
+                  color: Colors.white.withValues(alpha: 0.4),
+                  blurRadius: 12.r,
+                  spreadRadius: 3.r,
+                ),
+                BoxShadow(
+                  color: Colors.white.withValues(alpha: 0.2),
+                  blurRadius: 28.r,
+                  spreadRadius: 6.r,
+                ),
+              ]
+            : boxShadow,
       ),
       child: ClipRRect(
         borderRadius: BorderRadius.circular(10.r),
@@ -168,7 +187,11 @@ class _PaymentScreenState extends ConsumerState<PaymentScreen> {
             mainAxisAlignment: MainAxisAlignment.center,
             children: [
               if (nominatedBackPhotoCardList.length == 1)
-                _buildFixedBackPhotoCard(boxShadow: null, imageUrl: nominatedBackPhotoCardList[0].originUrl)
+                _buildFixedBackPhotoCard(
+                  boxShadow: null,
+                  imageUrl: nominatedBackPhotoCardList[0].originUrl,
+                  hasBorder: true,
+                )
               else
                 _buildVariant6AnimatedScaleOnUnselected(
                   index: 0,

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: flutter_snaptag_kiosk
 description: "A new Flutter project."
 publish_to: "none"
-version: 4.1.8
+version: 4.1.9
 
 environment:
   sdk: ^3.6.0


### PR DESCRIPTION
## Summary
- `nominatedBackPhotoCardList`가 1개일 때만 흰색 1pt 테두리 + 3겹 neon glow 표시
- 2개일 경우 기존 선택 애니메이션 UI(scale + opacity + buttonColor shadow) 유지
- `hasBorder` bool 플래그로 border 스타일 캡슐화

## Test plan
- [ ] 뒷면 이미지 1개인 키오스크에서 네온 테두리 표시 확인
- [ ] 뒷면 이미지 2개인 키오스크에서 기존 선택 애니메이션 정상 동작 확인
- [ ] 커스텀 QR 뒷면 이미지에서 테두리 없음 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)