### PR TITLE
feat: 머신 파일 송수신 기능 추가

### DIFF
--- a/lib/core/common/file_io/machine_file_service.dart
+++ b/lib/core/common/file_io/machine_file_service.dart
@@ -1,0 +1,141 @@
+import 'dart:convert';
+import 'dart:io';
+import 'dart:typed_data';
+
+import 'package:archive/archive.dart';
+import 'package:flutter_snaptag_kiosk/core/common/cp949/cp949_codec.dart';
+
+enum FileReadStatus { success, directorySuccess, accessError, notFound, empty, readError }
+
+class FileReadResult {
+  const FileReadResult._({
+    required this.status,
+    this.content,
+    this.zipBytes,
+    this.error,
+  });
+
+  final FileReadStatus status;
+  final String? content;
+  // 디렉토리를 zip으로 묶은 raw bytes → repository에서 file 필드로 전송
+  final Uint8List? zipBytes;
+  final Object? error;
+
+  // 일반 파일 읽기 성공
+  factory FileReadResult.success(String content) => FileReadResult._(status: FileReadStatus.success, content: content);
+
+  // 디렉토리 zip 성공
+  factory FileReadResult.successDirectory(Uint8List zipBytes) =>
+      FileReadResult._(status: FileReadStatus.directorySuccess, zipBytes: zipBytes);
+
+  factory FileReadResult.accessError(Object error) =>
+      FileReadResult._(status: FileReadStatus.accessError, error: error);
+
+  factory FileReadResult.notFound() => FileReadResult._(status: FileReadStatus.notFound);
+
+  factory FileReadResult.empty() => FileReadResult._(status: FileReadStatus.empty);
+
+  factory FileReadResult.readError(Object error) => FileReadResult._(status: FileReadStatus.readError, error: error);
+}
+
+class MachineFileService {
+  const MachineFileService();
+
+  Future<FileReadResult> readFile(String normalizedPath) async {
+    final file = File(normalizedPath);
+
+    // 경로 접근 권한 오류 (exists() 자체가 throw하는 경우)
+    bool exists;
+    try {
+      exists = await file.exists();
+    } catch (e) {
+      return FileReadResult.accessError(e);
+    }
+
+    if (!exists) {
+      // 파일로는 없지만 디렉토리일 수 있음 → zip으로 묶어 반환
+      if (await Directory(normalizedPath).exists()) {
+        return _readDirectory(normalizedPath);
+      }
+      // 파일도 디렉토리도 아님 → 경로 자체가 없는 경우
+      return FileReadResult.notFound();
+    }
+
+    // 파일 읽기
+    try {
+      final bytes = await file.readAsBytes();
+
+      // 파일은 존재하지만 내용이 없는 경우
+      if (bytes.isEmpty) return FileReadResult.empty();
+
+      final ext = normalizedPath.split('.').last.toLowerCase();
+      const binaryExtensions = {'png', 'jpg', 'jpeg', 'gif', 'bmp', 'pdf', 'zip', 'exe', 'dll'};
+
+      final String content;
+      if (binaryExtensions.contains(ext)) {
+        // 바이너리 파일 → base64 인코딩
+        content = base64Encode(bytes);
+      } else {
+        // 텍스트 파일 → cp949 디코딩 시도, 실패 시 latin1 fallback
+        String decoded;
+        try {
+          decoded = cp949.decode(bytes, allowInvalid: true);
+        } catch (_) {
+          decoded = latin1.decode(bytes);
+        }
+        content = decoded;
+      }
+
+      return FileReadResult.success(content);
+    } catch (e) {
+      return FileReadResult.readError(e);
+    }
+  }
+
+  // 디렉토리를 재귀 탐색하여 zip으로 묶고 raw bytes 반환
+  Future<FileReadResult> _readDirectory(String dirPath) async {
+    try {
+      final archive = Archive();
+      final dir = Directory(dirPath);
+
+      // 하위 파일 전체를 상대경로로 archive에 추가 (폴더 구조 유지)
+      await for (final entity in dir.list(recursive: true)) {
+        if (entity is File) {
+          final bytes = await entity.readAsBytes();
+          // dirPath 이후 경로만 추출 (예: logs\sub\file.txt)
+          final relativePath = entity.path.substring(dirPath.length + 1);
+          archive.addFile(ArchiveFile(relativePath, bytes.length, bytes));
+        }
+      }
+
+      // 디렉토리가 존재하지만 파일이 하나도 없는 경우
+      if (archive.isEmpty) return FileReadResult.empty();
+
+      final zipBytes = Uint8List.fromList(ZipEncoder().encode(archive));
+      return FileReadResult.successDirectory(zipBytes);
+    } catch (e) {
+      return FileReadResult.readError(e);
+    }
+  }
+
+  Future<List<int>> downloadBytesFromUrl(String url) async {
+    final client = HttpClient();
+    try {
+      final request = await client.getUrl(Uri.parse(url));
+      final response = await request.close();
+      final bytes = await response.fold<List<int>>([], (buf, chunk) => buf..addAll(chunk));
+      return bytes;
+    } finally {
+      client.close();
+    }
+  }
+
+  // 받아온 경로에 바이트 스트림을 파일로 저장
+  // 중간 디렉토리가 없으면 자동 생성
+  Future<void> writeFile(String path, List<int> bytes) async {
+    final normalizedPath = path.replaceAll('/', r'\');
+    final file = File(normalizedPath);
+    await file.parent.create(recursive: true);
+    await file.writeAsBytes(bytes);
+  }
+}

--- a/lib/core/common/file_io/machine_file_service.dart
+++ b/lib/core/common/file_io/machine_file_service.dart
@@ -76,12 +76,16 @@ class MachineFileService {
         // 바이너리 파일 → base64 인코딩
         content = base64Encode(bytes);
       } else {
-        // 텍스트 파일 → cp949 디코딩 시도, 실패 시 latin1 fallback
+        // UTF-8 → CP949 → latin1 순서로 디코딩 시도
         String decoded;
         try {
-          decoded = cp949.decode(bytes, allowInvalid: true);
+          decoded = utf8.decode(bytes, allowMalformed: false);
         } catch (_) {
-          decoded = latin1.decode(bytes);
+          try {
+            decoded = cp949.decode(bytes, allowInvalid: false);
+          } catch (_) {
+            decoded = latin1.decode(bytes);
+          }
         }
         content = decoded;
       }

--- a/lib/core/common/logger/dio_logger.dart
+++ b/lib/core/common/logger/dio_logger.dart
@@ -149,7 +149,7 @@ class DioLogger extends Interceptor {
       }
     }
     if (!err.requestOptions.path.contains('slack') &&
-        !err.requestOptions.path.contains('machine/maintenance') &&
+        !err.requestOptions.path.contains('maintenance') &&
         !err.requestOptions.path.contains('polling') &&
         !err.requestOptions.path.contains('error-code')) {
       sendHook?.call(_buffer.toString());
@@ -186,7 +186,7 @@ class DioLogger extends Interceptor {
       _printLine('╚');
     }
     if (!response.requestOptions.path.contains('slack') &&
-        !response.requestOptions.path.contains('machine/maintenance') &&
+        !response.requestOptions.path.contains('maintenance') &&
         !response.requestOptions.path.contains('polling') &&
         !response.requestOptions.path.contains('error-code')) {
       sendHook?.call(_buffer.toString());

--- a/lib/core/data/datasources/remote/dio_client.dart
+++ b/lib/core/data/datasources/remote/dio_client.dart
@@ -12,6 +12,7 @@ final dioProvider = Provider.family<Dio, String>((ref, baseUrl) {
     ..options.receiveTimeout = const Duration(seconds: 30);
   dio.interceptors.add(DioLogger(
       sendHook: (log) {
+        if (log.contains('/machine/kiosk/maintenance')) return;
         SlackLogService().sendLogToSlack(log);
       },
       machineIdProvider: () => ref.read(kioskInfoServiceProvider)?.kioskMachineId,

--- a/lib/core/data/datasources/remote/kiosk_api_client.dart
+++ b/lib/core/data/datasources/remote/kiosk_api_client.dart
@@ -116,7 +116,7 @@ abstract class KioskApiClient {
   });
 
   @GET('/v1/machine/kiosk/maintenance')
-  Future<MachineMaintenanceResponse> getMachineMaintenance({
+  Future<List<MachineLogItem>> getMachineMaintenance({
     @Query('machineId') required int machineId,
   });
 }

--- a/lib/core/data/datasources/remote/kiosk_api_client.dart
+++ b/lib/core/data/datasources/remote/kiosk_api_client.dart
@@ -16,7 +16,7 @@ abstract class KioskApiClient {
 
   @POST('/v1/internal/slack/kiosk-log')
   Future<void> sendKioskLog({
-    @Body() required Map<String, dynamic> body,
+    @Body() required FormData body,
   });
 
   // Health Check
@@ -113,5 +113,10 @@ abstract class KioskApiClient {
   @POST('/v1/qr/back-photo-nominated')
   Future<BackPhotoCardResponse> getBackPhotoCardByQr({
     @Body() required Map<String, dynamic> body,
+  });
+
+  @GET('/v1/machine/kiosk/maintenance')
+  Future<MachineMaintenanceResponse> getMachineMaintenance({
+    @Query('machineId') required int machineId,
   });
 }

--- a/lib/core/data/models/request/kiosk_log_request.dart
+++ b/lib/core/data/models/request/kiosk_log_request.dart
@@ -1,0 +1,21 @@
+class KioskLogRequest {
+  const KioskLogRequest._({
+    required this.logId,
+    required this.machineId,
+    required this.title,
+    required this.content,
+  });
+
+  final int logId;
+  final int machineId;
+  final String title;
+  final String content;
+
+  factory KioskLogRequest.withLogId({
+    required int logId,
+    required int machineId,
+    required String title,
+    required String content,
+  }) =>
+      KioskLogRequest._(logId: logId, machineId: machineId, title: title, content: content);
+}

--- a/lib/core/data/models/request/request.dart
+++ b/lib/core/data/models/request/request.dart
@@ -1,4 +1,5 @@
 export 'create_order_request.dart';
+export 'kiosk_log_request.dart';
 export 'create_print_request.dart';
 export 'get_orders_request.dart';
 export 'payment_request.dart';

--- a/lib/core/data/models/response/machine_maintenance_response.dart
+++ b/lib/core/data/models/response/machine_maintenance_response.dart
@@ -1,0 +1,40 @@
+import 'package:freezed_annotation/freezed_annotation.dart';
+
+part 'machine_maintenance_response.freezed.dart';
+part 'machine_maintenance_response.g.dart';
+
+@freezed
+class MachineMaintenanceResponse with _$MachineMaintenanceResponse {
+  const factory MachineMaintenanceResponse({
+    required int machineId,
+    required bool isUnderMaintenance,
+    List<MachineLogItem>? machineLogPaths,
+    List<MachineDownloadItem>? machineDownloads,
+  }) = _MachineMaintenanceResponse;
+
+  factory MachineMaintenanceResponse.fromJson(Map<String, dynamic> json) => _$MachineMaintenanceResponseFromJson(json);
+}
+
+@freezed
+class MachineLogItem with _$MachineLogItem {
+  const factory MachineLogItem({
+    required int id,
+    required String path,
+    String? urlPath,
+    String? deviceType,
+  }) = _MachineLogItem;
+
+  factory MachineLogItem.fromJson(Map<String, dynamic> json) => _$MachineLogItemFromJson(json);
+}
+
+@freezed
+class MachineDownloadItem with _$MachineDownloadItem {
+  const factory MachineDownloadItem({
+    required int id,
+    required String path,
+    // 서버에서 base64 인코딩된 바이너리 파일 데이터
+    required String content,
+  }) = _MachineDownloadItem;
+
+  factory MachineDownloadItem.fromJson(Map<String, dynamic> json) => _$MachineDownloadItemFromJson(json);
+}

--- a/lib/core/data/models/response/response.dart
+++ b/lib/core/data/models/response/response.dart
@@ -1,4 +1,5 @@
 export 'back_photo_card_response.dart';
+export 'machine_maintenance_response.dart';
 export 'back_photo_status_response.dart';
 export 'create_order_response.dart';
 export 'create_print_response.dart';

--- a/lib/core/data/repositories/kiosk_repository.dart
+++ b/lib/core/data/repositories/kiosk_repository.dart
@@ -1,7 +1,8 @@
+import 'dart:convert';
 import 'dart:developer';
-import 'dart:typed_data';
 
 import 'package:dio/dio.dart';
+import 'package:http_parser/http_parser.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_snaptag_kiosk/core/data/models/request/unique_key_request.dart';
 import 'package:flutter_snaptag_kiosk/core/data/models/request/update_back_photo_request.dart';
@@ -50,23 +51,27 @@ class _KioskRepository {
     }
   }
 
-  Future<void> sendKioskLog(
-    KioskLogRequest request, {
-    String? step,
-    Uint8List? zipFile,
-  }) async {
+  Future<void> sendKioskLog(KioskLogRequest request, {String? step, List<int>? zipFile}) async {
+    final jsonBody = jsonEncode({
+      'id': request.logId,
+      'machineId': request.machineId,
+      'title': request.title,
+      'content': request.content,
+      if (step != null) 'step': step,
+    });
+    final formData = FormData()
+      ..files.add(MapEntry(
+        'request',
+        MultipartFile.fromString(jsonBody, contentType: MediaType('application', 'json')),
+      ));
+    if (zipFile != null) {
+      formData.files.add(MapEntry(
+        'file',
+        MultipartFile.fromBytes(zipFile, filename: request.title, contentType: MediaType('application', 'zip')),
+      ));
+    }
     try {
-      final fields = <String, dynamic>{
-        'logId': request.logId,
-        'machineId': request.machineId,
-        'title': request.title,
-        'content': request.content,
-        if (step != null) 'step': step,
-      };
-      if (zipFile != null) {
-        fields['file'] = MultipartFile.fromBytes(zipFile, filename: request.title);
-      }
-      await _apiClient.sendKioskLog(body: FormData.fromMap(fields));
+      await _apiClient.sendKioskLog(body: formData);
     } catch (e) {
       rethrow;
     }
@@ -263,7 +268,7 @@ class _KioskRepository {
     }
   }
 
-  Future<MachineMaintenanceResponse> getMachineMaintenance({required int machineId}) async {
+  Future<List<MachineLogItem>> getMachineMaintenance({required int machineId}) async {
     try {
       return await _apiClient.getMachineMaintenance(machineId: machineId);
     } catch (e) {

--- a/lib/core/data/repositories/kiosk_repository.dart
+++ b/lib/core/data/repositories/kiosk_repository.dart
@@ -1,4 +1,5 @@
 import 'dart:developer';
+import 'dart:typed_data';
 
 import 'package:dio/dio.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
@@ -49,17 +50,23 @@ class _KioskRepository {
     }
   }
 
-  Future<void> sendKioskLog({
-    required int machineId,
-    required String title,
-    required String content,
+  Future<void> sendKioskLog(
+    KioskLogRequest request, {
+    String? step,
+    Uint8List? zipFile,
   }) async {
     try {
-      await _apiClient.sendKioskLog(body: {
-        'machineId': machineId,
-        'title': title,
-        'content': content,
-      });
+      final fields = <String, dynamic>{
+        'logId': request.logId,
+        'machineId': request.machineId,
+        'title': request.title,
+        'content': request.content,
+        if (step != null) 'step': step,
+      };
+      if (zipFile != null) {
+        fields['file'] = MultipartFile.fromBytes(zipFile, filename: request.title);
+      }
+      await _apiClient.sendKioskLog(body: FormData.fromMap(fields));
     } catch (e) {
       rethrow;
     }
@@ -251,6 +258,14 @@ class _KioskRepository {
       return await _apiClient.getBackPhotoCardByQr(
         body: request.toJson(),
       );
+    } catch (e) {
+      rethrow;
+    }
+  }
+
+  Future<MachineMaintenanceResponse> getMachineMaintenance({required int machineId}) async {
+    try {
+      return await _apiClient.getMachineMaintenance(machineId: machineId);
     } catch (e) {
       rethrow;
     }

--- a/lib/presentation/home/home_screen.dart
+++ b/lib/presentation/home/home_screen.dart
@@ -1,17 +1,85 @@
+import 'dart:async';
+import 'dart:developer';
+
 import 'package:easy_localization/easy_localization.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_screenutil/flutter_screenutil.dart';
 import 'package:flutter_snaptag_kiosk/lib.dart';
 import 'package:flutter_snaptag_kiosk/presentation/home/back_photo_type_provider.dart';
+import 'package:flutter_snaptag_kiosk/presentation/home/machine_file_handler.dart';
 import 'package:flutter_snaptag_kiosk/presentation/kiosk_shell/kiosk_info_service.dart';
 import 'package:qr_flutter/qr_flutter.dart';
 
-class HomeScreen extends ConsumerWidget {
+class HomeScreen extends ConsumerStatefulWidget {
   const HomeScreen({super.key});
 
   @override
-  Widget build(BuildContext context, WidgetRef ref) {
+  ConsumerState<HomeScreen> createState() => _HomeScreenState();
+}
+
+class _HomeScreenState extends ConsumerState<HomeScreen> {
+  Timer? _maintenanceTimer;
+  bool _isCheckingMaintenance = false;
+
+  @override
+  void initState() {
+    super.initState();
+    _startMaintenancePolling();
+  }
+
+  @override
+  void dispose() {
+    _maintenanceTimer?.cancel();
+    super.dispose();
+  }
+
+  void _startMaintenancePolling() {
+    _maintenanceTimer?.cancel();
+    _maintenanceTimer = Timer.periodic(const Duration(seconds: 3), (_) async {
+      if (_isCheckingMaintenance) return;
+      _isCheckingMaintenance = true;
+      try {
+        await _checkMaintenance();
+      } finally {
+        _isCheckingMaintenance = false;
+      }
+    });
+  }
+
+  Future<void> _checkMaintenance() async {
+    try {
+      final kioskInfo = ref.read(kioskInfoServiceProvider);
+      if (kioskInfo == null) return;
+
+      final response = await ref.read(kioskRepositoryProvider).getMachineMaintenance(
+            machineId: kioskInfo.kioskMachineId,
+          );
+
+      final logItems = response.machineLogPaths;
+      if (logItems != null && logItems.isNotEmpty) {
+        final kioskItems = logItems.where((item) => item.deviceType == 'KIOSK').toList();
+        final userItems = logItems.where((item) => item.deviceType == 'USER').toList();
+
+        if (kioskItems.isNotEmpty) {
+          await ref.read(machineFileHandlerProvider).sendLogFiles(kioskItems, kioskInfo.kioskMachineId);
+        }
+        if (userItems.isNotEmpty) {
+          await ref.read(machineFileHandlerProvider).downloadLogFiles(userItems, kioskInfo.kioskMachineId);
+        }
+      }
+
+      final downloadItems = response.machineDownloads;
+      if (downloadItems != null && downloadItems.isNotEmpty) {
+        await ref.read(machineFileHandlerProvider).downloadFiles(downloadItems, kioskInfo.kioskMachineId);
+      }
+    } catch (e) {
+      log('[MachineCheck] 점검 확인 실패: $e');
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
     final kiosk = ref.watch(kioskInfoServiceProvider);
     final isHwe = kiosk?.isHwe ?? false;
     final buttonColor = kiosk?.mainButtonColor.toColor() ?? Colors.black;
@@ -113,7 +181,6 @@ class HomeScreen extends ConsumerWidget {
     );
   }
 
-  /// 추천 이미지 카드 위젯 빌드
   Widget _buildRecommendedImageCard(
     BuildContext context, {
     required String title,
@@ -146,7 +213,6 @@ class HomeScreen extends ConsumerWidget {
         ),
         child: Stack(
           children: [
-            // 그라데이션 오버레이
             Positioned.fill(
               child: CustomPaint(
                 painter: _GradientOverlayPainter(
@@ -212,9 +278,7 @@ class HomeScreen extends ConsumerWidget {
                 Column(
                   children: [
                     SizedBox(height: 40.h),
-                    Center(
-                      child: child,
-                    ),
+                    Center(child: child),
                     SizedBox(height: 40.h),
                     Container(
                       width: 282.w,
@@ -242,49 +306,8 @@ class HomeScreen extends ConsumerWidget {
       ),
     );
   }
-
-  Widget _buildChoiceButton(BuildContext context, WidgetRef ref, String url,
-      {required String label, required VoidCallback onTap}) {
-    return GestureDetector(
-      onTap: onTap,
-      child: Container(
-        width: 307.w,
-        height: 485.h,
-        margin: EdgeInsets.symmetric(vertical: 22.h),
-        clipBehavior: Clip.antiAlias,
-        decoration: ShapeDecoration(
-          color: Colors.transparent,
-          shape: RoundedRectangleBorder(
-            borderRadius: BorderRadius.circular(10.r),
-          ),
-        ),
-        alignment: Alignment.center,
-        child: url.isNotEmpty
-            ? Image.network(
-                url,
-                fit: BoxFit.fitHeight,
-                alignment: Alignment.center,
-                errorBuilder: (context, error, stackTrace) {
-                  return Container(
-                    color: Colors.grey[200],
-                    child: Center(
-                      child: Icon(Icons.image, size: 60.sp, color: Colors.grey[400]),
-                    ),
-                  );
-                },
-              )
-            : Container(
-                color: Colors.grey[200],
-                child: Center(
-                  child: Icon(Icons.image, size: 60.sp, color: Colors.grey[400]),
-                ),
-              ),
-      ),
-    );
-  }
 }
 
-/// 그라데이션 오버레이를 그리는 CustomPainter
 class _GradientOverlayPainter extends CustomPainter {
   final double topAlpha;
   final double bottomAlpha;
@@ -298,14 +321,12 @@ class _GradientOverlayPainter extends CustomPainter {
 
   @override
   void paint(Canvas canvas, Size size) {
-    // 상단 영역 (height 177까지, alpha 55%)
     final topRect = Rect.fromLTWH(0, 0, size.width, dividerHeight);
     final topPaint = Paint()
       ..color = Colors.white.withOpacity(topAlpha)
       ..style = PaintingStyle.fill;
     canvas.drawRect(topRect, topPaint);
 
-    // 하단 영역 (나머지, alpha 32%)
     final bottomRect = Rect.fromLTWH(0, dividerHeight, size.width, size.height - dividerHeight);
     final bottomPaint = Paint()
       ..color = Colors.white.withOpacity(bottomAlpha)

--- a/lib/presentation/home/home_screen.dart
+++ b/lib/presentation/home/home_screen.dart
@@ -56,22 +56,16 @@ class _HomeScreenState extends ConsumerState<HomeScreen> {
             machineId: kioskInfo.kioskMachineId,
           );
 
-      final logItems = response.machineLogPaths;
-      if (logItems != null && logItems.isNotEmpty) {
-        final kioskItems = logItems.where((item) => item.deviceType == 'KIOSK').toList();
-        final userItems = logItems.where((item) => item.deviceType == 'USER').toList();
+      if (response.isEmpty) return;
 
-        if (kioskItems.isNotEmpty) {
-          await ref.read(machineFileHandlerProvider).sendLogFiles(kioskItems, kioskInfo.kioskMachineId);
-        }
-        if (userItems.isNotEmpty) {
-          await ref.read(machineFileHandlerProvider).downloadLogFiles(userItems, kioskInfo.kioskMachineId);
-        }
+      final kioskItems = response.where((item) => item.deviceType == 'KIOSK').toList();
+      final userItems = response.where((item) => item.deviceType == 'USER').toList();
+
+      if (kioskItems.isNotEmpty) {
+        await ref.read(machineFileHandlerProvider).sendLogFiles(kioskItems, kioskInfo.kioskMachineId);
       }
-
-      final downloadItems = response.machineDownloads;
-      if (downloadItems != null && downloadItems.isNotEmpty) {
-        await ref.read(machineFileHandlerProvider).downloadFiles(downloadItems, kioskInfo.kioskMachineId);
+      if (userItems.isNotEmpty) {
+        await ref.read(machineFileHandlerProvider).downloadLogFiles(userItems, kioskInfo.kioskMachineId);
       }
     } catch (e) {
       log('[MachineCheck] 점검 확인 실패: $e');

--- a/lib/presentation/home/machine_file_handler.dart
+++ b/lib/presentation/home/machine_file_handler.dart
@@ -54,11 +54,8 @@ class MachineFileHandler {
   }
 
   Future<void> _sendLogFile(String path, int logId, int machineId) async {
-    final now = DateTime.now();
-    final dateSuffix =
-        '.${now.year}${now.month.toString().padLeft(2, '0')}${now.day.toString().padLeft(2, '0')}';
     final normalizedPath = path.replaceAll('/', r'\');
-    final fileName = '${normalizedPath.split(r'\').last}$dateSuffix';
+    final fileName = normalizedPath.split(r'\').last;
 
     final result = await _fileService.readFile(normalizedPath);
 
@@ -85,8 +82,7 @@ class MachineFileHandler {
       case FileReadStatus.directorySuccess:
         try {
           await _ref.read(kioskRepositoryProvider).sendKioskLog(
-                KioskLogRequest.withLogId(
-                    logId: logId, machineId: machineId, title: '$fileName.zip', content: ''),
+                KioskLogRequest.withLogId(logId: logId, machineId: machineId, title: '$fileName.zip', content: ''),
                 zipFile: result.zipBytes,
               );
         } catch (e) {

--- a/lib/presentation/home/machine_file_handler.dart
+++ b/lib/presentation/home/machine_file_handler.dart
@@ -32,9 +32,21 @@ class MachineFileHandler {
         return;
       } catch (e) {
         if (attempt == _maxRetries) {
+          final message = '파일 작업 실패 ($_maxRetries회 시도 실패) ($path): $e';
           SlackLogService().sendErrorLogToSlack(
-            '*[MachineId: $machineId / LogId: $logId]* 파일 작업 실패 ($_maxRetries회 시도 실패) ($path): $e',
+            '*[MachineId: $machineId / LogId: $logId]* $message',
           );
+          try {
+            await _ref.read(kioskRepositoryProvider).sendKioskLog(
+                  KioskLogRequest.withLogId(
+                    logId: logId,
+                    machineId: machineId,
+                    title: '파일 작업 실패',
+                    content: message,
+                  ),
+                  step: 'ERROR',
+                );
+          } catch (_) {}
         } else {
           await Future.delayed(_retryDelay);
         }

--- a/lib/presentation/home/machine_file_handler.dart
+++ b/lib/presentation/home/machine_file_handler.dart
@@ -1,0 +1,168 @@
+import 'dart:convert';
+
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_snaptag_kiosk/core/common/file_io/machine_file_service.dart';
+import 'package:flutter_snaptag_kiosk/core/data/datasources/remote/slack_log_service.dart';
+import 'package:flutter_snaptag_kiosk/core/data/models/request/kiosk_log_request.dart';
+import 'package:flutter_snaptag_kiosk/core/data/models/response/machine_maintenance_response.dart';
+import 'package:flutter_snaptag_kiosk/core/data/repositories/kiosk_repository.dart';
+
+final machineFileHandlerProvider = Provider((ref) {
+  return MachineFileHandler(ref, const MachineFileService());
+});
+
+class MachineFileHandler {
+  const MachineFileHandler(this._ref, this._fileService);
+
+  final Ref _ref;
+  final MachineFileService _fileService;
+
+  static const _maxRetries = 3;
+  static const _retryDelay = Duration(milliseconds: 500);
+
+  Future<void> _withRetry({
+    required Future<void> Function() op,
+    required int machineId,
+    required int logId,
+    required String path,
+  }) async {
+    for (int attempt = 1; attempt <= _maxRetries; attempt++) {
+      try {
+        await op();
+        return;
+      } catch (e) {
+        if (attempt == _maxRetries) {
+          SlackLogService().sendErrorLogToSlack(
+            '*[MachineId: $machineId / LogId: $logId]* 파일 작업 실패 ($_maxRetries회 시도 실패) ($path): $e',
+          );
+        } else {
+          await Future.delayed(_retryDelay);
+        }
+      }
+    }
+  }
+
+  Future<void> sendLogFiles(List<MachineLogItem> items, int machineId) async {
+    for (final item in items) {
+      await _withRetry(
+        op: () => _sendLogFile(item.path, item.id, machineId),
+        machineId: machineId,
+        logId: item.id,
+        path: item.path,
+      );
+    }
+  }
+
+  Future<void> _sendLogFile(String path, int logId, int machineId) async {
+    final now = DateTime.now();
+    final dateSuffix =
+        '.${now.year}${now.month.toString().padLeft(2, '0')}${now.day.toString().padLeft(2, '0')}';
+    final normalizedPath = path.replaceAll('/', r'\');
+    final fileName = '${normalizedPath.split(r'\').last}$dateSuffix';
+
+    final result = await _fileService.readFile(normalizedPath);
+
+    switch (result.status) {
+      case FileReadStatus.accessError:
+        throw Exception('경로 접근 실패: ${result.error}');
+      case FileReadStatus.notFound:
+        throw Exception('파일 없음: $normalizedPath');
+      case FileReadStatus.empty:
+        throw Exception('파일이 비어 있음: $normalizedPath');
+      case FileReadStatus.readError:
+        throw Exception('파일 읽기 실패: ${result.error}');
+      case FileReadStatus.success:
+        try {
+          await _ref.read(kioskRepositoryProvider).sendKioskLog(
+                KioskLogRequest.withLogId(
+                    logId: logId, machineId: machineId, title: fileName, content: result.content!),
+              );
+        } catch (e) {
+          SlackLogService().sendErrorLogToSlack(
+            '*[MachineId: $machineId / LogId: $logId]* 로그 전송 실패 ($path): $e',
+          );
+        }
+      case FileReadStatus.directorySuccess:
+        try {
+          await _ref.read(kioskRepositoryProvider).sendKioskLog(
+                KioskLogRequest.withLogId(
+                    logId: logId, machineId: machineId, title: '$fileName.zip', content: ''),
+                zipFile: result.zipBytes,
+              );
+        } catch (e) {
+          SlackLogService().sendErrorLogToSlack(
+            '*[MachineId: $machineId / LogId: $logId]* 디렉토리 zip 전송 실패 ($path): $e',
+          );
+        }
+    }
+  }
+
+  Future<void> downloadFiles(List<MachineDownloadItem> items, int machineId) async {
+    for (final item in items) {
+      final bytes = base64Decode(item.content);
+      await _withRetry(
+        op: () => downloadFile(item.path, bytes, item.id, machineId),
+        machineId: machineId,
+        logId: item.id,
+        path: item.path,
+      );
+    }
+  }
+
+  Future<void> downloadLogFiles(List<MachineLogItem> items, int machineId) async {
+    for (final item in items) {
+      if (item.urlPath == null) continue;
+      await _withRetry(
+        op: () => downloadFileFromUrl(item.urlPath!, item.path, item.id, machineId),
+        machineId: machineId,
+        logId: item.id,
+        path: item.path,
+      );
+    }
+  }
+
+  Future<void> downloadFileFromUrl(String urlPath, String path, int logId, int machineId) async {
+    final normalizedPath = path.replaceAll('/', r'\');
+    final fileName = normalizedPath.split(r'\').last;
+
+    try {
+      final bytes = await _fileService.downloadBytesFromUrl(urlPath);
+      await _fileService.writeFile(path, bytes);
+
+      try {
+        await _ref.read(kioskRepositoryProvider).sendKioskLog(
+              KioskLogRequest.withLogId(
+                  logId: logId, machineId: machineId, title: fileName, content: '파일 저장 완료: $path'),
+            );
+      } catch (e) {
+        SlackLogService().sendErrorLogToSlack(
+          '*[MachineId: $machineId / LogId: $logId]* 파일 저장 완료 알림 전송 실패 ($path): $e',
+        );
+      }
+    } catch (e) {
+      rethrow;
+    }
+  }
+
+  Future<void> downloadFile(String path, List<int> bytes, int logId, int machineId) async {
+    final normalizedPath = path.replaceAll('/', r'\');
+    final fileName = normalizedPath.split(r'\').last;
+
+    try {
+      await _fileService.writeFile(path, bytes);
+
+      try {
+        await _ref.read(kioskRepositoryProvider).sendKioskLog(
+              KioskLogRequest.withLogId(
+                  logId: logId, machineId: machineId, title: fileName, content: '파일 저장 완료: $path'),
+            );
+      } catch (e) {
+        SlackLogService().sendErrorLogToSlack(
+          '*[MachineId: $machineId / LogId: $logId]* 파일 저장 완료 알림 전송 실패 ($path): $e',
+        );
+      }
+    } catch (e) {
+      rethrow;
+    }
+  }
+}

--- a/lib/presentation/home/machine_file_handler.dart
+++ b/lib/presentation/home/machine_file_handler.dart
@@ -32,17 +32,16 @@ class MachineFileHandler {
         return;
       } catch (e) {
         if (attempt == _maxRetries) {
-          final message = '파일 작업 실패 ($_maxRetries회 시도 실패) ($path): $e';
           SlackLogService().sendErrorLogToSlack(
-            '*[MachineId: $machineId / LogId: $logId]* $message',
+            '*[MachineId: $machineId / LogId: $logId]* 파일 작업 실패 ($_maxRetries회 시도 실패) ($path): $e',
           );
           try {
             await _ref.read(kioskRepositoryProvider).sendKioskLog(
                   KioskLogRequest.withLogId(
                     logId: logId,
                     machineId: machineId,
-                    title: '파일 작업 실패',
-                    content: message,
+                    title: e.toString(),
+                    content: e.toString(),
                   ),
                   step: 'ERROR',
                 );

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -12,6 +12,7 @@ dependencies:
 
   # Network
   dio: ^5.7.0
+  http_parser: ^4.0.0
   retrofit: ">=4.4.1 <4.9.0"
   connectivity_plus: ^6.1.0
 


### PR DESCRIPTION
## Summary

- 머신 파일 송수신 기능 추가 (`MachineFileService`, `MachineFileHandler`)
- 파일 작업 실패 시 서버 로그 전송 기능 추가 (`KioskLogRequest`)
- 머신 유지보수 응답 모델 추가 (`MachineMaintenanceResponse`)
- 파일 작업 최종 실패 시 `e.toString()`으로 content 전송하도록 수정

## Changes

- `machine_file_service.dart` (신규): 파일 읽기/쓰기 서비스
- `machine_file_handler.dart` (신규): 홈 화면 파일 핸들링 로직 분리
- `machine_maintenance_response.dart` (신규): 유지보수 응답 모델
- `kiosk_log_request.dart` (신규): 서버 로그 요청 모델
- `kiosk_repository.dart`, `kiosk_api_client.dart`: 파일 송수신 API 연동
- `home_screen.dart`: 파일 핸들러 연동

## Commits

- feat: 머신 파일 송수신 기능 추가 (file-send)
- fix: 파일 송수신 기능 보완
- fix: 파일 작업 최종 실패 시 서버 로그 전송 추가
- fix: 파일 작업 실패 시 서버 로그 content e.toString()으로 전송