### PR TITLE
chore: 버전 4.1.10 및 clearLibrary 비활성화

### DIFF
--- a/lib/presentation/print/isolate/printer_manager.dart
+++ b/lib/presentation/print/isolate/printer_manager.dart
@@ -244,7 +244,7 @@ class PrinterManager {
   Future<void> _initLibrary(PrinterBindings bindings) async {
     try {
       logger.i('1. Initializing printer library...');
-      bindings.clearLibrary();
+      // bindings.clearLibrary();
       bindings.initLibrary();
     } catch (e) {
       rethrow;
@@ -472,7 +472,7 @@ class PrinterManager {
 
       logger.i('2. Initializing printer library...');
 
-      bindings.clearLibrary();
+      // bindings.clearLibrary();
 
       logger.i('3. Printer library initialized');
       bindings.initLibrary();

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: flutter_snaptag_kiosk
 description: "A new Flutter project."
 publish_to: "none"
-version: 4.1.9
+version: 4.1.10
 
 environment:
   sdk: ^3.6.0


### PR DESCRIPTION
## Summary
- 버전 4.1.9 → 4.1.10 업데이트
- printer_manager: clearLibrary() 호출 주석 처리 (초기화 및 재시작 시)

## Test plan
- [ ] 앱 버전 4.1.10 확인
- [ ] 프린터 초기화 정상 동작 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)