### PR TITLE
fix: 프린터 연결 확인 오류 Slack 알림을 브로드캐스트에서 에러 로그 채널로 변경 (JKLI-203)

### DIFF
--- a/lib/presentation/print/isolate/printer_manager.dart
+++ b/lib/presentation/print/isolate/printer_manager.dart
@@ -311,7 +311,7 @@ class PrinterManager {
 
       return isConnected;
     } catch (e) {
-      SlackLogService().sendBroadcastLogToSlack('[MachineId: $_machineId] [PRINTER] checkConnectedPrint 오류: $e');
+      SlackLogService().sendErrorLogToSlack('[MachineId: $_machineId] [PRINTER] checkConnectedPrint 오류: $e');
       return false;
     }
   }


### PR DESCRIPTION
## 요약
- 운영 기기(한화 2번)에서 `checkConnectedPrint` 내부 오류(LateInitializationError)가 Slack **브로드캐스트(공지) 채널**로 발송되던 문제 수정
- 발송 채널을 `sendBroadcastLogToSlack` → `sendErrorLogToSlack`(error_log)으로 변경 — 같은 파일의 다른 프린터 오류 처리 5곳과 일관되게 통일

## 브로드캐스트 전수 검토
`sendBroadcastLogToSlack` 직접 호출 전수 조사 결과, raw 예외 문자열을 브로드캐스트로 보내던 곳은 이 1곳뿐. 나머지(인쇄 실패 4종, 리본/필름 경고, 모드 전환, 점검, 결제/환불)는 모두 AlertDefinition 키 기반의 의도된 QA 알림이라 유지. QA 기준인 결제/환불 알림 발송 조건·문구는 변경 없음.

## Jira
- [JKLI-203](https://snaptag-team.atlassian.net/browse/JKLI-203) — 원인 분석/검토 결과 정리 완료 (custom 대상, vending은 별도 검토)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[JKLI-203]: https://snaptag-team.atlassian.net/browse/JKLI-203?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