### PR TITLE
release: v4.1.17 - 환불 알림 정비 및 결제 게이트웨이 추상화

### DIFF
--- a/lib/core/common/constants/constants.dart
+++ b/lib/core/common/constants/constants.dart
@@ -1,3 +1,4 @@
 export 'directory_paths.dart';
 export 'image_paths.dart';
 export 'alert_key.dart';
+export 'refund_reason.dart';

--- a/lib/core/common/constants/refund_reason.dart
+++ b/lib/core/common/constants/refund_reason.dart
@@ -6,8 +6,9 @@ import 'package:flutter_snaptag_kiosk/lib.dart';
 /// 필요에 따라 이 Map에 줄만 추가/삭제하면 유동적으로 확장할 수 있다.
 /// 미등록 코드는 [refundReasonFor]에서 "확인필요 (코드: XXXX)"로 표기되므로,
 /// 로그에 뜬 코드를 보고 여기에 추가하면 된다.
+/// 실패 사유용 매핑이므로 성공 코드('0000')는 넣지 않는다.
+/// (성공 케이스는 refundReasonFor를 호출하지 않음)
 const Map<String, String> kRefundReasonByCode = {
-  '0000': '정상완료',
   // 1.신용(인증)
   '7001': '이미 취소된 거래',
   '7002': '이미 매입된 거래',

--- a/lib/core/common/constants/refund_reason.dart
+++ b/lib/core/common/constants/refund_reason.dart
@@ -1,0 +1,50 @@
+import 'package:flutter_snaptag_kiosk/lib.dart';
+
+/// 환불(취소) 응답코드 → 사람이 읽는 사유.
+///
+/// 구글시트 "KSCAT 응답코드 정리 > 환불관련" 탭을 seed로 한다.
+/// 필요에 따라 이 Map에 줄만 추가/삭제하면 유동적으로 확장할 수 있다.
+/// 미등록 코드는 [refundReasonFor]에서 "확인필요 (코드: XXXX)"로 표기되므로,
+/// 로그에 뜬 코드를 보고 여기에 추가하면 된다.
+const Map<String, String> kRefundReasonByCode = {
+  '0000': '정상완료',
+  // 1.신용(인증)
+  '7001': '이미 취소된 거래',
+  '7002': '이미 매입된 거래',
+  '7003': '원거래 없음',
+  '7803': '재조회 요망',
+  '7978': '가맹점 해지',
+  '7979': '가맹점 미등록/해지/거래정지',
+  '8038': 'Data Format 오류',
+  '8380': '카드사 장애 무응답/지연(timeout)',
+  '8381': '전산장애(KSNET 문의)',
+  '8555': '부분매입취소금액이 취소대상잔액보다 큼',
+  '8556': '원거래 전체취소 시 부분매입취소내역 존재',
+  // 5.KSCAT(F)
+  '1000': '거래 취소됨(취소 버튼)',
+  '1001': '전문 오류',
+  '1002': '로그생성 실패',
+  '1003': '이전거래 미완료',
+  '1004': '시간 초과',
+  '1099': '기타 오류',
+};
+
+/// 환불 실패 사유를 결정한다. (성공 케이스에는 호출하지 않는다.)
+///
+/// 우선순위: respCode 매핑 → res 매핑 → `확인필요 (코드: {코드})`.
+/// PG 원문 메시지(MESSAGE1/2)는 사용하지 않는다.
+String refundReasonFor(PaymentResponse? p) {
+  if (p == null) return '확인필요';
+
+  final respCode = p.respCode;
+  if (respCode != null && respCode.isNotEmpty) {
+    final byRespCode = kRefundReasonByCode[respCode];
+    if (byRespCode != null) return byRespCode;
+  }
+
+  final byRes = kRefundReasonByCode[p.res];
+  if (byRes != null) return byRes;
+
+  final unknown = (respCode != null && respCode.isNotEmpty) ? respCode : p.res;
+  return '확인필요 (코드: $unknown)';
+}

--- a/lib/core/core.dart
+++ b/lib/core/core.dart
@@ -2,5 +2,6 @@ export 'common/constants/constants.dart';
 export 'common/errors/errors.dart';
 export 'common/extensions/extensions.dart';
 export 'providers/providers.dart';
+export 'services/services.dart';
 export 'ui/theme/theme.dart';
 export 'common/utils.dart';

--- a/lib/core/data/datasources/remote/slack_log_service.dart
+++ b/lib/core/data/datasources/remote/slack_log_service.dart
@@ -177,10 +177,13 @@ ${slackLogTemplate.description}
 
       description = '''
 ${slackLogTemplate.description}
-            
+
 - $paymentDescription''';
 
-      final message = buildSlackAlertMessage(slackLogTemplate: slackLogTemplate.copyWith(description: description));
+      final category = errorKey == InfoKey.paymentRefundFail.key ? 'warning' : slackLogTemplate.category;
+
+      final message = buildSlackAlertMessage(
+          slackLogTemplate: slackLogTemplate.copyWith(description: description, category: category));
 
       await sendBroadcastLogToSlack(message);
     }

--- a/lib/core/data/repositories/repositories.dart
+++ b/lib/core/data/repositories/repositories.dart
@@ -1,2 +1,1 @@
 export 'kiosk_repository.dart';
-export 'payment_repository.dart';

--- a/lib/core/services/payment/disabled_payment_gateway.dart
+++ b/lib/core/services/payment/disabled_payment_gateway.dart
@@ -1,0 +1,39 @@
+import 'package:flutter_snaptag_kiosk/core/data/models/response/kscat_device_response.dart';
+import 'package:flutter_snaptag_kiosk/core/services/payment/kscat_payment_gateway.dart';
+import 'package:flutter_snaptag_kiosk/core/services/payment/payment_gateway.dart';
+import 'package:flutter_snaptag_kiosk/lib.dart';
+
+/// 결제 OFF(무료 모드) 상태의 게이트웨이 — P1에서 paymentMode에 따라 스왑된다.
+/// - approve: 무료 플로우는 승인을 호출하지 않으므로 방어선으로 예외
+/// - check/cancel: 환불 경로(원격 환불 전 단말 확인 포함)는 토글과 무관하게
+///   실제 단말로 동작해야 하므로 KSCAT에 위임
+class DisabledPaymentGateway implements PaymentGateway {
+  DisabledPaymentGateway(this._delegate);
+
+  final KscatPaymentGateway _delegate;
+
+  @override
+  Future<PaymentResponse> approve({
+    required int totalAmount,
+  }) async {
+    throw const PaymentDisabledException();
+  }
+
+  @override
+  Future<KscatDeviceResponse> check() {
+    return _delegate.check();
+  }
+
+  @override
+  Future<PaymentResponse> cancel({
+    required int totalAmount,
+    required String originalApprovalNo,
+    required String originalApprovalDate,
+  }) {
+    return _delegate.cancel(
+      totalAmount: totalAmount,
+      originalApprovalNo: originalApprovalNo,
+      originalApprovalDate: originalApprovalDate,
+    );
+  }
+}

--- a/lib/core/services/payment/disabled_payment_gateway.dart
+++ b/lib/core/services/payment/disabled_payment_gateway.dart
@@ -2,10 +2,8 @@ import 'package:flutter_snaptag_kiosk/core/data/models/response/kscat_device_res
 import 'package:flutter_snaptag_kiosk/core/services/payment/payment_gateway.dart';
 import 'package:flutter_snaptag_kiosk/lib.dart';
 
