### PR TITLE
ci: 윈도우 릴리즈 러너 windows-2022 고정 (v4.1.16 산출물 재생성용)

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -9,7 +9,7 @@ on:
 jobs:
   build:
     if: startsWith(github.ref, 'refs/tags/v')
-    runs-on: windows-latest
+    runs-on: windows-2022
 
     steps:
       - name: Checkout Repository


### PR DESCRIPTION
v4.1.16 릴리즈 빌드 실패(`windows-latest`에서 VS2019 미존재) 수정.
- `runs-on: windows-latest` → `windows-2022`
- 머지 후 v4.1.16 태그를 main HEAD로 이동하여 산출물 재생성 예정

🤖 Generated with [Claude Code](https://claude.com/claude-code)