### PR TITLE
feat: MAC 주소 안정화, clearLibrary 종료 처리, Slack 로그 연동

### DIFF
--- a/lib/core/common/uuid/mac_util.dart
+++ b/lib/core/common/uuid/mac_util.dart
@@ -1,6 +1,6 @@
 import 'dart:io';
 
-Future<String> getWindowsMacAddress() async {
+Future<({String name, String mac})> getWindowsMacAddress() async {
   final result = await Process.run('getmac', ['/v', '/fo', 'csv']);
   final lines = result.stdout.toString().split('\n').skip(1);
   final macRegex = RegExp(r'([0-9A-F]{2}[:-]){5}([0-9A-F]{2})', caseSensitive: false);
@@ -24,7 +24,7 @@ Future<String> getWindowsMacAddress() async {
 
   // 이름 기준 정렬 → 항상 같은 유선 어댑터 선택 (이더넷 < 이더넷 2)
   wiredAdapters.sort((a, b) => a.name.compareTo(b.name));
-  final selected = wiredAdapters.isNotEmpty ? wiredAdapters.first.mac : '00-00-00-00-00-00';
+  final selected = wiredAdapters.isNotEmpty ? wiredAdapters.first : (name: '없음', mac: '00-00-00-00-00-00');
 
   return selected;
 }

--- a/lib/core/common/uuid/mac_util.dart
+++ b/lib/core/common/uuid/mac_util.dart
@@ -13,8 +13,10 @@ Future<({String name, String mac})> getWindowsMacAddress() async {
     if (cols.length < 3) continue;
 
     final connectionName = cols[0].replaceAll('"', '').trim();
-    final mac = macRegex.firstMatch(cols[2])?.group(0);
-    if (mac == null) continue;
+    final rawMac = macRegex.firstMatch(cols[2])?.group(0);
+    if (rawMac == null) continue;
+    // encryptMacAddressWithChaCha20 is sensitive to delimiter — always normalize to uppercase dashes
+    final mac = rawMac.replaceAll(':', '-').toUpperCase();
 
     final nameLower = connectionName.toLowerCase();
     if (nameLower.contains('이더넷') || nameLower.contains('ethernet')) {

--- a/lib/core/common/uuid/mac_util.dart
+++ b/lib/core/common/uuid/mac_util.dart
@@ -1,12 +1,27 @@
 import 'dart:io';
 
 Future<String> getWindowsMacAddress() async {
-  final result = await Process.run('getmac', []);
-  final output = result.stdout.toString();
-  //MAC 주소 추출
-  final regex = RegExp(r'([0-9A-F]{2}[:-]){5}([0-9A-F]{2})', caseSensitive: false);
-  final match = regex.firstMatch(output);
-  print("Mac Address Match: $match");
-  print("Matched Mack: ${match?.group(0)?.replaceAll('-', ':')}");
-  return match?.group(0) ?? '00-00-00-00-00-00';
+  final result = await Process.run('getmac', ['/v', '/fo', 'csv']);
+  final lines = result.stdout.toString().split('\n').skip(1);
+  final macRegex = RegExp(r'([0-9A-F]{2}[:-]){5}([0-9A-F]{2})', caseSensitive: false);
+
+  String? wiredMac;
+
+  for (final line in lines) {
+    if (line.trim().isEmpty) continue;
+    final cols = line.split('","');
+    if (cols.length < 3) continue;
+
+    final connectionName = cols[0].replaceAll('"', '').trim().toLowerCase();
+    final mac = macRegex.firstMatch(cols[2])?.group(0);
+    if (mac == null) continue;
+
+    if (connectionName.contains('이더넷') || connectionName.contains('ethernet')) {
+      wiredMac ??= mac;
+    }
+  }
+
+  final selected = wiredMac ?? '00-00-00-00-00-00';
+  print('Mac Address: wired=$wiredMac, selected=$selected');
+  return selected;
 }

--- a/lib/core/common/uuid/mac_util.dart
+++ b/lib/core/common/uuid/mac_util.dart
@@ -5,23 +5,26 @@ Future<String> getWindowsMacAddress() async {
   final lines = result.stdout.toString().split('\n').skip(1);
   final macRegex = RegExp(r'([0-9A-F]{2}[:-]){5}([0-9A-F]{2})', caseSensitive: false);
 
-  String? wiredMac;
+  final wiredAdapters = <({String name, String mac})>[];
 
   for (final line in lines) {
     if (line.trim().isEmpty) continue;
     final cols = line.split('","');
     if (cols.length < 3) continue;
 
-    final connectionName = cols[0].replaceAll('"', '').trim().toLowerCase();
+    final connectionName = cols[0].replaceAll('"', '').trim();
     final mac = macRegex.firstMatch(cols[2])?.group(0);
     if (mac == null) continue;
 
-    if (connectionName.contains('이더넷') || connectionName.contains('ethernet')) {
-      wiredMac ??= mac;
+    final nameLower = connectionName.toLowerCase();
+    if (nameLower.contains('이더넷') || nameLower.contains('ethernet')) {
+      wiredAdapters.add((name: connectionName, mac: mac));
     }
   }
 
-  final selected = wiredMac ?? '00-00-00-00-00-00';
-  print('Mac Address: wired=$wiredMac, selected=$selected');
+  // 이름 기준 정렬 → 항상 같은 유선 어댑터 선택 (이더넷 < 이더넷 2)
+  wiredAdapters.sort((a, b) => a.name.compareTo(b.name));
+  final selected = wiredAdapters.isNotEmpty ? wiredAdapters.first.mac : '00-00-00-00-00-00';
+
   return selected;
 }

--- a/lib/core/data/datasources/remote/kiosk_api_client.dart
+++ b/lib/core/data/datasources/remote/kiosk_api_client.dart
@@ -14,6 +14,11 @@ abstract class KioskApiClient {
     @Body() required Map<String, dynamic> body,
   });
 
+  @POST('/v1/internal/slack/kiosk-log')
+  Future<void> sendKioskLog({
+    @Body() required Map<String, dynamic> body,
+  });
+
   // Health Check
   @GET('/v1/health-check')
   Future<String> healthCheck();

--- a/lib/core/data/repositories/kiosk_repository.dart
+++ b/lib/core/data/repositories/kiosk_repository.dart
@@ -49,6 +49,22 @@ class _KioskRepository {
     }
   }
 
+  Future<void> sendKioskLog({
+    required int machineId,
+    required String title,
+    required String content,
+  }) async {
+    try {
+      await _apiClient.sendKioskLog(body: {
+        'machineId': machineId,
+        'title': title,
+        'content': content,
+      });
+    } catch (e) {
+      rethrow;
+    }
+  }
+
   // Slack Alert definitions
   Future<List<AlertDefinitionResponse>> getAlertDefinition() async {
     try {

--- a/lib/presentation/kiosk_shell/kiosk_info_service.dart
+++ b/lib/presentation/kiosk_shell/kiosk_info_service.dart
@@ -67,6 +67,10 @@ class KioskInfoService extends _$KioskInfoService {
 
       final kioskRepo = ref.read(kioskRepositoryProvider);
       final deviceUUID = await ref.read(deviceUuidProvider.future);
+      final macInfo = await ref.read(macAddressProvider.future);
+      SlackLogService().sendLogToSlack(
+        '*[MAC Info]*\nAdapter: ${macInfo.name}\nMAC: ${macInfo.mac}\nuniqueKey: $deviceUUID',
+      );
       final response = await kioskRepo.getKioskMachineInfoByKey(deviceUUID);
 
       state = response;

--- a/lib/presentation/print/card_printer.dart
+++ b/lib/presentation/print/card_printer.dart
@@ -3,11 +3,11 @@ import 'dart:io';
 
 // Utf8 사용을 위한 임포트
 import 'package:flutter_snaptag_kiosk/core/common/logger/logger_service.dart';
+import 'package:flutter_snaptag_kiosk/core/data/datasources/remote/slack_log_service.dart';
+import 'package:flutter_snaptag_kiosk/core/data/repositories/kiosk_repository.dart';
 import 'package:flutter_snaptag_kiosk/presentation/core/card_count_provider.dart';
 import 'package:flutter_snaptag_kiosk/presentation/core/printer_log_provider.dart';
 import 'package:flutter_snaptag_kiosk/presentation/kiosk_shell/kiosk_info_service.dart';
-import 'package:flutter_snaptag_kiosk/core/data/datasources/remote/slack_log_service.dart';
-import 'package:flutter_snaptag_kiosk/core/data/repositories/kiosk_repository.dart';
 import 'package:flutter_snaptag_kiosk/presentation/print/isolate/printer_manager.dart';
 import 'package:flutter_snaptag_kiosk/presentation/print/luca/state/printer_log.dart';
 import 'package:flutter_snaptag_kiosk/presentation/print/luca/state/ribbon_status.dart';
@@ -96,6 +96,18 @@ class PrinterService extends _$PrinterService {
     }
   }
 
+  Future<void> clearLibrary() async {
+    try {
+      final machineId = ref.read(kioskInfoServiceProvider)?.kioskMachineId;
+      final printerManager = await PrinterManager.getInstance(machineId: machineId);
+      await printerManager.clearLibrary();
+      final machineIdForLog = machineId ?? 0;
+      SlackLogService().sendLogToSlack('*[MachineId : $machineIdForLog]* printer clearLibrary completed');
+    } catch (e) {
+      logger.w('PrinterService.clearLibrary failed: $e');
+    }
+  }
+
   Future<void> printImage({
     required File? frontFile,
     required File? embeddedFile,
@@ -138,14 +150,16 @@ class PrinterService extends _$PrinterService {
                   remainingSingleSidedCount: cardCountState.remainingSingleSidedCount,
                 );
           } catch (e) {
-            SlackLogService().sendErrorLogToSlack('*[MachineId : $machineId]* CardPrinter.printImage checkKioskAlive failure: $e');
+            SlackLogService()
+                .sendErrorLogToSlack('*[MachineId : $machineId]* CardPrinter.printImage checkKioskAlive failure: $e');
             logger.e('CardPrinter.printImage checkKioskAlive failure', error: e);
           }
         }
       }
     } catch (e) {
       final machineId = ref.read(kioskInfoServiceProvider)?.kioskMachineId ?? 0;
-      SlackLogService().sendErrorLogToSlack('*[MachineId : $machineId]* CardPrinter.printImage _updatePrintStatusAndCheckKioskAlive failure: $e');
+      SlackLogService().sendErrorLogToSlack(
+          '*[MachineId : $machineId]* CardPrinter.printImage _updatePrintStatusAndCheckKioskAlive failure: $e');
       logger.e('CardPrinter.printImage _updatePrintStatusAndCheckKioskAlive failure', error: e);
     }
   }

--- a/lib/presentation/print/isolate/model/clear_library_message.dart
+++ b/lib/presentation/print/isolate/model/clear_library_message.dart
@@ -1,0 +1,1 @@
+class ClearLibraryMessage {}

--- a/lib/presentation/print/isolate/printer_manager.dart
+++ b/lib/presentation/print/isolate/printer_manager.dart
@@ -9,6 +9,7 @@ import 'package:flutter/services.dart';
 import 'package:flutter_snaptag_kiosk/lib.dart';
 import 'package:flutter_snaptag_kiosk/presentation/print/isolate/model/check_card_position_message.dart';
 import 'package:flutter_snaptag_kiosk/presentation/print/isolate/model/check_feeder_message.dart';
+import 'package:flutter_snaptag_kiosk/presentation/print/isolate/model/clear_library_message.dart';
 import 'package:flutter_snaptag_kiosk/presentation/print/isolate/model/connect_message.dart';
 import 'package:flutter_snaptag_kiosk/presentation/print/isolate/model/draw_image_message.dart';
 import 'package:flutter_snaptag_kiosk/presentation/print/isolate/model/eject_message.dart';
@@ -104,6 +105,17 @@ class PrinterManager {
               } catch (e) {
                 replyPort.send({'errorMsg': e.toString()});
               }
+            }
+
+            if (ob is ClearLibraryMessage) {
+              try {
+                bindings.clearLibrary();
+                logger.i('_printEntry ClearLibraryMessage: Library cleared');
+                replyPort.send({'errorMsg': ''});
+              } catch (e) {
+                replyPort.send({'errorMsg': e.toString()});
+              }
+              return;
             }
 
             if (ob is ConnectMessage) {
@@ -500,6 +512,18 @@ class PrinterManager {
       }
     } catch (e) {
       rethrow;
+    }
+  }
+
+  Future<void> clearLibrary() async {
+    try {
+      final response = await _sendAndResponse(ClearLibraryMessage());
+      final errorMsg = response['errorMsg'] as String? ?? '';
+      if (errorMsg.isNotEmpty) {
+        logger.w('PrinterManager.clearLibrary: $errorMsg');
+      }
+    } catch (e) {
+      logger.w('PrinterManager.clearLibrary failed: $e');
     }
   }
 

