### PR TITLE
ci: 윈도우 릴리즈 러너를 windows-2022로 고정

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -9,7 +9,7 @@ on:
 jobs:
   build:
     if: startsWith(github.ref, 'refs/tags/v')
-    runs-on: windows-latest
+    runs-on: windows-2022
 
     steps:
       - name: Checkout Repository


### PR DESCRIPTION
## 배경
`v4.1.16` 태그 push로 트리거된 릴리즈 빌드(`release.yaml`)가 실패했습니다.

```
CMake Error at CMakeLists.txt:3 (project):
  Generator  Visual Studio 16 2019  could not find any instance of Visual Studio.
```

- `windows-latest` 러너 이미지가 변경되며 **VS 2019가 더 이상 존재하지 않아** 발생 (코드 변경과 무관한 CI 환경 회귀)
- v4.1.15까지는 정상 업로드되었으나, v4.1.16 릴리즈 산출물(Release.zip/Debug.zip)이 생성되지 못함

## 변경
- `runs-on: windows-latest` → `runs-on: windows-2022`
  - VS2022가 안정적으로 포함된 이미지로 고정 → Flutter 3.29.1이 정상 감지

## 후속
- 머지 후 `v4.1.16` 태그를 재푸시하여 산출물 재생성 예정

🤖 Generated with [Claude Code](https://claude.com/claude-code)