### PR TITLE
feat: 비-한화 추천 이미지 카드 라벨 밴드 크롭 표시 (JKLI-214)

### DIFF
--- a/lib/presentation/payment/payment_screen.dart
+++ b/lib/presentation/payment/payment_screen.dart
@@ -1,4 +1,4 @@
-// ignore_for_file: public_member_api_docs, sort_constructors_first
+﻿// ignore_for_file: public_member_api_docs, sort_constructors_first
 import 'package:easy_localization/easy_localization.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
@@ -52,14 +52,26 @@ class PaymentScreen extends ConsumerStatefulWidget {
 class _PaymentScreenState extends ConsumerState<PaymentScreen> {
   bool _isNetworkErrorHandled = false;
 
+  /// 실제 포토카드 원본 규격 — 650×1023, 상/하단 각 80px가 이벤트명·날짜 라벨 밴드
+  static const double _photoCardWidth = 650;
+  static const double _photoCardHeight = 1023;
+  static const double _labelBandHeight = 80;
+
   Widget _buildFixedBackPhotoCard({
     required List<BoxShadow>? boxShadow,
     required String? imageUrl,
     bool hasBorder = false,
+    bool cropLabelBands = false,
   }) {
+    // cropLabelBands: 높이는 기존 카드와 같은 355를 유지하고, 폭을 라벨 제외 영역(650×863)
+    // 비율로 늘린다(≈267). cover로 채우면 650×1023 원본 기준 위아래가 정확히 80px씩만 잘린다.
+    final double height = 355.h;
+    final double width =
+        cropLabelBands ? height * _photoCardWidth / (_photoCardHeight - 2 * _labelBandHeight) : 226.w;
+
     return Container(
-      width: 226.w,
-      height: 355.h,
+      width: width,
+      height: height,
       clipBehavior: Clip.antiAlias,
       decoration: BoxDecoration(
         borderRadius: BorderRadius.circular(10.r),
@@ -86,7 +98,9 @@ class _PaymentScreenState extends ConsumerState<PaymentScreen> {
       ),
       child: ClipRRect(
         borderRadius: BorderRadius.circular(10.r),
-        child: imageUrl != null && imageUrl.isNotEmpty ? _buildNetworkImage(imageUrl) : const BackPhotoPlaceholder(),
+        child: imageUrl != null && imageUrl.isNotEmpty
+            ? (cropLabelBands ? CoverNetworkImage(imageUrl) : _buildNetworkImage(imageUrl))
+            : const BackPhotoPlaceholder(),
       ),
     );
   }
@@ -164,7 +178,8 @@ class _PaymentScreenState extends ConsumerState<PaymentScreen> {
 
   Widget _buildLegacyFixedCards(List<NominatedBackPhotoCard> cards, int? selectedIndex) {
     if (cards.length == 1) {
-      return _buildFixedBackPhotoCard(boxShadow: null, imageUrl: cards[0].originUrl, hasBorder: true);
+      return _buildFixedBackPhotoCard(
+          boxShadow: null, imageUrl: cards[0].originUrl, hasBorder: true, cropLabelBands: true);
     }
 
     return Row(
@@ -207,6 +222,7 @@ class _PaymentScreenState extends ConsumerState<PaymentScreen> {
                   BoxShadow(color: Colors.black.withValues(alpha: 0.1), blurRadius: 4.r, offset: Offset(0, 2.h)),
                 ],
           imageUrl: imageUrl,
+          cropLabelBands: true,
         ),
       ),
     );


### PR DESCRIPTION
## 개요

비-한화 업체의 추천 이미지 선택 카드가 실제 포토카드 원본(650×1023)을 통째로 보여주던 것을, **상/하단 라벨 밴드(각 80px)를 제외한 콘텐츠 영역(650×863)만** 보여주도록 변경. 인쇄물에는 영향 없음(화면 표시만).

## 변경 내용

- `_buildFixedBackPhotoCard`에 `cropLabelBands` 파라미터 추가 — 카드 비율을 650:863으로 맞추고 `CoverNetworkImage`(cover)로 채워, 650×1023 원본 기준 위아래가 정확히 80px씩만 잘림 (중앙 정렬, 좌우 손실 0)
- 카드 크기: 226×355 → **267×355** (높이는 기존 릴리즈와 동일, 폭만 확장. 2장 배치 시 267×2+100=634 < 1080)
- 원본이 650×863 규격으로 바뀌어도 클라 수정 없이 크롭 0으로 동작
- 적용 범위: 비-한화 legacy 카드(1장 네온 테두리 / 2장 선택형)만. 커스텀(인증번호) 미리보기·한화 경로 무변화

## QA 포인트

- 비-한화 이벤트: 카드에 라벨 밴드(이벤트명/날짜 영역)가 보이지 않는지, 좌우가 잘리지 않는지
- 커스텀 흐름: 기존과 동일하게 전체 이미지 표시 유지
- 결제·인쇄 동작 무관(표시 전용 변경), 테스트 54개 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)