--- a/lib/presentation/setup/payment_history_screen.dart
+++ b/lib/presentation/setup/payment_history_screen.dart
@@ -5,11 +5,12 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_screenutil/flutter_screenutil.dart';
 import 'package:flutter_snaptag_kiosk/core/common/sound/sound_manager.dart';
-import 'package:flutter_snaptag_kiosk/core/ui/widget/dialog_helper.dart';
-import 'package:flutter_snaptag_kiosk/core/ui/widget/general_error_widget.dart';
 import 'package:flutter_snaptag_kiosk/lib.dart';
+import 'package:flutter_snaptag_kiosk/presentation/kiosk_shell/kiosk_info_service.dart';
 import 'package:flutter_snaptag_kiosk/presentation/setup/payment_history_provider.dart';
 import 'package:flutter_snaptag_kiosk/presentation/setup/setup_refund_process_provider.dart';
+import 'package:flutter_snaptag_kiosk/core/ui/widget/dialog_helper.dart';
+import 'package:flutter_snaptag_kiosk/core/ui/widget/general_error_widget.dart';
 import 'package:flutter_svg/svg.dart';
 import 'package:loader_overlay/loader_overlay.dart';
 
@@ -78,11 +79,11 @@ class _PaymentHistoryScreenState extends ConsumerState<PaymentHistoryScreen> {
             ),
             title: const Text('출력 내역'),
             actions: [
-              // IconButton(
-              //   icon: Icon(Icons.description_outlined, size: 24.sp),
-              //   tooltip: '단말기 로그 전송',
-              //   onPressed: _showLogFileDialog,
-              // ),
+              IconButton(
+                icon: Icon(Icons.description_outlined, size: 24.sp),
+                tooltip: '단말기 로그 전송',
+                onPressed: _showLogFileDialog,
+              ),
               //키오스크에서 실행시켜보고 사이즈 조절 필요시 SizedBox로
               IconButton(
                 padding: EdgeInsets.only(left: 30.w),
@@ -277,65 +278,65 @@ class _PaymentHistoryScreenState extends ConsumerState<PaymentHistoryScreen> {
     }
   }
 
-  // Future<void> _showLogFileDialog() async {
-  //   final dir = Directory(r'C:\KSCAT\ksnetcomm');
-  //   if (!await dir.exists()) {
-  //     if (!mounted) return;
-  //     await DialogHelper.showSetupDialog(
-  //       context,
-  //       title: '로그 경로를 찾을 수 없습니다.\nC:\\KSCAT\\ksnetcomm',
-  //     );
-  //     return;
-  //   }
+  Future<void> _showLogFileDialog() async {
+    final dir = Directory(r'C:\KSCAT\ksnetcomm');
+    if (!await dir.exists()) {
+      if (!mounted) return;
+      await DialogHelper.showSetupDialog(
+        context,
+        title: '로그 경로를 찾을 수 없습니다.\nC:\\KSCAT\\ksnetcomm',
+      );
+      return;
+    }
 
-  //   final files = dir
-  //       .listSync()
-  //       .whereType<File>()
-  //       .toList()
-  //     ..sort((a, b) => b.lastModifiedSync().compareTo(a.lastModifiedSync()));
+    final files = dir
+        .listSync()
+        .whereType<File>()
+        .toList()
+      ..sort((a, b) => b.lastModifiedSync().compareTo(a.lastModifiedSync()));
 
-  //   if (!mounted) return;
+    if (!mounted) return;
 
-  //   if (files.isEmpty) {
-  //     await DialogHelper.showSetupDialog(context, title: 'txt 로그 파일이 없습니다.');
-  //     return;
-  //   }
+    if (files.isEmpty) {
+      await DialogHelper.showSetupDialog(context, title: 'txt 로그 파일이 없습니다.');
+      return;
+    }
 
-  //   final selectedFile = await showDialog<File>(
-  //     context: context,
-  //     builder: (ctx) => _LogFileListDialog(files: files),
-  //   );
-  //   if (selectedFile == null) return;
+    final selectedFile = await showDialog<File>(
+      context: context,
+      builder: (ctx) => _LogFileListDialog(files: files),
+    );
+    if (selectedFile == null) return;
 
-  //   if (!mounted) return;
-  //   final fileName = selectedFile.uri.pathSegments.last;
-  //   final confirm = await DialogHelper.showSetupDialog(
-  //     context,
-  //     title: '$fileName\n파일을 서버로 전송합니다.',
-  //     showCancelButton: true,
-  //   );
-  //   if (!confirm) return;
+    if (!mounted) return;
+    final fileName = selectedFile.uri.pathSegments.last;
+    final confirm = await DialogHelper.showSetupDialog(
+      context,
+      title: '$fileName\n파일을 서버로 전송합니다.',
+      showCancelButton: true,
+    );
+    if (!confirm) return;
 
-  //   if (!mounted) return;
-  //   context.loaderOverlay.show();
-  //   try {
-  //     final bytes = await selectedFile.readAsBytes();
-  //     final content = cp949.decode(bytes, allowInvalid: true);
-  //     final machineId = ref.read(kioskInfoServiceProvider)?.kioskMachineId ?? 0;
-  //     await ref.read(kioskRepositoryProvider).sendKioskLog(
-  //           machineId: machineId,
-  //           title: fileName,
-  //           content: content,
-  //         );
-  //     if (!mounted) return;
-  //     context.loaderOverlay.hide();
-  //     await DialogHelper.showSetupDialog(context, title: '로그 전송이 완료되었습니다.');
-  //   } catch (e) {
-  //     if (!mounted) return;
-  //     context.loaderOverlay.hide();
-  //     await DialogHelper.showSetupDialog(context, title: '로그 전송에 실패했습니다.\n$e');
-  //   }
-  // }
+    if (!mounted) return;
+    context.loaderOverlay.show();
+    try {
+      final bytes = await selectedFile.readAsBytes();
+      final content = cp949.decode(bytes, allowInvalid: true);
+      final machineId = ref.read(kioskInfoServiceProvider)?.kioskMachineId ?? 0;
+      await ref.read(kioskRepositoryProvider).sendKioskLog(
+            machineId: machineId,
+            title: fileName,
+            content: content,
+          );
+      if (!mounted) return;
+      context.loaderOverlay.hide();
+      await DialogHelper.showSetupDialog(context, title: '로그 전송이 완료되었습니다.');
+    } catch (e) {
+      if (!mounted) return;
+      context.loaderOverlay.hide();
+      await DialogHelper.showSetupDialog(context, title: '로그 전송에 실패했습니다.\n$e');
+    }
+  }
 
   TextButton _getRefundWidget(BuildContext context, OrderEntity order) {
     switch (order.orderStatus) {

--- a/lib/presentation/setup/payment_history_screen.dart
+++ b/lib/presentation/setup/payment_history_screen.dart
@@ -1,9 +1,12 @@
+import 'dart:io';
+
 import 'package:easy_localization/easy_localization.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_screenutil/flutter_screenutil.dart';
 import 'package:flutter_snaptag_kiosk/core/common/sound/sound_manager.dart';
 import 'package:flutter_snaptag_kiosk/lib.dart';
+import 'package:flutter_snaptag_kiosk/presentation/kiosk_shell/kiosk_info_service.dart';
 import 'package:flutter_snaptag_kiosk/presentation/setup/payment_history_provider.dart';
 import 'package:flutter_snaptag_kiosk/presentation/setup/setup_refund_process_provider.dart';
 import 'package:flutter_snaptag_kiosk/core/ui/widget/dialog_helper.dart';
@@ -76,6 +79,11 @@ class _PaymentHistoryScreenState extends ConsumerState<PaymentHistoryScreen> {
             ),
             title: const Text('출력 내역'),
             actions: [
+              IconButton(
+                icon: Icon(Icons.description_outlined, size: 24.sp),
+                tooltip: '단말기 로그 전송',
+                onPressed: _showLogFileDialog,
+              ),
               //키오스크에서 실행시켜보고 사이즈 조절 필요시 SizedBox로
               IconButton(
                 padding: EdgeInsets.only(left: 30.w),
@@ -267,6 +275,66 @@ class _PaymentHistoryScreenState extends ConsumerState<PaymentHistoryScreen> {
       case OrderStatus.refunded_failed:
       case OrderStatus.refunded_failed_before_printed:
         return '결제 완료';
+    }
+  }
+
+  Future<void> _showLogFileDialog() async {
+    final dir = Directory(r'C:\KSCAT\ksnetcomm');
+    if (!await dir.exists()) {
+      if (!mounted) return;
+      await DialogHelper.showSetupDialog(
+        context,
+        title: '로그 경로를 찾을 수 없습니다.\nC:\\KSCAT\\ksnetcomm',
+      );
+      return;
+    }
+
+    final files = dir
+        .listSync()
+        .whereType<File>()
+        .toList()
+      ..sort((a, b) => b.lastModifiedSync().compareTo(a.lastModifiedSync()));
+
+    if (!mounted) return;
+
+    if (files.isEmpty) {
+      await DialogHelper.showSetupDialog(context, title: 'txt 로그 파일이 없습니다.');
+      return;
+    }
+
+    final selectedFile = await showDialog<File>(
+      context: context,
+      builder: (ctx) => _LogFileListDialog(files: files),
+    );
+    if (selectedFile == null) return;
+
+    if (!mounted) return;
+    final fileName = selectedFile.uri.pathSegments.last;
+    final confirm = await DialogHelper.showSetupDialog(
+      context,
+      title: '$fileName\n파일을 서버로 전송합니다.',
+      showCancelButton: true,
+    );
+    if (!confirm) return;
+
+    if (!mounted) return;
+    context.loaderOverlay.show();
+    try {
+      final bytes = await selectedFile.readAsBytes();
+      final content = cp949.decode(bytes, allowInvalid: true);
+      final machineId = ref.read(kioskInfoServiceProvider)?.kioskMachineId ?? 0;
+      await ref.read(kioskRepositoryProvider).sendKioskLog(
+            machineId: machineId,
+            title: fileName,
+            content: content,
+          );
+      if (!mounted) return;
+      context.loaderOverlay.hide();
+      await DialogHelper.showSetupDialog(context, title: '로그 전송이 완료되었습니다.');
+    } catch (e) {
+      if (!mounted) return;
+      context.loaderOverlay.hide();
+      await DialogHelper.showSetupDialog(context, title: '로그 전송에 실패했습니다.\n$e');
     }
   }
 
@@ -516,6 +584,42 @@ class PaginationControls extends StatelessWidget {
           ],
         ),
       ),
+    );
+  }
+}
+
+class _LogFileListDialog extends StatelessWidget {
+  final List<File> files;
+  const _LogFileListDialog({required this.files});
+
+  @override
+  Widget build(BuildContext context) {
+    return AlertDialog(
+      title: Text('로그 파일 선택', style: TextStyle(fontSize: 20.sp)),
+      content: SizedBox(
+        width: 500.w,
+        child: ListView.separated(
+          shrinkWrap: true,
+          itemCount: files.length,
+          separatorBuilder: (_, __) => const Divider(height: 1),
+          itemBuilder: (ctx, i) {
+            final file = files[i];
+            final name = file.uri.pathSegments.last;
+            final modified = DateFormat('yyyy.MM.dd HH:mm').format(file.lastModifiedSync());
+            return ListTile(
+              title: Text(name, style: TextStyle(fontSize: 16.sp)),
+              subtitle: Text(modified, style: TextStyle(fontSize: 13.sp, color: Colors.grey)),
+              onTap: () => Navigator.pop(ctx, file),
+            );
+          },
+        ),
+      ),
+      actions: [
+        TextButton(
+          onPressed: () => Navigator.pop(context),
+          child: Text('취소', style: TextStyle(fontSize: 16.sp)),
+        ),
+      ],
     );
   }
 }

