### PR TITLE
release: v4.1.14 - 파일 송수신 핸들러 구조 개선 및 버그 수정

### DIFF
--- a/lib/core/ui/widget/dialog_helper.dart
+++ b/lib/core/ui/widget/dialog_helper.dart
@@ -270,6 +270,7 @@ class DialogHelper {
     VoidCallback? onButtonPressed,
   }) async {
     Future.delayed(const Duration(seconds: 5), () {
+      if (!context.mounted) return;
       if (Navigator.of(context, rootNavigator: true).canPop()) {
         HomeRouteData().go(context);
         Navigator.of(context, rootNavigator: true).pop();

--- a/lib/presentation/home/home_screen.dart
+++ b/lib/presentation/home/home_screen.dart
@@ -20,7 +20,6 @@ class HomeScreen extends ConsumerStatefulWidget {
 
 class _HomeScreenState extends ConsumerState<HomeScreen> {
   Timer? _maintenanceTimer;
-  bool _isCheckingMaintenance = false;
 
   @override
   void initState() {
@@ -36,14 +35,8 @@ class _HomeScreenState extends ConsumerState<HomeScreen> {
 
   void _startMaintenancePolling() {
     _maintenanceTimer?.cancel();
-    _maintenanceTimer = Timer.periodic(const Duration(seconds: 3), (_) async {
-      if (_isCheckingMaintenance) return;
-      _isCheckingMaintenance = true;
-      try {
-        await _checkMaintenance();
-      } finally {
-        _isCheckingMaintenance = false;
-      }
+    _maintenanceTimer = Timer.periodic(const Duration(seconds: 3), (_) {
+      _checkMaintenance();
     });
   }
 
@@ -56,17 +49,11 @@ class _HomeScreenState extends ConsumerState<HomeScreen> {
             machineId: kioskInfo.kioskMachineId,
           );
 
-      if (response.isEmpty) return;
-
-      final kioskItems = response.where((item) => item.deviceType == 'KIOSK').toList();
-      final userItems = response.where((item) => item.deviceType == 'USER').toList();
-
-      if (kioskItems.isNotEmpty) {
-        await ref.read(machineFileHandlerProvider).sendLogFiles(kioskItems, kioskInfo.kioskMachineId);
-      }
-      if (userItems.isNotEmpty) {
-        await ref.read(machineFileHandlerProvider).downloadLogFiles(userItems, kioskInfo.kioskMachineId);
-      }
+      unawaited(ref.read(machineFileHandlerProvider).handleFileTasks(
+            logPaths: response,
+            downloads: null,
+            machineId: kioskInfo.kioskMachineId,
+          ));
     } catch (e) {
       log('[MachineCheck] 점검 확인 실패: $e');
     }

--- a/lib/presentation/home/machine_file_handler.dart
+++ b/lib/presentation/home/machine_file_handler.dart
@@ -12,13 +12,41 @@ final machineFileHandlerProvider = Provider((ref) {
 });
 
 class MachineFileHandler {
-  const MachineFileHandler(this._ref, this._fileService);
+  MachineFileHandler(this._ref, this._fileService);
 
   final Ref _ref;
   final MachineFileService _fileService;
 
+  bool _isRunning = false;
+
   static const _maxRetries = 3;
   static const _retryDelay = Duration(milliseconds: 500);
+
+  Future<void> handleFileTasks({
+    required List<MachineLogItem>? logPaths,
+    required List<MachineDownloadItem>? downloads,
+    required int machineId,
+  }) async {
+    if (_isRunning) return;
+    _isRunning = true;
+    try {
+      if (logPaths != null && logPaths.isNotEmpty) {
+        final kioskItems = logPaths.where((item) => item.deviceType == 'KIOSK').toList();
+        final userItems = logPaths.where((item) => item.deviceType == 'USER').toList();
+        if (kioskItems.isNotEmpty) await _sendLogFiles(kioskItems, machineId);
+        if (userItems.isNotEmpty) await _downloadLogFiles(userItems, machineId);
+      }
+      if (downloads != null && downloads.isNotEmpty) {
+        await _downloadFiles(downloads, machineId);
+      }
+    } catch (e) {
+      SlackLogService().sendErrorLogToSlack(
+        '*[MachineId: $machineId]* handleFileTasks 실패: $e',
+      );
+    } finally {
+      _isRunning = false;
+    }
+  }
 
   Future<void> _withRetry({
     required Future<void> Function() op,
@@ -32,8 +60,9 @@ class MachineFileHandler {
         return;
       } catch (e) {
         if (attempt == _maxRetries) {
+          final message = '파일 작업 실패 ($_maxRetries회 시도 실패) ($path): $e';
           SlackLogService().sendErrorLogToSlack(
-            '*[MachineId: $machineId / LogId: $logId]* 파일 작업 실패 ($_maxRetries회 시도 실패) ($path): $e',
+            '*[MachineId: $machineId / LogId: $logId]* $message',
           );
           try {
             await _ref.read(kioskRepositoryProvider).sendKioskLog(
@@ -53,7 +82,7 @@ class MachineFileHandler {
     }
   }
 
-  Future<void> sendLogFiles(List<MachineLogItem> items, int machineId) async {
+  Future<void> _sendLogFiles(List<MachineLogItem> items, int machineId) async {
     for (final item in items) {
       await _withRetry(
         op: () => _sendLogFile(item.path, item.id, machineId),
@@ -104,11 +133,11 @@ class MachineFileHandler {
     }
   }
 
-  Future<void> downloadFiles(List<MachineDownloadItem> items, int machineId) async {
+  Future<void> _downloadFiles(List<MachineDownloadItem> items, int machineId) async {
     for (final item in items) {
       final bytes = base64Decode(item.content);
       await _withRetry(
-        op: () => downloadFile(item.path, bytes, item.id, machineId),
+        op: () => _downloadFile(item.path, bytes, item.id, machineId),
         machineId: machineId,
         logId: item.id,
         path: item.path,
@@ -116,11 +145,11 @@ class MachineFileHandler {
     }
   }
 
-  Future<void> downloadLogFiles(List<MachineLogItem> items, int machineId) async {
+  Future<void> _downloadLogFiles(List<MachineLogItem> items, int machineId) async {
     for (final item in items) {
       if (item.urlPath == null) continue;
       await _withRetry(
-        op: () => downloadFileFromUrl(item.urlPath!, item.path, item.id, machineId),
+        op: () => _downloadFileFromUrl(item.urlPath!, item.path, item.id, machineId),
         machineId: machineId,
         logId: item.id,
         path: item.path,
@@ -128,48 +157,40 @@ class MachineFileHandler {
     }
   }
 
-  Future<void> downloadFileFromUrl(String urlPath, String path, int logId, int machineId) async {
+  Future<void> _downloadFileFromUrl(String urlPath, String path, int logId, int machineId) async {
     final normalizedPath = path.replaceAll('/', r'\');
     final fileName = normalizedPath.split(r'\').last;
 
-    try {
-      final bytes = await _fileService.downloadBytesFromUrl(urlPath);
-      await _fileService.writeFile(path, bytes);
+    final bytes = await _fileService.downloadBytesFromUrl(urlPath);
+    await _fileService.writeFile(path, bytes);
 
-      try {
-        await _ref.read(kioskRepositoryProvider).sendKioskLog(
-              KioskLogRequest.withLogId(
-                  logId: logId, machineId: machineId, title: fileName, content: '파일 저장 완료: $path'),
-            );
-      } catch (e) {
-        SlackLogService().sendErrorLogToSlack(
-          '*[MachineId: $machineId / LogId: $logId]* 파일 저장 완료 알림 전송 실패 ($path): $e',
-        );
-      }
+    try {
+      await _ref.read(kioskRepositoryProvider).sendKioskLog(
+            KioskLogRequest.withLogId(
+                logId: logId, machineId: machineId, title: fileName, content: '파일 저장 완료: $path'),
+          );
     } catch (e) {
-      rethrow;
+      SlackLogService().sendErrorLogToSlack(
+        '*[MachineId: $machineId / LogId: $logId]* 파일 저장 완료 알림 전송 실패 ($path): $e',
+      );
     }
   }
 
-  Future<void> downloadFile(String path, List<int> bytes, int logId, int machineId) async {
+  Future<void> _downloadFile(String path, List<int> bytes, int logId, int machineId) async {
     final normalizedPath = path.replaceAll('/', r'\');
     final fileName = normalizedPath.split(r'\').last;
 
-    try {
-      await _fileService.writeFile(path, bytes);
+    await _fileService.writeFile(path, bytes);
 
-      try {
-        await _ref.read(kioskRepositoryProvider).sendKioskLog(
-              KioskLogRequest.withLogId(
-                  logId: logId, machineId: machineId, title: fileName, content: '파일 저장 완료: $path'),
-            );
-      } catch (e) {
-        SlackLogService().sendErrorLogToSlack(
-          '*[MachineId: $machineId / LogId: $logId]* 파일 저장 완료 알림 전송 실패 ($path): $e',
-        );
-      }
+    try {
+      await _ref.read(kioskRepositoryProvider).sendKioskLog(
+            KioskLogRequest.withLogId(
+                logId: logId, machineId: machineId, title: fileName, content: '파일 저장 완료: $path'),
+          );
     } catch (e) {
-      rethrow;
+      SlackLogService().sendErrorLogToSlack(
+        '*[MachineId: $machineId / LogId: $logId]* 파일 저장 완료 알림 전송 실패 ($path): $e',
+      );
     }
   }
 }

--- a/lib/presentation/payment/payment_service.dart
+++ b/lib/presentation/payment/payment_service.dart
@@ -356,7 +356,7 @@ class PaymentService extends _$PaymentService {
       approvalNumber: approval?.approvalNo ?? '-',
       purchaseAuthNumber: approval?.approvalNo ?? '-',
       authSeqNumber: approval?.approvalNo ?? '-',
-      detail: approval?.KSNET ?? '{}',
+      detail: approval?.KSNET ?? '({})',
       description: description,
     );
 

--- a/lib/presentation/payment/photo_card_preview_screen_provider.dart
+++ b/lib/presentation/payment/photo_card_preview_screen_provider.dart
@@ -68,7 +68,12 @@ class PhotoCardPreviewScreenProvider extends _$PhotoCardPreviewScreenProvider {
 
       state = const AsyncValue.data(null);
     } catch (e, stack) {
-      if (e is! OrderCreationException && e is! PreconditionFailedException && e is! EmptyApprovalNumberException) {
+      if (e is! OrderCreationException &&
+          e is! PreconditionFailedException &&
+          e is! EmptyApprovalNumberException &&
+          e is! CancelledPaymentException &&
+          e is! TimeoutPaymentException &&
+          e is! UnknownPaymentException) {
         try {
           await ref.read(paymentServiceProvider.notifier).refund();
           if (ref.read(pagePrintProvider) == PagePrintType.single) {

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: flutter_snaptag_kiosk
 description: "A new Flutter project."
 publish_to: "none"
-version: 4.1.13
+version: 4.1.14
 
 environment:
   sdk: ^3.6.0


### PR DESCRIPTION
## Summary
- 파일 송수신 핸들러(`MachineFileHandler`) 구조 개선: `_isRunning` 가드 및 단일 진입점 추가, 구현 메서드 전체 private화
- 결제 실패(고객취소·시간초과·미정의 응답코드) 시 불필요한 `refund()` 호출 방지
- 인쇄 완료 다이얼로그 5초 타이머에서 `context.mounted` 체크 추가로 ZONE ERROR 수정
- KSNET 응답 null 필드 기본값 대체 처리

## Changes
- `MachineFileHandler`: `_isRunning` 가드, `handleFileTasks` 단일 진입점, HomeScreen 폴링 단순화
- `PhotoCardPreviewScreenProvider`: `CancelledPaymentException`, `TimeoutPaymentException`, `UnknownPaymentException` 환불 제외 처리
- `DialogHelper`: `showPrintCompleteDialog` 5초 타이머 `context.mounted` 체크 추가
- `PaymentService`: KSNET 응답 null 대체값 수정

🤖 Generated with [Claude Code](https://claude.com/claude-code)