-/// 결제 OFF(무료 모드) 상태의 게이트웨이 — P1에서 paymentMode에 따라 스왑된다.
-/// - approve: 무료 플로우는 승인을 호출하지 않으므로 방어선으로 예외
-/// - check/cancel: 환불 경로(원격 환불 전 단말 확인 포함)는 토글과 무관하게
-///   실제 단말로 동작해야 하므로 위임한다. 런타임에는 실제 KscatPaymentGateway가 주입된다.
+/// approve는 막지만, 환불 경로(원격 환불 전 check 포함)는 결제 토글과 무관하게
+/// 동작해야 하므로 실제 게이트웨이로 위임한다.
 class DisabledPaymentGateway implements PaymentGateway {
   DisabledPaymentGateway(this._delegate);
 

--- a/lib/core/services/payment/disabled_payment_gateway.dart
+++ b/lib/core/services/payment/disabled_payment_gateway.dart
@@ -1,16 +1,15 @@
 import 'package:flutter_snaptag_kiosk/core/data/models/response/kscat_device_response.dart';
-import 'package:flutter_snaptag_kiosk/core/services/payment/kscat_payment_gateway.dart';
 import 'package:flutter_snaptag_kiosk/core/services/payment/payment_gateway.dart';
 import 'package:flutter_snaptag_kiosk/lib.dart';
 
 /// 결제 OFF(무료 모드) 상태의 게이트웨이 — P1에서 paymentMode에 따라 스왑된다.
 /// - approve: 무료 플로우는 승인을 호출하지 않으므로 방어선으로 예외
 /// - check/cancel: 환불 경로(원격 환불 전 단말 확인 포함)는 토글과 무관하게
-///   실제 단말로 동작해야 하므로 KSCAT에 위임
+///   실제 단말로 동작해야 하므로 위임한다. 런타임에는 실제 KscatPaymentGateway가 주입된다.
 class DisabledPaymentGateway implements PaymentGateway {
   DisabledPaymentGateway(this._delegate);
 
-  final KscatPaymentGateway _delegate;
+  final PaymentGateway _delegate;
 
   @override
   Future<PaymentResponse> approve({

--- a/lib/core/services/payment/kscat_payment_gateway.dart
+++ b/lib/core/services/payment/kscat_payment_gateway.dart
@@ -2,22 +2,12 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_snaptag_kiosk/core/common/constants/default.dart';
 import 'package:flutter_snaptag_kiosk/core/data/models/request/kscat_device_request.dart';
 import 'package:flutter_snaptag_kiosk/core/data/models/response/kscat_device_response.dart';
+import 'package:flutter_snaptag_kiosk/core/services/payment/payment_gateway.dart';
 import 'package:flutter_snaptag_kiosk/lib.dart';
 import 'package:flutter_snaptag_kiosk/presentation/kiosk_shell/kiosk_info_service.dart';
-import 'package:riverpod_annotation/riverpod_annotation.dart';
 
-part 'payment_repository.g.dart';
-
-@riverpod
-PaymentRepository paymentRepository(Ref ref) {
-  return PaymentRepository(
-    PaymentApiClient(),
-    ref,
-  );
-}
-
-class PaymentRepository {
-  PaymentRepository(this._client, this.ref);
+class KscatPaymentGateway implements PaymentGateway {
+  KscatPaymentGateway(this._client, this.ref);
 
   final PaymentApiClient _client;
   final Ref ref;
@@ -28,6 +18,7 @@ class PaymentRepository {
     return 'jsonp200911MI$formattedMachineId';
   }
 
+  @override
   Future<PaymentResponse> approve({
     required int totalAmount,
   }) async {
@@ -46,6 +37,7 @@ class PaymentRepository {
     return _request(request);
   }
 
+  @override
   Future<KscatDeviceResponse> check() async {
     final request = KscatDeviceRequest(
       req: 'C0',
@@ -54,6 +46,7 @@ class PaymentRepository {
     return _deviceRequest(request);
   }
 
+  @override
   Future<PaymentResponse> cancel({
     required int totalAmount,
     required String originalApprovalNo,

--- a/lib/core/services/payment/payment.dart
+++ b/lib/core/services/payment/payment.dart
@@ -1,0 +1,4 @@
+export 'disabled_payment_gateway.dart';
+export 'kscat_payment_gateway.dart';
+export 'payment_gateway.dart';
+export 'payment_gateway_provider.dart';

--- a/lib/core/services/payment/payment_gateway.dart
+++ b/lib/core/services/payment/payment_gateway.dart
@@ -1,0 +1,26 @@
+import 'package:flutter_snaptag_kiosk/core/data/models/response/kscat_device_response.dart';
+import 'package:flutter_snaptag_kiosk/lib.dart';
+
+abstract class PaymentGateway {
+  Future<PaymentResponse> approve({
+    required int totalAmount,
+  });
+
+  Future<KscatDeviceResponse> check();
+
+  Future<PaymentResponse> cancel({
+    required int totalAmount,
+    required String originalApprovalNo,
+    required String originalApprovalDate,
+  });
+}
+
+/// 결제 비활성(무료 모드) 상태에서 approve 호출 시 발생 (P1에서 사용)
+class PaymentDisabledException implements Exception {
+  final String message;
+
+  const PaymentDisabledException([this.message = '결제 기능이 비활성화되어 있습니다.']);
+
+  @override
+  String toString() => message;
+}

--- a/lib/core/services/payment/payment_gateway.dart
+++ b/lib/core/services/payment/payment_gateway.dart
@@ -15,7 +15,6 @@ abstract class PaymentGateway {
   });
 }
 
-/// 결제 비활성(무료 모드) 상태에서 approve 호출 시 발생 (P1에서 사용)
 class PaymentDisabledException implements Exception {
   final String message;
 

--- a/lib/core/services/payment/payment_gateway_provider.dart
+++ b/lib/core/services/payment/payment_gateway_provider.dart
@@ -1,0 +1,21 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_snaptag_kiosk/core/services/payment/kscat_payment_gateway.dart';
+import 'package:flutter_snaptag_kiosk/core/services/payment/payment_gateway.dart';
+import 'package:flutter_snaptag_kiosk/lib.dart';
+import 'package:riverpod_annotation/riverpod_annotation.dart';
+
+part 'payment_gateway_provider.g.dart';
+
+@Riverpod(keepAlive: true)
+KscatPaymentGateway kscatPaymentGateway(Ref ref) {
+  return KscatPaymentGateway(
+    PaymentApiClient(),
+    ref,
+  );
+}
+
+/// P0: 항상 KSCAT 반환. (P1: paymentModeProvider를 watch해 OFF면 DisabledPaymentGateway로 스왑)
+@riverpod
+PaymentGateway paymentGateway(Ref ref) {
+  return ref.watch(kscatPaymentGatewayProvider);
+}

--- a/lib/core/services/payment/payment_gateway_provider.dart
+++ b/lib/core/services/payment/payment_gateway_provider.dart
@@ -14,7 +14,7 @@ KscatPaymentGateway kscatPaymentGateway(Ref ref) {
   );
 }
 
-/// P0: 항상 KSCAT 반환. (P1: paymentModeProvider를 watch해 OFF면 DisabledPaymentGateway로 스왑)
+/// 결제 모드에 따라 게이트웨이를 교체하는 지점. 현재는 항상 KSCAT를 반환한다.
 @riverpod
 PaymentGateway paymentGateway(Ref ref) {
   return ref.watch(kscatPaymentGatewayProvider);

--- a/lib/core/services/services.dart
+++ b/lib/core/services/services.dart
@@ -1,0 +1,1 @@
+export 'payment/payment.dart';

--- a/lib/core/ui/widget/dialog_helper.dart
+++ b/lib/core/ui/widget/dialog_helper.dart
@@ -20,46 +20,47 @@ class DialogHelper {
   static Future<bool> showRefundFailDialog(
     BuildContext context,
   ) async {
-    return await showDialog(
-      context: context,
-      builder: (BuildContext context) {
-        return DefaultTextStyle(
-          style: TextStyle(
-            fontFamily: context.locale.languageCode == 'ja' ? 'MPLUSRounded' : 'Cafe24Ssurround2',
-          ),
-          child: Center(
-            child: SizedBox(
-              width: 658.w,
-              child: AlertDialog(
-                backgroundColor: Colors.white,
-                insetPadding: EdgeInsets.zero,
-                shape: RoundedRectangleBorder(
-                  borderRadius: BorderRadius.circular(20.r),
-                ),
-                title: Row(
-                  mainAxisAlignment: MainAxisAlignment.center,
-                  children: [
-                    SvgPicture.asset(
-                      SnaptagSvg.error,
-                      width: 44.w,
-                      height: 44.w,
+    return await showDialog<bool>(
+          context: context,
+          builder: (BuildContext context) {
+            return DefaultTextStyle(
+              style: TextStyle(
+                fontFamily: context.locale.languageCode == 'ja' ? 'MPLUSRounded' : 'Cafe24Ssurround2',
+              ),
+              child: Center(
+                child: SizedBox(
+                  width: 658.w,
+                  child: AlertDialog(
+                    backgroundColor: Colors.white,
+                    insetPadding: EdgeInsets.zero,
+                    shape: RoundedRectangleBorder(
+                      borderRadius: BorderRadius.circular(20.r),
                     ),
-                    SizedBox(width: 20.w),
-                    Text(
-                      '환불이 실패했습니다.',
-                      style: context.typography.kioskAlert1B.copyWith(
-                        fontFamily: 'Pretendard',
-                        color: Colors.black,
-                      ),
+                    title: Row(
+                      mainAxisAlignment: MainAxisAlignment.center,
+                      children: [
+                        SvgPicture.asset(
+                          SnaptagSvg.error,
+                          width: 44.w,
+                          height: 44.w,
+                        ),
+                        SizedBox(width: 20.w),
+                        Text(
+                          '환불이 실패했습니다.',
+                          style: context.typography.kioskAlert1B.copyWith(
+                            fontFamily: 'Pretendard',
+                            color: Colors.black,
+                          ),
+                        ),
+                      ],
                     ),
-                  ],
+                  ),
                 ),
               ),
-            ),
-          ),
-        );
-      },
-    );
+            );
+          },
+        ) ??
+        false;
   }
 
   static Future<void> showRefundSuccessDialog(

--- a/lib/presentation/home/refund_job_provider.dart
+++ b/lib/presentation/home/refund_job_provider.dart
@@ -64,7 +64,7 @@ class RefundJobNotifier extends _$RefundJobNotifier {
     // C0(디바이스 조회)는 정상 시 RES가 0000이 아니라 1001로 와서 코드값으로 판정하지 않고,
     // 응답 수신 여부로만 판단한다(기존 setup_main_screen._checkPaymentDevice와 동일 컨벤션).
     try {
-      await ref.read(paymentRepositoryProvider).check();
+      await ref.read(paymentGatewayProvider).check();
     } catch (e) {
       await _failJob(printJobId, '단말기 점검 실패(응답 없음): $e');
       return const RefundFailure(LocaleKeys.alert_txt_refund_terminal_error);
@@ -73,7 +73,7 @@ class RefundJobNotifier extends _$RefundJobNotifier {
     // Phase 1: 결제사 취소 — 실패 시 failMachineJob 가능
     final PaymentResponse paymentResponse;
     try {
-      paymentResponse = await ref.read(paymentRepositoryProvider).cancel(
+      paymentResponse = await ref.read(paymentGatewayProvider).cancel(
             totalAmount: refundInfo.amount,
             originalApprovalNo: refundInfo.originalApprovalNo,
             originalApprovalDate: refundInfo.originalApprovalDate,

--- a/lib/presentation/home/refund_job_provider.dart
+++ b/lib/presentation/home/refund_job_provider.dart
@@ -150,10 +150,9 @@ class RefundJobNotifier extends _$RefundJobNotifier {
 
     if (isSuccess) {
       await _succeedJob(printJobId);
-      // 성공: 브로드캐스트 알림 (동작로직: web 어드민 환불)
       SlackLogService().sendPaymentBroadcastLogToSlak(InfoKey.paymentRefund.key,
           paymentDescription:
-              "동작로직: web 어드민 환불\n- 인증번호: ${refundInfo.photoAuthNumber}\n- 승인번호: ${refundInfo.originalApprovalNo}\n- 금액: ${refundInfo.amount}원");
+              "동작로직: 포토코드web환불\n- 인증번호: ${refundInfo.photoAuthNumber}\n- 승인번호: ${refundInfo.originalApprovalNo}\n- 금액: ${refundInfo.amount}원");
       if (!orderUpdated) {
         // 카드 취소(환불)는 됐지만 주문 상태 갱신 실패 → 데이터 불일치, 사람이 직접 정산 필요
         SlackLogService().sendErrorLogToSlack(
@@ -168,7 +167,7 @@ class RefundJobNotifier extends _$RefundJobNotifier {
       await _failJob(printJobId, reason);
       SlackLogService().sendPaymentBroadcastLogToSlak(InfoKey.paymentRefundFail.key,
           paymentDescription:
-              "동작로직: web 어드민 환불\n- 사유: $reason\n- 인증번호: ${refundInfo.photoAuthNumber}\n- 승인번호: ${refundInfo.originalApprovalNo}");
+              "동작로직: 포토코드web환불\n- 사유: $reason\n- 인증번호: ${refundInfo.photoAuthNumber}\n- 승인번호: ${refundInfo.originalApprovalNo}");
       return const RefundFailure(LocaleKeys.alert_txt_refund_failed);
     }
   }

--- a/lib/presentation/home/refund_job_provider.dart
+++ b/lib/presentation/home/refund_job_provider.dart
@@ -150,10 +150,11 @@ class RefundJobNotifier extends _$RefundJobNotifier {
 
     if (isSuccess) {
       await _succeedJob(printJobId);
-      if (orderUpdated) {
-        SlackLogService()
-            .sendLogToSlack('[MachineId: $machineId] polling 환불 성공 | job=$printJobId | ${refundInfo.amount}원');
-      } else {
+      // 성공: 브로드캐스트 알림 (동작로직: web 어드민 환불)
+      SlackLogService().sendPaymentBroadcastLogToSlak(InfoKey.paymentRefund.key,
+          paymentDescription:
+              "동작로직: web 어드민 환불\n- 인증번호: ${refundInfo.photoAuthNumber}\n- 승인번호: ${refundInfo.originalApprovalNo}\n- 금액: ${refundInfo.amount}원");
+      if (!orderUpdated) {
         // 카드 취소(환불)는 됐지만 주문 상태 갱신 실패 → 데이터 불일치, 사람이 직접 정산 필요
         SlackLogService().sendErrorLogToSlack(
           '[MachineId: $machineId] ⚠️ polling 환불 성공했으나 주문 상태 갱신 실패 — 수동 정산 필요 '
@@ -162,12 +163,12 @@ class RefundJobNotifier extends _$RefundJobNotifier {
       }
       return RefundSuccess(refundInfo.amount);
     } else {
-      final failReason =
-          (paymentResponse.msg?.isNotEmpty == true ? paymentResponse.msg : paymentResponse.message1) ?? '환불 실패';
-      await _failJob(printJobId, failReason);
-      SlackLogService().sendErrorLogToSlack(
-        '[MachineId: $machineId] polling 환불 실패 | job=$printJobId | $failReason',
-      );
+      // 실패: PG 원문 대신 응답코드 기반 상세 사유로 통일
+      final reason = refundReasonFor(paymentResponse);
+      await _failJob(printJobId, reason);
+      SlackLogService().sendPaymentBroadcastLogToSlak(InfoKey.paymentRefundFail.key,
+          paymentDescription:
+              "동작로직: web 어드민 환불\n- 사유: $reason\n- 인증번호: ${refundInfo.photoAuthNumber}\n- 승인번호: ${refundInfo.originalApprovalNo}");
       return const RefundFailure(LocaleKeys.alert_txt_refund_failed);
     }
   }

--- a/lib/presentation/payment/payment_service.dart
+++ b/lib/presentation/payment/payment_service.dart
@@ -220,15 +220,10 @@ class PaymentService extends _$PaymentService {
       final approvalInfo = ref.read(paymentResponseStateProvider);
       final backPhoto = ref.watch(verifyPhotoCardProvider).value;
       if (approvalInfo?.orderState == OrderStatus.refunded) {
-        // 성공: 현행 유지
         await _updateOrder(isRefund: true, description: "자동환불");
-        SlackLogService().sendPaymentBroadcastLogToSlak(InfoKey.paymentRefund.key,
-            paymentDescription:
-                "동작로직: 자동환불\n- 인증번호: ${backPhoto?.photoAuthNumber ?? "없음"}\n- 승인번호: ${approvalInfo?.approvalNo ?? "없음"}");
         ref.read(paymentResponseStateProvider.notifier).reset();
         SlackLogService().sendLogToSlack('paymentResponseState Reset'); //paymentTestSlack
       } else {
-        // 실패: 응답코드 기반 상세 사유로 통일
         final reason = refundReasonFor(approvalInfo);
         await _updateOrder(isRefund: true, description: reason);
         SlackLogService().sendPaymentBroadcastLogToSlak(InfoKey.paymentRefundFail.key,

--- a/lib/presentation/payment/payment_service.dart
+++ b/lib/presentation/payment/payment_service.dart
@@ -219,8 +219,8 @@ class PaymentService extends _$PaymentService {
     } finally {
       final approvalInfo = ref.read(paymentResponseStateProvider);
       final backPhoto = ref.watch(verifyPhotoCardProvider).value;
-      final paymentRes = approvalInfo?.res;
       if (approvalInfo?.orderState == OrderStatus.refunded) {
+        // 성공: 현행 유지
         await _updateOrder(isRefund: true, description: "자동환불");
         SlackLogService().sendPaymentBroadcastLogToSlak(InfoKey.paymentRefund.key,
             paymentDescription:
@@ -228,25 +228,12 @@ class PaymentService extends _$PaymentService {
         ref.read(paymentResponseStateProvider.notifier).reset();
         SlackLogService().sendLogToSlack('paymentResponseState Reset'); //paymentTestSlack
       } else {
-        switch (paymentRes) {
-          case '1000':
-            await _updateOrder(isRefund: true, description: "고객취소");
-            SlackLogService().sendPaymentBroadcastLogToSlak(InfoKey.paymentRefundFail.key,
-                paymentDescription:
-                    "동작로직: 자동환불\n- 사유: 사용자가 환불취소 누름\n- 인증번호: ${backPhoto?.photoAuthNumber ?? "없음"}\n- 승인번호: ${approvalInfo?.approvalNo ?? "없음"}");
-            break;
-          case '1004':
-            await _updateOrder(isRefund: true, description: "시간초과");
-            SlackLogService().sendPaymentBroadcastLogToSlak(InfoKey.paymentRefundFail.key,
-                paymentDescription:
-                    "동작로직: 자동환불\n- 사유: 시간초과\n- 인증번호: ${backPhoto?.photoAuthNumber ?? "없음"}\n- 승인번호: ${approvalInfo?.approvalNo ?? "없음"}");
-            break;
-          default:
-            await _updateOrder(isRefund: true, description: "확인필요");
-            SlackLogService().sendPaymentBroadcastLogToSlak(InfoKey.paymentRefundFail.key,
-                paymentDescription:
-                    "동작로직: 자동환불\n- 사유: 확인필요\n- 인증번호: ${backPhoto?.photoAuthNumber ?? "없음"}\n- 승인번호: ${approvalInfo?.approvalNo ?? "없음"}");
-        }
+        // 실패: 응답코드 기반 상세 사유로 통일
+        final reason = refundReasonFor(approvalInfo);
+        await _updateOrder(isRefund: true, description: reason);
+        SlackLogService().sendPaymentBroadcastLogToSlak(InfoKey.paymentRefundFail.key,
+            paymentDescription:
+                "동작로직: 자동환불\n- 사유: $reason\n- 인증번호: ${backPhoto?.photoAuthNumber ?? "없음"}\n- 승인번호: ${approvalInfo?.approvalNo ?? "없음"}");
       }
     }
   }

--- a/lib/presentation/payment/payment_service.dart
+++ b/lib/presentation/payment/payment_service.dart
@@ -64,7 +64,7 @@ class PaymentService extends _$PaymentService {
   /// 결제 승인 처리
   Future<PaymentResponse> _approvePayment() async {
     final price = ref.read(kioskInfoServiceProvider)!.photoCardPrice;
-    final paymentResponse = await ref.read(paymentRepositoryProvider).approve(
+    final paymentResponse = await ref.read(paymentGatewayProvider).approve(
           totalAmount: price,
         );
     ref.read(paymentResponseStateProvider.notifier).update(paymentResponse);
@@ -205,7 +205,7 @@ class PaymentService extends _$PaymentService {
       }
 
       final price = ref.read(kioskInfoServiceProvider)!.photoCardPrice;
-      final paymentResponse = await ref.read(paymentRepositoryProvider).cancel(
+      final paymentResponse = await ref.read(paymentGatewayProvider).cancel(
             totalAmount: price,
             originalApprovalNo: approvalInfo.approvalNo ?? '',
             originalApprovalDate: approvalInfo.tradeTime?.substring(0, 6) ?? '',
@@ -248,7 +248,7 @@ class PaymentService extends _$PaymentService {
       }
 
       final price = ref.read(kioskInfoServiceProvider)!.photoCardPrice;
-      final paymentResponse = await ref.read(paymentRepositoryProvider).cancel(
+      final paymentResponse = await ref.read(paymentGatewayProvider).cancel(
             totalAmount: price,
             originalApprovalNo: approvalInfo.authSeqNumber ?? '',
             originalApprovalDate: DateFormat('yyMMdd').format(approvalInfo.completedAt!),

--- a/lib/presentation/setup/payment_history_screen.dart
+++ b/lib/presentation/setup/payment_history_screen.dart
@@ -17,7 +17,8 @@ class PaymentHistoryScreen extends ConsumerStatefulWidget {
   const PaymentHistoryScreen({super.key});
 
   @override
-  ConsumerState<ConsumerStatefulWidget> createState() => _PaymentHistoryScreenState();
+  ConsumerState<ConsumerStatefulWidget> createState() =>
+      _PaymentHistoryScreenState();
 }
 
 class _PaymentHistoryScreenState extends ConsumerState<PaymentHistoryScreen> {
@@ -34,7 +35,8 @@ class _PaymentHistoryScreenState extends ConsumerState<PaymentHistoryScreen> {
         data: (response) async {
           context.loaderOverlay.hide();
           if (response != null && response.code == 1) {
-            await DialogHelper.showRefundSuccessDialog(context, amount: _lastRefundAmount);
+            await DialogHelper.showRefundSuccessDialog(context,
+                amount: _lastRefundAmount);
           } else if (response != null) {
             await DialogHelper.showRefundFailDialog(context);
           }
@@ -131,7 +133,8 @@ class _PaymentHistoryScreenState extends ConsumerState<PaymentHistoryScreen> {
                     columns: columns,
                     rows: response.list.map((order) {
                       return DataRow(
-                        color: WidgetStateColor.resolveWith((states) => Colors.white),
+                        color: WidgetStateColor.resolveWith(
+                            (states) => Colors.white),
                         cells: [
                           DataCell(
                             Center(
@@ -156,16 +159,22 @@ class _PaymentHistoryScreenState extends ConsumerState<PaymentHistoryScreen> {
                             ),
                           ),
                           DataCell(
-                            Center(child: Text(NumberFormat('#,###').format(order.amount.toInt()))),
+                            Center(
+                                child: Text(NumberFormat('#,###')
+                                    .format(order.amount.toInt()))),
                           ),
                           DataCell(
-                            Center(child: Text(_getOrderState(order.orderStatus))),
+                            Center(
+                                child: Text(_getOrderState(order.orderStatus))),
                           ),
                           DataCell(
                             Center(child: _getRefundWidget(context, order)),
                           ),
                           DataCell(
-                            Center(child: Text(isPrinted(order.printedStatus) ? 'O' : 'X')),
+                            Center(
+                                child: Text(isPrinted(order.printedStatus)
+                                    ? 'O'
+                                    : 'X')),
                           ),
                           DataCell(
                             Center(child: Text(order.photoAuthNumber)),
@@ -179,7 +188,9 @@ class _PaymentHistoryScreenState extends ConsumerState<PaymentHistoryScreen> {
                   ),
                   PaginationControls(
                     currentPage: response.paging.currentPage,
-                    totalPages: (response.paging.totalCount / response.paging.pageSize).ceil(),
+                    totalPages:
+                        (response.paging.totalCount / response.paging.pageSize)
+                            .ceil(),
                     onPageChanged: (newPage) {
                       ref.read(ordersPageProvider().notifier).goToPage(newPage);
                     },
@@ -353,113 +364,114 @@ class _PaymentHistoryScreenState extends ConsumerState<PaymentHistoryScreen> {
             ),
           ),
         );
-      default:
-        switch (order.printedStatus) {
-          case PrintedStatus.refunded_after_printed:
-          case PrintedStatus.refunded_before_printed:
-            return TextButton(
-              onPressed: null,
-              child: Text(
-                '환불 완료',
-                style: TextStyle(
-                  color: Color(0xFF414448),
-                  fontSize: 16.sp,
+      case OrderStatus.refunded:
+        // 환불 상태 판정은 orderStatus 기준으로 한다. (printedStatus와 불일치 케이스 방지)
+        return TextButton(
+          onPressed: null,
+          child: Text(
+            '환불 완료',
+            style: TextStyle(
+              color: Color(0xFF414448),
+              fontSize: 16.sp,
+            ),
+          ),
+        );
+      case OrderStatus.refunded_failed:
+      case OrderStatus.refunded_failed_before_printed:
+        return TextButton(
+          child: Container(
+            decoration: BoxDecoration(
+              border: Border(
+                bottom: BorderSide(
+                  color: Color(0xFFFF333F),
                 ),
               ),
+            ),
+            child: Text(
+              '환불 실패',
+              style: TextStyle(
+                color: Color(0xFFFF333F),
+                fontSize: 16.sp,
+              ),
+            ),
+          ),
+          onPressed: () async {
+            context.loaderOverlay.show();
+            final result1 = await DialogHelper.showSetupDialog(
+              context,
+              title: '환불을 진행합니다.',
+              showCancelButton: true,
             );
-          case PrintedStatus.refunded_failed_after_printed:
-          case PrintedStatus.refunded_failed_before_printed:
-            return TextButton(
-              child: Container(
-                decoration: BoxDecoration(
-                  border: Border(
-                    bottom: BorderSide(
-                      color: Color(0xFFFF333F),
-                    ),
-                  ),
-                ),
-                child: Text(
-                  '환불 실패',
-                  style: TextStyle(
-                    color: Color(0xFFFF333F),
-                    fontSize: 16.sp,
-                  ),
+            if (!result1) {
+              context.loaderOverlay.hide();
+              return;
+            }
+            final result2 = await DialogHelper.showSetupDialog(
+              context,
+              title: '결제한 카드를 삽입해 주세요.',
+              cancelButtonText: '환불 취소',
+              confirmButtonText: '환불 진행',
+              showCancelButton: true,
+            );
+            if (result2) {
+              _lastRefundAmount = order.amount.toInt();
+              await ref
+                  .read(setupRefundProcessProvider.notifier)
+                  .startRefund(order);
+              context.loaderOverlay.hide();
+            } else {
+              context.loaderOverlay.hide();
+            }
+          },
+        );
+      case OrderStatus.completed:
+        return TextButton(
+          child: Container(
+            decoration: BoxDecoration(
+              border: Border(
+                bottom: BorderSide(
+                  color: Color(0xFF9D9D9D),
                 ),
               ),
-              onPressed: () async {
-                context.loaderOverlay.show();
-                final result1 = await DialogHelper.showSetupDialog(
-                  context,
-                  title: '환불을 진행합니다.',
-                  showCancelButton: true,
-                );
-                if (!result1) {
-                  context.loaderOverlay.hide();
-                  return;
-                }
-                final result2 = await DialogHelper.showSetupDialog(
-                  context,
-                  title: '결제한 카드를 삽입해 주세요.',
-                  cancelButtonText: '환불 취소',
-                  confirmButtonText: '환불 진행',
-                  showCancelButton: true,
-                );
-                if (result2) {
-                  _lastRefundAmount = order.amount.toInt();
-                  await ref.read(setupRefundProcessProvider.notifier).startRefund(order);
-                  context.loaderOverlay.hide();
-                } else {
-                  context.loaderOverlay.hide();
-                }
-              },
-            );
-          default:
-            return TextButton(
-              child: Container(
-                decoration: BoxDecoration(
-                  border: Border(
-                    bottom: BorderSide(
-                      color: Color(0xFF9D9D9D),
-                    ),
-                  ),
-                ),
-                child: Text(
-                  '환불',
-                  style: TextStyle(
-                    color: Color(0xFF9D9D9D),
-                    fontSize: 16.sp,
-                  ),
-                ),
+            ),
+            child: Text(
+              '환불',
+              style: TextStyle(
+                color: Color(0xFF9D9D9D),
+                fontSize: 16.sp,
               ),
-              onPressed: () async {
-                context.loaderOverlay.show();
-                await SoundManager().playSound();
-                final result1 = await DialogHelper.showSetupDialog(
-                  context,
-                  title: '환불을 진행합니다.',
-                  showCancelButton: true,
-                );
-                if (!result1) {
-                  context.loaderOverlay.hide();
-                  return;
-                }
-                final result2 = await DialogHelper.showSetupDialog(
-                  context,
-                  title: '결제한 카드를 삽입해 주세요.',
-                  cancelButtonText: '환불 취소',
-                  confirmButtonText: '환불 진행',
-                  showCancelButton: true,
-                );
-                if (result2) {
-                  _lastRefundAmount = order.amount.toInt();
-                  await ref.read(setupRefundProcessProvider.notifier).startRefund(order);
-                  context.loaderOverlay.hide();
-                } else {
-                  context.loaderOverlay.hide();
-                }
-              },
+            ),
+          ),
+          onPressed: () async {
+            context.loaderOverlay.show();
+            await SoundManager().playSound();
+            final result1 = await DialogHelper.showSetupDialog(
+              context,
+              title: '환불을 진행합니다.',
+              showCancelButton: true,
             );
-        }
+            if (!result1) {
+              context.loaderOverlay.hide();
+              return;
+            }
+            final result2 = await DialogHelper.showSetupDialog(
+              context,
+              title: '결제한 카드를 삽입해 주세요.',
+              cancelButtonText: '환불 취소',
+              confirmButtonText: '환불 진행',
+              showCancelButton: true,
+            );
+            if (result2) {
+              _lastRefundAmount = order.amount.toInt();
+              await ref
+                  .read(setupRefundProcessProvider.notifier)
+                  .startRefund(order);
+              context.loaderOverlay.hide();
+            } else {
+              context.loaderOverlay.hide();
+            }
+          },
+        );
     }
   }
 }
@@ -477,7 +489,8 @@ class DateWidget extends StatelessWidget {
       crossAxisAlignment: CrossAxisAlignment.center,
       children: [
         Text(
-          DateFormat('yyyy.MM.dd').format(DateTime.now().subtract(const Duration(days: 14))),
+          DateFormat('yyyy.MM.dd')
+              .format(DateTime.now().subtract(const Duration(days: 14))),
           textAlign: TextAlign.center,
           style: TextStyle(
             color: Color(0xFF1C1C1C),
@@ -525,7 +538,8 @@ class PaginationControls extends StatelessWidget {
   Widget build(BuildContext context) {
     List<Widget> pageButtons() {
       List<Widget> buttons = [];
-      int startPage = (currentPage - 5).clamp(1, totalPages > 10 ? totalPages - 9 : 1);
+      int startPage =
+          (currentPage - 5).clamp(1, totalPages > 10 ? totalPages - 9 : 1);
       int endPage = (startPage + 9).clamp(startPage, totalPages);
 
       for (int i = startPage; i <= endPage; i++) {
@@ -540,7 +554,8 @@ class PaginationControls extends StatelessWidget {
                 fontSize: 14,
               ),
             ),
-            backgroundColor: i == currentPage ? Color(0xFFA671EA) : Color(0xFFF2F2F2),
+            backgroundColor:
+                i == currentPage ? Color(0xFFA671EA) : Color(0xFFF2F2F2),
             shape: RoundedRectangleBorder(
               borderRadius: BorderRadius.circular(4),
               side: BorderSide(color: Colors.transparent),
@@ -566,7 +581,8 @@ class PaginationControls extends StatelessWidget {
             const SizedBox(width: 8),
             // Previous page button
             InkWell(
-              onTap: currentPage > 1 ? () => onPageChanged(currentPage - 1) : null,
+              onTap:
+                  currentPage > 1 ? () => onPageChanged(currentPage - 1) : null,
               child: const Icon(Icons.chevron_left),
             ),
             const SizedBox(width: 8),
@@ -575,13 +591,17 @@ class PaginationControls extends StatelessWidget {
             const SizedBox(width: 8),
             // Next page button
             InkWell(
-              onTap: currentPage < totalPages ? () => onPageChanged(currentPage + 1) : null,
+              onTap: currentPage < totalPages
+                  ? () => onPageChanged(currentPage + 1)
+                  : null,
               child: const Icon(Icons.chevron_right),
             ),
             const SizedBox(width: 8),
             // Last page button
             InkWell(
-              onTap: currentPage < totalPages ? () => onPageChanged(totalPages) : null,
+              onTap: currentPage < totalPages
+                  ? () => onPageChanged(totalPages)
+                  : null,
               child: const Icon(Icons.keyboard_double_arrow_right_sharp),
             ),
           ],
@@ -608,10 +628,12 @@ class _LogFileListDialog extends StatelessWidget {
           itemBuilder: (ctx, i) {
             final file = files[i];
             final name = file.uri.pathSegments.last;
-            final modified = DateFormat('yyyy.MM.dd HH:mm').format(file.lastModifiedSync());
+            final modified =
+                DateFormat('yyyy.MM.dd HH:mm').format(file.lastModifiedSync());
             return ListTile(
               title: Text(name, style: TextStyle(fontSize: 16.sp)),
-              subtitle: Text(modified, style: TextStyle(fontSize: 13.sp, color: Colors.grey)),
+              subtitle: Text(modified,
+                  style: TextStyle(fontSize: 13.sp, color: Colors.grey)),
               onTap: () => Navigator.pop(ctx, file),
             );
           },

--- a/lib/presentation/setup/setup_main_screen.dart
+++ b/lib/presentation/setup/setup_main_screen.dart
@@ -213,7 +213,7 @@ class _SetupMainScreenState extends ConsumerState<SetupMainScreen> {
 
   Future<bool> _checkPaymentDevice() async {
     try {
-      final response = await ref.read(paymentRepositoryProvider).check();
+      final response = await ref.read(paymentGatewayProvider).check();
       SlackLogService().sendLogToSlack("Payment Device check: $response");
 
       return true;

--- a/lib/presentation/setup/setup_refund_process_provider.dart
+++ b/lib/presentation/setup/setup_refund_process_provider.dart
@@ -23,7 +23,7 @@ class SetupRefundProcess extends _$SetupRefundProcess {
       final Invoice invoice = Invoice.calculate(order.amount.toInt());
       state = const AsyncValue.loading();
 
-      final response = await ref.read(paymentRepositoryProvider).cancel(
+      final response = await ref.read(paymentGatewayProvider).cancel(
             totalAmount: invoice.total,
             originalApprovalNo: order.paymentAuthNumber ?? '',
             originalApprovalDate: DateFormat('yyMMdd').format(order.completedAt!),

--- a/lib/presentation/setup/setup_refund_process_provider.dart
+++ b/lib/presentation/setup/setup_refund_process_provider.dart
@@ -60,49 +60,27 @@ class SetupRefundProcess extends _$SetupRefundProcess {
       detail: payment?.KSNET ?? '{}',
     );
 
-    if (payment?.respCode == '7001') {
-      // 이미 취소된 거래
-      await ref.read(kioskRepositoryProvider).updateOrderStatus(
-            order.orderId.toInt(),
-            request.copyWith(status: OrderStatus.refunded_failed, description: "기취소된 거래"),
-          );
+    // 성공/실패 판정은 res 단독이 아니라 실제 결과(orderState)로 통일한다.
+    // (예: RES=0000 이지만 RESPCODE=7003(원거래없음)인 실패가 res만 보면 누락되던 버그 수정)
+    final success = payment?.orderState == OrderStatus.refunded;
+    final reason = success ? null : refundReasonFor(payment);
+
+    await ref.read(kioskRepositoryProvider).updateOrderStatus(
+          order.orderId.toInt(),
+          request.copyWith(
+            status: success ? OrderStatus.refunded : OrderStatus.refunded_failed,
+            description: reason,
+          ),
+        );
+
+    if (success) {
+      SlackLogService().sendPaymentBroadcastLogToSlak(InfoKey.paymentRefund.key,
+          paymentDescription:
+              "동작로직: 관리자 환불\n- 결과: 환불 성공\n- 인증번호: ${order.photoAuthNumber}\n- 승인번호: ${order.paymentAuthNumber ?? "없음"}");
+    } else {
       SlackLogService().sendPaymentBroadcastLogToSlak(InfoKey.paymentRefundFail.key,
           paymentDescription:
-              "동작로직: 관리자 환불\n- 사유: 기취소된 거래\n- 인증번호: ${order.photoAuthNumber}\n- 승인번호: ${order.paymentAuthNumber ?? "없음"}");
-    } else {
-      switch (payment?.res) {
-        case '0000':
-          await ref.read(kioskRepositoryProvider).updateOrderStatus(
-                order.orderId.toInt(),
-                request,
-              );
-        case '1000':
-          await ref.read(kioskRepositoryProvider).updateOrderStatus(
-                order.orderId.toInt(),
-                request.copyWith(description: "고객취소"),
-              );
-          SlackLogService().sendPaymentBroadcastLogToSlak(InfoKey.paymentRefundFail.key,
-              paymentDescription:
-                  "동작로직: 관리자 환불\n- 사유: 사용자가 환불취소 누름\n- 인증번호: ${order.photoAuthNumber}\n- 승인번호: ${order.paymentAuthNumber ?? "없음"}");
-          break;
-        case '1004':
-          await ref.read(kioskRepositoryProvider).updateOrderStatus(
-                order.orderId.toInt(),
-                request.copyWith(description: "시간초과"),
-              );
-          SlackLogService().sendPaymentBroadcastLogToSlak(InfoKey.paymentRefundFail.key,
-              paymentDescription:
-                  "동작로직: 관리자 환불\n- 사유: 시간초과\n- 인증번호: ${order.photoAuthNumber}\n- 승인번호: ${order.paymentAuthNumber ?? "없음"}");
-          break;
-        default:
-          await ref.read(kioskRepositoryProvider).updateOrderStatus(
-                order.orderId.toInt(),
-                request.copyWith(description: "확인필요"),
-              );
-          SlackLogService().sendPaymentBroadcastLogToSlak(InfoKey.paymentRefundFail.key,
-              paymentDescription:
-                  "동작로직: 관리자 환불\n- 사유: 확인필요\n- 인증번호: ${order.photoAuthNumber}\n- 승인번호: ${order.paymentAuthNumber ?? "없음"}");
-      }
+              "동작로직: 관리자 환불\n- 사유: $reason\n- 인증번호: ${order.photoAuthNumber}\n- 승인번호: ${order.paymentAuthNumber ?? "없음"}");
     }
   }
 }

--- a/lib/presentation/setup/setup_refund_process_provider.dart
+++ b/lib/presentation/setup/setup_refund_process_provider.dart
@@ -60,8 +60,6 @@ class SetupRefundProcess extends _$SetupRefundProcess {
       detail: payment?.KSNET ?? '{}',
     );
 
-    // 성공/실패 판정은 res 단독이 아니라 실제 결과(orderState)로 통일한다.
-    // (예: RES=0000 이지만 RESPCODE=7003(원거래없음)인 실패가 res만 보면 누락되던 버그 수정)
     final success = payment?.orderState == OrderStatus.refunded;
     final reason = success ? null : refundReasonFor(payment);
 

--- a/lib/presentation/test/payment_test_widget.dart
+++ b/lib/presentation/test/payment_test_widget.dart
@@ -26,7 +26,7 @@ class PaymentTestWidget extends ConsumerWidget {
         throw Exception('금액을 입력해주세요');
       }
 
-      final response = await ref.read(paymentRepositoryProvider).approve(
+      final response = await ref.read(paymentGatewayProvider).approve(
             totalAmount: int.parse(amount),
           );
 
@@ -62,7 +62,7 @@ class PaymentTestWidget extends ConsumerWidget {
         throw Exception('승인번호와 승인일자를 입력해주세요');
       }
 
-      final response = await ref.read(paymentRepositoryProvider).cancel(
+      final response = await ref.read(paymentGatewayProvider).cancel(
             totalAmount: int.parse(amount),
             originalApprovalNo: approvalNo,
             originalApprovalDate: approvalDate,

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: flutter_snaptag_kiosk
 description: "A new Flutter project."
 publish_to: "none"
-version: 4.1.16
+version: 4.1.17
 
 environment:
   sdk: ^3.6.0

--- a/test/disabled_payment_gateway_test.dart
+++ b/test/disabled_payment_gateway_test.dart
@@ -2,8 +2,6 @@ import 'package:flutter_snaptag_kiosk/core/data/models/response/kscat_device_res
 import 'package:flutter_snaptag_kiosk/lib.dart';
 import 'package:flutter_test/flutter_test.dart';
 
-/// 위임 대상(실제로는 KscatPaymentGateway) 대역.
-/// 호출 여부/인자를 기록하고, 지정한 응답을 돌려주거나 예외를 던진다.
 class FakePaymentGateway implements PaymentGateway {
   int approveCallCount = 0;
   int checkCallCount = 0;

--- a/test/disabled_payment_gateway_test.dart
+++ b/test/disabled_payment_gateway_test.dart
@@ -1,0 +1,171 @@
+import 'package:flutter_snaptag_kiosk/core/data/models/response/kscat_device_response.dart';
+import 'package:flutter_snaptag_kiosk/lib.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+/// 위임 대상(실제로는 KscatPaymentGateway) 대역.
+/// 호출 여부/인자를 기록하고, 지정한 응답을 돌려주거나 예외를 던진다.
+class FakePaymentGateway implements PaymentGateway {
+  int approveCallCount = 0;
+  int checkCallCount = 0;
+  int cancelCallCount = 0;
+
+  int? lastCancelAmount;
+  String? lastOriginalApprovalNo;
+  String? lastOriginalApprovalDate;
+
+  bool shouldThrow = false;
+
+  PaymentResponse approveResponse = const PaymentResponse(res: '0000');
+  KscatDeviceResponse checkResponse = const KscatDeviceResponse(res: '0000');
+  PaymentResponse cancelResponse = const PaymentResponse(res: '0000');
+
+  @override
+  Future<PaymentResponse> approve({required int totalAmount}) async {
+    approveCallCount++;
+    if (shouldThrow) throw Exception('delegate approve failed');
+    return approveResponse;
+  }
+
+  @override
+  Future<KscatDeviceResponse> check() async {
+    checkCallCount++;
+    if (shouldThrow) throw Exception('delegate check failed');
+    return checkResponse;
+  }
+
+  @override
+  Future<PaymentResponse> cancel({
+    required int totalAmount,
+    required String originalApprovalNo,
+    required String originalApprovalDate,
+  }) async {
+    cancelCallCount++;
+    lastCancelAmount = totalAmount;
+    lastOriginalApprovalNo = originalApprovalNo;
+    lastOriginalApprovalDate = originalApprovalDate;
+    if (shouldThrow) throw Exception('delegate cancel failed');
+    return cancelResponse;
+  }
+}
+
+void main() {
+  late FakePaymentGateway delegate;
+  late DisabledPaymentGateway gateway;
+
+  setUp(() {
+    delegate = FakePaymentGateway();
+    gateway = DisabledPaymentGateway(delegate);
+  });
+
+  group('DisabledPaymentGateway.approve — 승인은 차단된다', () {
+    test('approve 호출 시 PaymentDisabledException을 던진다', () async {
+      await expectLater(
+        gateway.approve(totalAmount: 1000),
+        throwsA(isA<PaymentDisabledException>()),
+      );
+    });
+
+    test('approve는 위임 대상을 절대 호출하지 않는다 (0원 주문에 실제 승인이 붙는 것 방지)', () async {
+      await expectLater(
+        gateway.approve(totalAmount: 1000),
+        throwsA(isA<PaymentDisabledException>()),
+      );
+
+      expect(delegate.approveCallCount, 0);
+    });
+
+    test('던져진 예외는 기본 메시지를 가진다', () async {
+      try {
+        await gateway.approve(totalAmount: 1000);
+        fail('PaymentDisabledException이 던져져야 한다');
+      } on PaymentDisabledException catch (e) {
+        expect(e.message, '결제 기능이 비활성화되어 있습니다.');
+      }
+    });
+  });
+
+  group('DisabledPaymentGateway.check — 단말 확인은 위임된다', () {
+    test('check는 위임 대상을 한 번 호출한다', () async {
+      await gateway.check();
+
+      expect(delegate.checkCallCount, 1);
+    });
+
+    test('check는 위임 대상의 응답을 그대로 반환한다', () async {
+      delegate.checkResponse = const KscatDeviceResponse(res: '0000', reader: 'KSCAT-01');
+
+      final response = await gateway.check();
+
+      expect(response, same(delegate.checkResponse));
+      expect(response.reader, 'KSCAT-01');
+    });
+
+    test('위임 대상이 던진 예외를 그대로 전파한다 (원격 환불 전 단말 점검 실패가 삼켜지면 안 됨)', () async {
+      delegate.shouldThrow = true;
+
+      await expectLater(gateway.check(), throwsA(isA<Exception>()));
+      expect(delegate.checkCallCount, 1);
+    });
+  });
+
+  group('DisabledPaymentGateway.cancel — 환불은 실제 단말로 위임된다', () {
+    test('cancel은 전달받은 인자를 그대로 위임한다', () async {
+      await gateway.cancel(
+        totalAmount: 5000,
+        originalApprovalNo: 'APPROVAL-123',
+        originalApprovalDate: '260702',
+      );
+
+      expect(delegate.cancelCallCount, 1);
+      expect(delegate.lastCancelAmount, 5000);
+      expect(delegate.lastOriginalApprovalNo, 'APPROVAL-123');
+      expect(delegate.lastOriginalApprovalDate, '260702');
+    });
+
+    test('cancel은 위임 대상의 응답을 그대로 반환한다', () async {
+      delegate.cancelResponse = const PaymentResponse(res: '0000', approvalNo: 'CANCEL-999');
+
+      final response = await gateway.cancel(
+        totalAmount: 5000,
+        originalApprovalNo: 'APPROVAL-123',
+        originalApprovalDate: '260702',
+      );
+
+      expect(response, same(delegate.cancelResponse));
+      expect(response.approvalNo, 'CANCEL-999');
+    });
+
+    test('위임 대상이 던진 예외를 그대로 전파한다', () async {
+      delegate.shouldThrow = true;
+
+      await expectLater(
+        gateway.cancel(
+          totalAmount: 5000,
+          originalApprovalNo: 'APPROVAL-123',
+          originalApprovalDate: '260702',
+        ),
+        throwsA(isA<Exception>()),
+      );
+    });
+  });
+
+  group('PaymentDisabledException', () {
+    test('기본 메시지를 가진다', () {
+      const exception = PaymentDisabledException();
+
+      expect(exception.message, '결제 기능이 비활성화되어 있습니다.');
+    });
+
+    test('커스텀 메시지를 받을 수 있다', () {
+      const exception = PaymentDisabledException('무료 모드입니다.');
+
+      expect(exception.message, '무료 모드입니다.');
+    });
+
+    test('toString은 메시지를 반환한다', () {
+      const exception = PaymentDisabledException('무료 모드입니다.');
+
+      expect(exception.toString(), '무료 모드입니다.');
+    });
+  });
+}


### PR DESCRIPTION
## 릴리즈 v4.1.17

### 주요 변경사항

**환불 알림/상태 정비**
- 자동환불 성공 시 무알림, 실패 시에만 🟡 경고 알림
- 자동·관리자·원격 3가지 환불 실패 사유를 응답코드별 한글 사유로 통일 (PG 원문 미사용)
- 관리자 수동 환불 판정을 주문 상태 기준으로 통일 (응답 정상이나 원거래 없음 등 실패 누락 버그 수정)
- 관리자 수동 환불 성공 시 '환불 성공' Slack 알림 신규 추가
- 관리자 출력 내역 환불 상태 판정을 printedStatus → orderStatus 기준으로 변경

**결제 게이트웨이 추상화 (JKLI-172)**
- KSCAT 결제 연동을 PaymentGateway 인터페이스로 분리
- KscatPaymentGateway 구현 + DisabledPaymentGateway(무료 모드 준비물) 추가
- DisabledPaymentGateway 계약 테스트 추가

### 커밋
- refactor: KSCAT 결제 연동 PaymentGateway 추상화 (JKLI-172)
- feat: 환불 알림 응답코드별 상세 사유 통일 + 관리자환불 누락 수정
- feat: 환불 알림/상태 정비 (자동환불 성공 무알림, 실패 🟡, 출력내역 orderStatus 판정)

🤖 Generated with [Claude Code](https://claude.com/claude-code)