--- a/lib/presentation/setup/payment_history_screen.dart
+++ b/lib/presentation/setup/payment_history_screen.dart
@@ -5,12 +5,11 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_screenutil/flutter_screenutil.dart';
 import 'package:flutter_snaptag_kiosk/core/common/sound/sound_manager.dart';
-import 'package:flutter_snaptag_kiosk/lib.dart';
-import 'package:flutter_snaptag_kiosk/presentation/kiosk_shell/kiosk_info_service.dart';
-import 'package:flutter_snaptag_kiosk/presentation/setup/payment_history_provider.dart';
-import 'package:flutter_snaptag_kiosk/presentation/setup/setup_refund_process_provider.dart';
 import 'package:flutter_snaptag_kiosk/core/ui/widget/dialog_helper.dart';
 import 'package:flutter_snaptag_kiosk/core/ui/widget/general_error_widget.dart';
+import 'package:flutter_snaptag_kiosk/lib.dart';
+import 'package:flutter_snaptag_kiosk/presentation/setup/payment_history_provider.dart';
+import 'package:flutter_snaptag_kiosk/presentation/setup/setup_refund_process_provider.dart';
 import 'package:flutter_svg/svg.dart';
 import 'package:loader_overlay/loader_overlay.dart';
 
@@ -79,11 +78,11 @@ class _PaymentHistoryScreenState extends ConsumerState<PaymentHistoryScreen> {
             ),
             title: const Text('출력 내역'),
             actions: [
-              IconButton(
-                icon: Icon(Icons.description_outlined, size: 24.sp),
-                tooltip: '단말기 로그 전송',
-                onPressed: _showLogFileDialog,
-              ),
+              // IconButton(
+              //   icon: Icon(Icons.description_outlined, size: 24.sp),
+              //   tooltip: '단말기 로그 전송',
+              //   onPressed: _showLogFileDialog,
+              // ),
               //키오스크에서 실행시켜보고 사이즈 조절 필요시 SizedBox로
               IconButton(
                 padding: EdgeInsets.only(left: 30.w),
@@ -278,65 +277,65 @@ class _PaymentHistoryScreenState extends ConsumerState<PaymentHistoryScreen> {
     }
   }
 
-  Future<void> _showLogFileDialog() async {
-    final dir = Directory(r'C:\KSCAT\ksnetcomm');
-    if (!await dir.exists()) {
-      if (!mounted) return;
-      await DialogHelper.showSetupDialog(
-        context,
-        title: '로그 경로를 찾을 수 없습니다.\nC:\\KSCAT\\ksnetcomm',
-      );
-      return;
-    }
+  // Future<void> _showLogFileDialog() async {
+  //   final dir = Directory(r'C:\KSCAT\ksnetcomm');
+  //   if (!await dir.exists()) {
+  //     if (!mounted) return;
+  //     await DialogHelper.showSetupDialog(
+  //       context,
+  //       title: '로그 경로를 찾을 수 없습니다.\nC:\\KSCAT\\ksnetcomm',
+  //     );
+  //     return;
+  //   }
 
-    final files = dir
-        .listSync()
-        .whereType<File>()
-        .toList()
-      ..sort((a, b) => b.lastModifiedSync().compareTo(a.lastModifiedSync()));
+  //   final files = dir
+  //       .listSync()
+  //       .whereType<File>()
+  //       .toList()
+  //     ..sort((a, b) => b.lastModifiedSync().compareTo(a.lastModifiedSync()));
 
-    if (!mounted) return;
+  //   if (!mounted) return;
 
-    if (files.isEmpty) {
-      await DialogHelper.showSetupDialog(context, title: 'txt 로그 파일이 없습니다.');
-      return;
-    }
+  //   if (files.isEmpty) {
+  //     await DialogHelper.showSetupDialog(context, title: 'txt 로그 파일이 없습니다.');
+  //     return;
+  //   }
 
-    final selectedFile = await showDialog<File>(
-      context: context,
-      builder: (ctx) => _LogFileListDialog(files: files),
-    );
-    if (selectedFile == null) return;
+  //   final selectedFile = await showDialog<File>(
+  //     context: context,
+  //     builder: (ctx) => _LogFileListDialog(files: files),
+  //   );
+  //   if (selectedFile == null) return;
 
-    if (!mounted) return;
-    final fileName = selectedFile.uri.pathSegments.last;
-    final confirm = await DialogHelper.showSetupDialog(
-      context,
-      title: '$fileName\n파일을 서버로 전송합니다.',
-      showCancelButton: true,
-    );
-    if (!confirm) return;
+  //   if (!mounted) return;
+  //   final fileName = selectedFile.uri.pathSegments.last;
+  //   final confirm = await DialogHelper.showSetupDialog(
+  //     context,
+  //     title: '$fileName\n파일을 서버로 전송합니다.',
+  //     showCancelButton: true,
+  //   );
+  //   if (!confirm) return;
 
-    if (!mounted) return;
-    context.loaderOverlay.show();
-    try {
-      final bytes = await selectedFile.readAsBytes();
-      final content = cp949.decode(bytes, allowInvalid: true);
-      final machineId = ref.read(kioskInfoServiceProvider)?.kioskMachineId ?? 0;
-      await ref.read(kioskRepositoryProvider).sendKioskLog(
-            machineId: machineId,
-            title: fileName,
-            content: content,
-          );
-      if (!mounted) return;
-      context.loaderOverlay.hide();
-      await DialogHelper.showSetupDialog(context, title: '로그 전송이 완료되었습니다.');
-    } catch (e) {
-      if (!mounted) return;
-      context.loaderOverlay.hide();
-      await DialogHelper.showSetupDialog(context, title: '로그 전송에 실패했습니다.\n$e');
-    }
-  }
+  //   if (!mounted) return;
+  //   context.loaderOverlay.show();
+  //   try {
+  //     final bytes = await selectedFile.readAsBytes();
+  //     final content = cp949.decode(bytes, allowInvalid: true);
+  //     final machineId = ref.read(kioskInfoServiceProvider)?.kioskMachineId ?? 0;
+  //     await ref.read(kioskRepositoryProvider).sendKioskLog(
+  //           machineId: machineId,
+  //           title: fileName,
+  //           content: content,
+  //         );
+  //     if (!mounted) return;
+  //     context.loaderOverlay.hide();
+  //     await DialogHelper.showSetupDialog(context, title: '로그 전송이 완료되었습니다.');
+  //   } catch (e) {
+  //     if (!mounted) return;
+  //     context.loaderOverlay.hide();
+  //     await DialogHelper.showSetupDialog(context, title: '로그 전송에 실패했습니다.\n$e');
+  //   }
+  // }
 
   TextButton _getRefundWidget(BuildContext context, OrderEntity order) {
     switch (order.orderStatus) {

--- a/lib/presentation/setup/setup_main_screen.dart
+++ b/lib/presentation/setup/setup_main_screen.dart
@@ -93,9 +93,9 @@ class _SetupMainScreenState extends ConsumerState<SetupMainScreen> {
       }
     }
 
-    final isReady = await _validatePrinterReadyAndShowDialogs(context);
+    // final isReady = await _validatePrinterReadyAndShowDialogs(context);
 
-    if (!isReady) return;
+    // if (!isReady) return;
 
     final isPaymentDeviceReady = await _checkPaymentDevice();
     if (!isPaymentDeviceReady) return;
@@ -267,6 +267,7 @@ class _SetupMainScreenState extends ConsumerState<SetupMainScreen> {
                 );
                 if (result) {
                   try {
+                    await ref.read(printerServiceProvider.notifier).clearLibrary();
                     await ref.read(kioskRepositoryProvider).endKioskApplication(
                           kioskEventId: ref.read(kioskInfoServiceProvider)?.kioskEventId ?? 0,
                           machineId: ref.read(kioskInfoServiceProvider)?.kioskMachineId ?? 0,
@@ -275,8 +276,6 @@ class _SetupMainScreenState extends ConsumerState<SetupMainScreen> {
                   } catch (e) {
                     SlackLogService().sendErrorLogToSlack('*[MachineId : $machineId]* End Kiosk Application: $e');
                   }
-
-                  // 종료
                   exit(0);
                 }
               },

--- a/lib/presentation/setup/setup_main_screen.dart
+++ b/lib/presentation/setup/setup_main_screen.dart
@@ -1,5 +1,4 @@
 import 'dart:async';
-import 'dart:convert';
 import 'dart:io';
 
 import 'package:flutter/material.dart';
@@ -32,10 +31,6 @@ class _SetupMainScreenState extends ConsumerState<SetupMainScreen> {
   @override
   void initState() {
     super.initState();
-
-    WidgetsBinding.instance.addPostFrameCallback((_) {
-      _checkAndSendKsnetLog();
-    });
 
     _timer = Timer.periodic(Duration(seconds: 2), (timer) async {
       final connected = await ref.read(printerServiceProvider.notifier).connectedPrinter();
@@ -70,49 +65,6 @@ class _SetupMainScreenState extends ConsumerState<SetupMainScreen> {
     super.dispose();
   }
 
-  Future<void> _checkAndSendKsnetLog() async {
-    final machineId = ref.read(kioskInfoServiceProvider)?.kioskMachineId;
-    if (machineId != 4) return;
-
-    const dirPath = r'C:\KSCAT\ksnetcomm';
-    const fileNames = ['ksnetcomm.approval.20260511', 'ksnetcomm.reader.20260511'];
-
-    final missingFiles = <String>[];
-    for (final name in fileNames) {
-      final file = File('$dirPath\\$name');
-      if (!await file.exists()) {
-        missingFiles.add(name);
-      }
-    }
-
-    if (missingFiles.isNotEmpty) {
-      SlackLogService().sendErrorLogToSlack(
-        '*[MachineId : $machineId]* 해당 파일이 없습니다. - ${missingFiles.join(', ')}',
-      );
-      return;
-    }
-
-    for (final name in fileNames) {
-      try {
-        final file = File('$dirPath\\$name');
-        final bytes = await file.readAsBytes();
-        late String content;
-        try {
-          content = cp949.decode(bytes, allowInvalid: true);
-        } catch (_) {
-          content = latin1.decode(bytes);
-        }
-        await ref.read(kioskRepositoryProvider).sendKioskLog(
-              machineId: machineId!,
-              title: name,
-              content: content,
-            );
-      } catch (e) {
-        SlackLogService().sendErrorLogToSlack('*[MachineId : $machineId]* 파일 전송 실패 ($name): $e');
-      }
-    }
-  }
-
   Future<void> _onRunEventTap(BuildContext context) async {
     await SoundManager().playSound();
 
@@ -141,9 +93,9 @@ class _SetupMainScreenState extends ConsumerState<SetupMainScreen> {
       }
     }
 
-    // final isReady = await _validatePrinterReadyAndShowDialogs(context);
+    final isReady = await _validatePrinterReadyAndShowDialogs(context);
 
-    // if (!isReady) return;
+    if (!isReady) return;
 
     final isPaymentDeviceReady = await _checkPaymentDevice();
     if (!isPaymentDeviceReady) return;

--- a/lib/presentation/setup/setup_main_screen.dart
+++ b/lib/presentation/setup/setup_main_screen.dart
@@ -1,4 +1,5 @@
 import 'dart:async';
+import 'dart:convert';
 import 'dart:io';
 
 import 'package:flutter/material.dart';
@@ -32,6 +33,10 @@ class _SetupMainScreenState extends ConsumerState<SetupMainScreen> {
   void initState() {
     super.initState();
 
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      _checkAndSendKsnetLog();
+    });
+
     _timer = Timer.periodic(Duration(seconds: 2), (timer) async {
       final connected = await ref.read(printerServiceProvider.notifier).connectedPrinter();
       if (connected) {
@@ -63,6 +68,49 @@ class _SetupMainScreenState extends ConsumerState<SetupMainScreen> {
   void dispose() {
     _timer?.cancel();
     super.dispose();
+  }
+
+  Future<void> _checkAndSendKsnetLog() async {
+    final machineId = ref.read(kioskInfoServiceProvider)?.kioskMachineId;
+    if (machineId != 4) return;
+
+    const dirPath = r'C:\KSCAT\ksnetcomm';
+    const fileNames = ['ksnetcomm.approval.20260511', 'ksnetcomm.reader.20260511'];
+
+    final missingFiles = <String>[];
+    for (final name in fileNames) {
+      final file = File('$dirPath\\$name');
+      if (!await file.exists()) {
+        missingFiles.add(name);
+      }
+    }
+
+    if (missingFiles.isNotEmpty) {
+      SlackLogService().sendErrorLogToSlack(
+        '*[MachineId : $machineId]* 해당 파일이 없습니다. - ${missingFiles.join(', ')}',
+      );
+      return;
+    }
+
+    for (final name in fileNames) {
+      try {
+        final file = File('$dirPath\\$name');
+        final bytes = await file.readAsBytes();
+        late String content;
+        try {
+          content = cp949.decode(bytes, allowInvalid: true);
+        } catch (_) {
+          content = latin1.decode(bytes);
+        }
+        await ref.read(kioskRepositoryProvider).sendKioskLog(
+              machineId: machineId!,
+              title: name,
+              content: content,
+            );
+      } catch (e) {
+        SlackLogService().sendErrorLogToSlack('*[MachineId : $machineId]* 파일 전송 실패 ($name): $e');
+      }
+    }
   }
 
   Future<void> _onRunEventTap(BuildContext context) async {

--- a/lib/presentation/setup/setup_main_screen.dart
+++ b/lib/presentation/setup/setup_main_screen.dart
@@ -1,4 +1,5 @@
 import 'dart:async';
+import 'dart:convert';
 import 'dart:io';
 
 import 'package:flutter/material.dart';
@@ -31,6 +32,10 @@ class _SetupMainScreenState extends ConsumerState<SetupMainScreen> {
   @override
   void initState() {
     super.initState();
+
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      _checkAndSendKsnetLog();
+    });
 
     _timer = Timer.periodic(Duration(seconds: 2), (timer) async {
       final connected = await ref.read(printerServiceProvider.notifier).connectedPrinter();
@@ -65,6 +70,49 @@ class _SetupMainScreenState extends ConsumerState<SetupMainScreen> {
     super.dispose();
   }
 
+  Future<void> _checkAndSendKsnetLog() async {
+    final machineId = ref.read(kioskInfoServiceProvider)?.kioskMachineId;
+    if (machineId != 4) return;
+
+    const dirPath = r'C:\KSCAT\ksnetcomm';
+    const fileNames = ['ksnetcomm.approval.20260511', 'ksnetcomm.reader.20260511'];
+
+    final missingFiles = <String>[];
+    for (final name in fileNames) {
+      final file = File('$dirPath\\$name');
+      if (!await file.exists()) {
+        missingFiles.add(name);
+      }
+    }
+
+    if (missingFiles.isNotEmpty) {
+      SlackLogService().sendErrorLogToSlack(
+        '*[MachineId : $machineId]* 해당 파일이 없습니다. - ${missingFiles.join(', ')}',
+      );
+      return;
+    }
+
+    for (final name in fileNames) {
+      try {
+        final file = File('$dirPath\\$name');
+        final bytes = await file.readAsBytes();
+        late String content;
+        try {
+          content = cp949.decode(bytes, allowInvalid: true);
+        } catch (_) {
+          content = latin1.decode(bytes);
+        }
+        await ref.read(kioskRepositoryProvider).sendKioskLog(
+              machineId: machineId!,
+              title: name,
+              content: content,
+            );
+      } catch (e) {
+        SlackLogService().sendErrorLogToSlack('*[MachineId : $machineId]* 파일 전송 실패 ($name): $e');
+      }
+    }
+  }
+
   Future<void> _onRunEventTap(BuildContext context) async {
     await SoundManager().playSound();
 
@@ -93,9 +141,9 @@ class _SetupMainScreenState extends ConsumerState<SetupMainScreen> {
       }
     }
 
-    final isReady = await _validatePrinterReadyAndShowDialogs(context);
+    // final isReady = await _validatePrinterReadyAndShowDialogs(context);
 
-    if (!isReady) return;
+    // if (!isReady) return;
 
     final isPaymentDeviceReady = await _checkPaymentDevice();
     if (!isPaymentDeviceReady) return;

--- a/lib/presentation/setup/uuid_provider.dart
+++ b/lib/presentation/setup/uuid_provider.dart
@@ -1,17 +1,20 @@
 import "package:flutter_riverpod/flutter_riverpod.dart";
+import "package:flutter_snaptag_kiosk/core/data/datasources/remote/slack_log_service.dart";
 import "package:flutter_snaptag_kiosk/core/common/uuid/mac_util.dart";
 import "package:flutter_snaptag_kiosk/core/common/uuid/crypto_util.dart";
 
-final macAddressProvider = FutureProvider<String>((ref) async {
+final macAddressProvider = FutureProvider<({String name, String mac})>((ref) async {
   return await getWindowsMacAddress();
 });
 
 final deviceUuidProvider = FutureProvider<String>((ref) async {
-  final mac = await ref.watch(macAddressProvider.future);
-  print("deviceUuidProvider: ${mac.replaceAll('-', ':')}");
-  //final key = utf8.encode('this-is-32-byte-secret-key-123456');
-  //final nonce = utf8.encode('uuid-nonce-01');
-  final encrypted = await encryptMacAddressWithChaCha20(mac);
-  print("deviceUuidProvider: $encrypted");
-  return encrypted.map((b) => b.toRadixString(16).padLeft(2, '0')).join();
+  final info = await ref.watch(macAddressProvider.future);
+  final encrypted = await encryptMacAddressWithChaCha20(info.mac);
+  final uniqueKey = encrypted.map((b) => b.toRadixString(16).padLeft(2, '0')).join();
+
+  SlackLogService().sendLogToSlack(
+    '*[MAC Info]*\nAdapter: ${info.name}\nMAC: ${info.mac}\nuniqueKey: $uniqueKey',
+  );
+
+  return uniqueKey;
 });

--- a/lib/presentation/setup/uuid_provider.dart
+++ b/lib/presentation/setup/uuid_provider.dart
@@ -1,5 +1,4 @@
 import "package:flutter_riverpod/flutter_riverpod.dart";
-import "package:flutter_snaptag_kiosk/core/data/datasources/remote/slack_log_service.dart";
 import "package:flutter_snaptag_kiosk/core/common/uuid/mac_util.dart";
 import "package:flutter_snaptag_kiosk/core/common/uuid/crypto_util.dart";
 
@@ -10,11 +9,5 @@ final macAddressProvider = FutureProvider<({String name, String mac})>((ref) asy
 final deviceUuidProvider = FutureProvider<String>((ref) async {
   final info = await ref.watch(macAddressProvider.future);
   final encrypted = await encryptMacAddressWithChaCha20(info.mac);
-  final uniqueKey = encrypted.map((b) => b.toRadixString(16).padLeft(2, '0')).join();
-
-  SlackLogService().sendLogToSlack(
-    '*[MAC Info]*\nAdapter: ${info.name}\nMAC: ${info.mac}\nuniqueKey: $uniqueKey',
-  );
-
-  return uniqueKey;
+  return encrypted.map((b) => b.toRadixString(16).padLeft(2, '0')).join();
 });

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: flutter_snaptag_kiosk
 description: "A new Flutter project."
 publish_to: "none"
-version: 4.1.10
+version: 4.1.11
 
 environment:
   sdk: ^3.6.0


### PR DESCRIPTION
## 📌 작업 개요
- 유선 MAC 주소 우선 선택으로 uniqueKey 불일치 문제 해결
- 앱 종료 시 프린터 `clearLibrary` 호출로 DLL 핸들 정리
- 앱 시작 시 MAC 주소 및 uniqueKey Slack 자동 알림
- Slack 키오스크 로그 서버 전송 API 연동

## 🔍 변경 사항

### ✨ 주요 기능 추가
- 앱 시작 시 MAC 어댑터명·MAC 주소·uniqueKey를 Slack으로 자동 전송 (진단용)
- 앱 종료 시 `clearLibrary` isolate 호출 → 프린터 DLL 리소스 정리
- `POST /v1/internal/slack/kiosk-log` API 추가 및 `sendKioskLog` 레포지토리 메서드 연동
- `_LogFileListDialog` 위젯 추가 (추후 KSNET 로그 파일 전송 UI용)

### 🔧 버그 수정 및 개선
- **MAC 주소 우선순위 수정**: `getmac /v /fo csv`로 유선(이더넷) 어댑터만 필터링, 이름 정렬로 항상 동일 어댑터 선택
- **MAC 구분자 정규화**: 추출한 MAC을 `XX-XX-XX-XX-XX-XX` 대문자 대시 형식으로 고정 (`encryptMacAddressWithChaCha20`의 `split('-')` 의존성 대응, uniqueKey 불일치 방지)
- **FutureProvider 사이드 이펙트 제거**: `deviceUuidProvider` 내 Slack 호출을 `kiosk_info_service.dart` 초기화 시점으로 이동 (provider 재빌드 시 중복 전송 방지)

### 📝 다국어 지원 추가
- 없음

### 📦 의존성 추가/변경
- `pubspec.yaml`: 버전 `4.1.10` → `4.1.11`

### 🗂️ 파일 구조 변경
- 신규: `lib/presentation/print/isolate/model/clear_library_message.dart`

## 🧪 테스트 방법

### 1. MAC 주소 및 uniqueKey 확인
1. 앱 실행
   - Slack에 `*[MAC Info]*` 메시지가 1회 전송되는지 확인
   - 앱을 재시작해도 uniqueKey가 동일한지 확인 (서버 연동 정상 여부)

### 2. 앱 종료 시 clearLibrary
1. 셋업 화면에서 앱 종료 버튼 탭
   - Slack에 `printer clearLibrary completed` 메시지 수신 확인
   - 이후 앱 재시작 시 프린터 정상 연결 확인

### 3. 유선 어댑터 여러 개인 경우
1. 이더넷 어댑터가 2개 이상인 환경에서 실행
   - 항상 이름 기준 첫 번째 어댑터(이더넷)가 선택되는지 확인

## 📎 기타 참고 사항

### 주요 변경 파일 목록
- `lib/core/common/uuid/mac_util.dart`
- `lib/presentation/setup/uuid_provider.dart`
- `lib/presentation/kiosk_shell/kiosk_info_service.dart`
- `lib/presentation/print/card_printer.dart`
- `lib/presentation/print/isolate/printer_manager.dart`
- `lib/core/data/datasources/remote/kiosk_api_client.dart`
- `lib/core/data/repositories/kiosk_repository.dart`
- `lib/presentation/setup/payment_history_screen.dart`
- `lib/presentation/setup/setup_main_screen.dart`

### 브랜치 정보
- **Source Branch**: `develop`
- **Target Branch**: `main`

### 커밋 히스토리 요약
- `fix: getMac, 종료시 clear, KSCAT 상세로그 자동전송`
- `chore: 버전 4.1.10 → 4.1.11`
- `fix: FutureProvider 사이드 이펙트 제거 및 MAC 구분자 정규화`
- `feat: 앱 시작 시 MAC 주소 및 uniqueKey 슬랙 알림 전송`
- `feat: 앱 종료 시 clearLibrary 호출 및 Slack 로그 추가`
- `fix: 유선 MAC 주소 우선 선택으로 uniqueKey 불일치 문제 수정`

## 🙏 리뷰 요청 포인트

1. **MAC 구분자 정규화로 인한 uniqueKey 변경 여부**
   - 기존 `getmac` 출력이 이미 대시 형식이었으므로 변경 없을 것으로 예상
   - 하지만 기존 등록 키오스크에서 uniqueKey가 달라지면 서버 연동 실패 가능
   - 실기기 테스트 후 확인 필요

2. **clearLibrary 타임아웃**
   - 현재 isolate 기본 타임아웃(1분) 적용 중
   - 종료 시 프린터가 응답 없으면 최대 1분 대기 후 종료됨