### PR TITLE
refactor: 파일 송수신 핸들러 구조 개선 및 버그 수정

### DIFF
--- a/lib/core/ui/widget/dialog_helper.dart
+++ b/lib/core/ui/widget/dialog_helper.dart
@@ -270,6 +270,7 @@ class DialogHelper {
     VoidCallback? onButtonPressed,
   }) async {
     Future.delayed(const Duration(seconds: 5), () {
+      if (!context.mounted) return;
       if (Navigator.of(context, rootNavigator: true).canPop()) {
         HomeRouteData().go(context);
         Navigator.of(context, rootNavigator: true).pop();

--- a/lib/presentation/home/home_screen.dart
+++ b/lib/presentation/home/home_screen.dart
@@ -20,7 +20,6 @@ class HomeScreen extends ConsumerStatefulWidget {
 
 class _HomeScreenState extends ConsumerState<HomeScreen> {
   Timer? _maintenanceTimer;
-  bool _isCheckingMaintenance = false;
 
   @override
   void initState() {
@@ -36,14 +35,8 @@ class _HomeScreenState extends ConsumerState<HomeScreen> {
 
   void _startMaintenancePolling() {
     _maintenanceTimer?.cancel();
-    _maintenanceTimer = Timer.periodic(const Duration(seconds: 3), (_) async {
-      if (_isCheckingMaintenance) return;
-      _isCheckingMaintenance = true;
-      try {
-        await _checkMaintenance();
-      } finally {
-        _isCheckingMaintenance = false;
-      }
+    _maintenanceTimer = Timer.periodic(const Duration(seconds: 3), (_) {
+      _checkMaintenance();
     });
   }
 
@@ -56,17 +49,11 @@ class _HomeScreenState extends ConsumerState<HomeScreen> {
             machineId: kioskInfo.kioskMachineId,
           );
 
-      if (response.isEmpty) return;
-
-      final kioskItems = response.where((item) => item.deviceType == 'KIOSK').toList();
-      final userItems = response.where((item) => item.deviceType == 'USER').toList();
-
-      if (kioskItems.isNotEmpty) {
-        await ref.read(machineFileHandlerProvider).sendLogFiles(kioskItems, kioskInfo.kioskMachineId);
-      }
-      if (userItems.isNotEmpty) {
-        await ref.read(machineFileHandlerProvider).downloadLogFiles(userItems, kioskInfo.kioskMachineId);
-      }
+      unawaited(ref.read(machineFileHandlerProvider).handleFileTasks(
+            logPaths: response,
+            downloads: null,
+            machineId: kioskInfo.kioskMachineId,
+          ));
     } catch (e) {
       log('[MachineCheck] 점검 확인 실패: $e');
     }

--- a/lib/presentation/home/machine_file_handler.dart
+++ b/lib/presentation/home/machine_file_handler.dart
@@ -12,13 +12,41 @@ final machineFileHandlerProvider = Provider((ref) {
 });
 
 class MachineFileHandler {
-  const MachineFileHandler(this._ref, this._fileService);
+  MachineFileHandler(this._ref, this._fileService);
 
   final Ref _ref;
   final MachineFileService _fileService;
 
+  bool _isRunning = false;
+
   static const _maxRetries = 3;
   static const _retryDelay = Duration(milliseconds: 500);
+
+  Future<void> handleFileTasks({
+    required List<MachineLogItem>? logPaths,
+    required List<MachineDownloadItem>? downloads,
+    required int machineId,
+  }) async {
+    if (_isRunning) return;
+    _isRunning = true;
+    try {
+      if (logPaths != null && logPaths.isNotEmpty) {
+        final kioskItems = logPaths.where((item) => item.deviceType == 'KIOSK').toList();
+        final userItems = logPaths.where((item) => item.deviceType == 'USER').toList();
+        if (kioskItems.isNotEmpty) await _sendLogFiles(kioskItems, machineId);
+        if (userItems.isNotEmpty) await _downloadLogFiles(userItems, machineId);
+      }
+      if (downloads != null && downloads.isNotEmpty) {
+        await _downloadFiles(downloads, machineId);
+      }
+    } catch (e) {
+      SlackLogService().sendErrorLogToSlack(
+        '*[MachineId: $machineId]* handleFileTasks 실패: $e',
+      );
+    } finally {
+      _isRunning = false;
+    }
+  }
 
   Future<void> _withRetry({
     required Future<void> Function() op,
@@ -32,8 +60,9 @@ class MachineFileHandler {
         return;
       } catch (e) {
         if (attempt == _maxRetries) {
+          final message = '파일 작업 실패 ($_maxRetries회 시도 실패) ($path): $e';
           SlackLogService().sendErrorLogToSlack(
-            '*[MachineId: $machineId / LogId: $logId]* 파일 작업 실패 ($_maxRetries회 시도 실패) ($path): $e',
+            '*[MachineId: $machineId / LogId: $logId]* $message',
           );
           try {
             await _ref.read(kioskRepositoryProvider).sendKioskLog(
@@ -53,7 +82,7 @@ class MachineFileHandler {
     }
   }
 
-  Future<void> sendLogFiles(List<MachineLogItem> items, int machineId) async {
+  Future<void> _sendLogFiles(List<MachineLogItem> items, int machineId) async {
     for (final item in items) {
       await _withRetry(
         op: () => _sendLogFile(item.path, item.id, machineId),
@@ -104,11 +133,11 @@ class MachineFileHandler {
     }
   }
 
-  Future<void> downloadFiles(List<MachineDownloadItem> items, int machineId) async {
+  Future<void> _downloadFiles(List<MachineDownloadItem> items, int machineId) async {
     for (final item in items) {
       final bytes = base64Decode(item.content);
       await _withRetry(
-        op: () => downloadFile(item.path, bytes, item.id, machineId),
+        op: () => _downloadFile(item.path, bytes, item.id, machineId),
         machineId: machineId,
         logId: item.id,
         path: item.path,
@@ -116,11 +145,11 @@ class MachineFileHandler {
     }
   }
 
-  Future<void> downloadLogFiles(List<MachineLogItem> items, int machineId) async {
+  Future<void> _downloadLogFiles(List<MachineLogItem> items, int machineId) async {
     for (final item in items) {
       if (item.urlPath == null) continue;
       await _withRetry(
-        op: () => downloadFileFromUrl(item.urlPath!, item.path, item.id, machineId),
+        op: () => _downloadFileFromUrl(item.urlPath!, item.path, item.id, machineId),
         machineId: machineId,
         logId: item.id,
         path: item.path,
@@ -128,48 +157,40 @@ class MachineFileHandler {
     }
   }
 
-  Future<void> downloadFileFromUrl(String urlPath, String path, int logId, int machineId) async {
+  Future<void> _downloadFileFromUrl(String urlPath, String path, int logId, int machineId) async {
     final normalizedPath = path.replaceAll('/', r'\');
     final fileName = normalizedPath.split(r'\').last;
 
-    try {
-      final bytes = await _fileService.downloadBytesFromUrl(urlPath);
-      await _fileService.writeFile(path, bytes);
+    final bytes = await _fileService.downloadBytesFromUrl(urlPath);
+    await _fileService.writeFile(path, bytes);
 
-      try {
-        await _ref.read(kioskRepositoryProvider).sendKioskLog(
-              KioskLogRequest.withLogId(
-                  logId: logId, machineId: machineId, title: fileName, content: '파일 저장 완료: $path'),
-            );
-      } catch (e) {
-        SlackLogService().sendErrorLogToSlack(
-          '*[MachineId: $machineId / LogId: $logId]* 파일 저장 완료 알림 전송 실패 ($path): $e',
-        );
-      }
+    try {
+      await _ref.read(kioskRepositoryProvider).sendKioskLog(
+            KioskLogRequest.withLogId(
+                logId: logId, machineId: machineId, title: fileName, content: '파일 저장 완료: $path'),
+          );
     } catch (e) {
-      rethrow;
+      SlackLogService().sendErrorLogToSlack(
+        '*[MachineId: $machineId / LogId: $logId]* 파일 저장 완료 알림 전송 실패 ($path): $e',
+      );
     }
   }
 
-  Future<void> downloadFile(String path, List<int> bytes, int logId, int machineId) async {
+  Future<void> _downloadFile(String path, List<int> bytes, int logId, int machineId) async {
     final normalizedPath = path.replaceAll('/', r'\');
     final fileName = normalizedPath.split(r'\').last;
 
-    try {
-      await _fileService.writeFile(path, bytes);
+    await _fileService.writeFile(path, bytes);
 
-      try {
-        await _ref.read(kioskRepositoryProvider).sendKioskLog(
-              KioskLogRequest.withLogId(
-                  logId: logId, machineId: machineId, title: fileName, content: '파일 저장 완료: $path'),
-            );
-      } catch (e) {
-        SlackLogService().sendErrorLogToSlack(
-          '*[MachineId: $machineId / LogId: $logId]* 파일 저장 완료 알림 전송 실패 ($path): $e',
-        );
-      }
+    try {
+      await _ref.read(kioskRepositoryProvider).sendKioskLog(
+            KioskLogRequest.withLogId(
+                logId: logId, machineId: machineId, title: fileName, content: '파일 저장 완료: $path'),
+          );
     } catch (e) {
-      rethrow;
+      SlackLogService().sendErrorLogToSlack(
+        '*[MachineId: $machineId / LogId: $logId]* 파일 저장 완료 알림 전송 실패 ($path): $e',
+      );
     }
   }
 }

--- a/lib/presentation/payment/payment_service.dart
+++ b/lib/presentation/payment/payment_service.dart
@@ -356,7 +356,7 @@ class PaymentService extends _$PaymentService {
       approvalNumber: approval?.approvalNo ?? '-',
       purchaseAuthNumber: approval?.approvalNo ?? '-',
       authSeqNumber: approval?.approvalNo ?? '-',
-      detail: approval?.KSNET ?? '{}',
+      detail: approval?.KSNET ?? '({})',
       description: description,
     );
 

--- a/lib/presentation/payment/photo_card_preview_screen_provider.dart
+++ b/lib/presentation/payment/photo_card_preview_screen_provider.dart
@@ -68,7 +68,12 @@ class PhotoCardPreviewScreenProvider extends _$PhotoCardPreviewScreenProvider {
 
       state = const AsyncValue.data(null);
     } catch (e, stack) {
-      if (e is! OrderCreationException && e is! PreconditionFailedException && e is! EmptyApprovalNumberException) {
+      if (e is! OrderCreationException &&
+          e is! PreconditionFailedException &&
+          e is! EmptyApprovalNumberException &&
+          e is! CancelledPaymentException &&
+          e is! TimeoutPaymentException &&
+          e is! UnknownPaymentException) {
         try {
           await ref.read(paymentServiceProvider.notifier).refund();
           if (ref.read(pagePrintProvider) == PagePrintType.single) {


### PR DESCRIPTION
## 📌 작업 개요
- `MachineFileHandler`에 단일 공개 진입점 `handleFileTasks` 추가 및 `_isRunning` 가드로 중복 실행 방지
- KIOSK/USER 분기 로직을 `HomeScreen`에서 `MachineFileHandler`로 이동
- `HomeScreen` 폴링 로직 단순화 (`_isCheckingMaintenance` 제거, `unawaited` 적용)
- 결제 실패 시 불필요한 `refund()` 호출 방지
- 인쇄 완료 다이얼로그 타이머에서 `context.mounted` 체크 추가

## 🔍 변경 사항

### ✨ 주요 기능 추가
- `MachineFileHandler.handleFileTasks`: 파일 송수신 작업을 단일 진입점으로 통합, `downloads`(base64) 경로도 처리 가능하도록 확장

### 🔧 버그 수정 및 개선
- **파일 핸들러 구조 개선**: `_isRunning` 가드로 폴링 중복 실행 차단 (기존 `_isCheckingMaintenance`는 widget state에 있어 dispose 이슈 존재)
- **메서드 private화**: `sendLogFiles`, `downloadLogFiles`, `downloadFiles` 등 구현 메서드를 private으로 변경하여 `_isRunning` 가드 우회 차단
- **불필요한 try-catch 제거**: `_downloadFileFromUrl`, `_downloadFile`의 `try { ... } catch (e) { rethrow; }` 패턴 제거
- **결제 실패 시 refund() 중복 호출 방지**: `photo_card_preview_screen_provider.dart` 수정
- **인쇄 완료 다이얼로그**: 5초 타이머 콜백에서 `context.mounted` 체크 추가
- **KSNET null 대체값 수정**: `payment_service.dart`에서 `'{}'` → `'({})'`

### 📝 다국어 지원 추가
- 없음

### 📦 의존성 추가/변경
- `pubspec.yaml` 버전 업데이트

### 🗂️ 파일 구조 변경
- 없음 (기존 파일 수정만)

## 🧪 테스트 방법

### 1. 파일 송수신 폴링 동작 확인
1. 키오스크 앱 실행 후 HomeScreen 진입
2. 서버에서 점검 작업(machineLogPaths) 등록
3. 3초 이내에 파일 업로드/다운로드가 정상 실행되는지 확인
   - KIOSK 타입: 지정 경로 파일이 서버로 업로드되는지 확인
   - USER 타입: urlPath의 파일이 로컬에 저장되는지 확인
4. 파일 작업 중 추가 폴링이 스킵되는지 확인 (`_isRunning` 가드)

### 2. 결제 실패 케이스 확인
1. 결제 진행 중 실패 상황 발생
2. `refund()` 가 한 번만 호출되는지 확인 (기존: 실패 시 불필요하게 중복 호출)

## 📎 기타 참고 사항

### 주요 변경 파일 목록
- `lib/presentation/home/machine_file_handler.dart` (+93 / -57)
- `lib/presentation/home/home_screen.dart` (+8 / -19)
- `lib/presentation/payment/payment_service.dart` (+1 / -1)
- `lib/core/ui/widget/dialog_helper.dart` (+1)
- `lib/presentation/kiosk_shell/photo_card_preview_screen_provider.dart` (+4 / -3)

### 브랜치 정보
- **Source Branch**: `feature/file-send-refactor`
- **Target Branch**: `develop`

### 커밋 히스토리 요약
- `fix: KSNET null 대체값 수정`
- `refactor: 파일 송수신 핸들러 구조 개선`
- `fix: 인쇄 완료 다이얼로그 5초 타이머에서 context.mounted 체크 추가`
- `fix: 결제 실패 시 불필요한 refund() 호출 방지`

## 🙏 리뷰 요청 포인트

1. **`_isRunning` 가드 동작 방식**
   - `Provider` 싱글톤이므로 앱 생명주기 동안 상태 유지
   - `unawaited(handleFileTasks(...))` 패턴으로 폴링 사이클이 파일 작업 완료를 기다리지 않음
   - 장시간 작업(대용량 zip) 중 신규 폴링이 스킵되는 트레이드오프 있음

2. **`home_screen.dart` dispose 후 ref 접근**
   - `getMachineMaintenance` await 이후 widget이 dispose되면 이후 `ref.read` 호출 가능성 있음
   - `if (!mounted) return;` 추가 여부 검토 요청