### PR TITLE
release: v4.1.19 - 프린터 오류 Slack 알림 채널 정비 (JKLI-203)

### DIFF
--- a/lib/presentation/print/isolate/printer_manager.dart
+++ b/lib/presentation/print/isolate/printer_manager.dart
@@ -311,7 +311,7 @@ class PrinterManager {
 
       return isConnected;
     } catch (e) {
-      SlackLogService().sendBroadcastLogToSlack('[MachineId: $_machineId] [PRINTER] checkConnectedPrint 오류: $e');
+      SlackLogService().sendErrorLogToSlack('[MachineId: $_machineId] [PRINTER] checkConnectedPrint 오류: $e');
       return false;
     }
   }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: flutter_snaptag_kiosk
 description: "A new Flutter project."
 publish_to: "none"
-version: 4.1.18
+version: 4.1.19
 
 environment:
   sdk: ^3.6.0


### PR DESCRIPTION
## v4.1.19

- fix: 프린터 연결 확인 오류(`checkConnectedPrint`) Slack 알림을 브로드캐스트 → 에러 로그 채널로 변경 (JKLI-203, #178)
- 브로드캐스트 발송 전수 검토: raw 예외 문자열 브로드캐스트는 해당 1곳뿐, AlertDefinition 키 기반 QA 알림은 변경 없음

Jira: https://snaptag-team.atlassian.net/browse/JKLI-203

🤖 Generated with [Claude Code](https://claude.com/claude-code)