### PR TITLE
release: v4.1.22 - 단면 카드 재고 서버 연동 (JKLI-254)

### DIFF
--- a/lib/core/data/datasources/remote/kiosk_api_client.dart
+++ b/lib/core/data/datasources/remote/kiosk_api_client.dart
@@ -39,6 +39,16 @@ abstract class KioskApiClient {
     @Query('uniqueKey') required String uniqueKey,
   });
 
+  @POST('/v1/machine/card-stock/set')
+  Future<CardStockResponse> setCardStock({
+    @Body() required Map<String, dynamic> body,
+  });
+
+  @GET('/v1/machine/card-stock')
+  Future<CardStockResponse> getCardStock({
+    @Query('machineId') required int machineId,
+  });
+
   @GET('/v1/kiosk-event/back-photo')
   Future<BackPhotoCardResponse> getBackPhotoCard({
     @Query('kioskEventId') required int kioskEventId,

--- a/lib/core/data/models/enums/enums.dart
+++ b/lib/core/data/models/enums/enums.dart
@@ -1,5 +1,6 @@
 export 'machine_job_type.dart';
 export 'order_status.dart';
 export 'payment_type.dart';
+export 'print_type.dart';
 export 'printed_status.dart';
 export 'keypad_mode.dart';

--- a/lib/core/data/models/enums/print_type.dart
+++ b/lib/core/data/models/enums/print_type.dart
@@ -1,0 +1,8 @@
+import 'package:json_annotation/json_annotation.dart';
+
+enum PrintType {
+  @JsonValue('SINGLE')
+  single,
+  @JsonValue('DOUBLE')
+  double,
+}

--- a/lib/core/data/models/request/card_stock_set_request.dart
+++ b/lib/core/data/models/request/card_stock_set_request.dart
@@ -1,0 +1,17 @@
+import 'package:freezed_annotation/freezed_annotation.dart';
+
+part 'card_stock_set_request.freezed.dart';
+part 'card_stock_set_request.g.dart';
+
+/// [machineId] / [uniqueKey] 중 하나는 반드시 있어야 한다.
+/// [requestCount]는 가산이 아닌 절대값이다(0 = CLEAR).
+@freezed
+class CardStockSetRequest with _$CardStockSetRequest {
+  const factory CardStockSetRequest({
+    @JsonKey(includeIfNull: false) int? machineId,
+    @JsonKey(includeIfNull: false) String? uniqueKey,
+    required int requestCount,
+  }) = _CardStockSetRequest;
+
+  factory CardStockSetRequest.fromJson(Map<String, dynamic> json) => _$CardStockSetRequestFromJson(json);
+}

--- a/lib/core/data/models/request/request.dart
+++ b/lib/core/data/models/request/request.dart
@@ -6,3 +6,4 @@ export 'payment_request.dart';
 export 'update_order_request.dart';
 export 'update_print_request.dart';
 export 'get_back_photo_by_qr_request.dart';
+export 'card_stock_set_request.dart';

--- a/lib/core/data/models/request/update_print_request.dart
+++ b/lib/core/data/models/request/update_print_request.dart
@@ -10,6 +10,7 @@ class UpdatePrintRequest with _$UpdatePrintRequest {
     required int kioskMachineId,
     required int kioskEventId,
     required PrintedStatus status,
+    @JsonKey(includeIfNull: false) PrintType? printType,
   }) = _UpdatePrintRequest;
   factory UpdatePrintRequest.fromJson(Map<String, dynamic> json) => _$UpdatePrintRequestFromJson(json);
 }

--- a/lib/core/data/models/response/card_stock_response.dart
+++ b/lib/core/data/models/response/card_stock_response.dart
@@ -1,0 +1,18 @@
+import 'package:freezed_annotation/freezed_annotation.dart';
+
+part 'card_stock_response.freezed.dart';
+part 'card_stock_response.g.dart';
+
+/// [cardCapacity]는 머신에 미설정일 수 있어 nullable로 둔다.
+/// 응답의 `slackNotified`는 KIOSK에서 항상 false라 파싱하지 않는다.
+@freezed
+class CardStockResponse with _$CardStockResponse {
+  const factory CardStockResponse({
+    @Default(0) int id,
+    @Default('') String name,
+    @Default(0) int cardCurrentCount,
+    int? cardCapacity,
+  }) = _CardStockResponse;
+
+  factory CardStockResponse.fromJson(Map<String, dynamic> json) => _$CardStockResponseFromJson(json);
+}

--- a/lib/core/data/models/response/response.dart
+++ b/lib/core/data/models/response/response.dart
@@ -17,3 +17,4 @@ export 'server_error.dart';
 export 'update_order_response.dart';
 export 'update_print_response.dart';
 export 'alert_definition_response.dart';
+export 'card_stock_response.dart';

--- a/lib/core/data/models/response/update_print_response.dart
+++ b/lib/core/data/models/response/update_print_response.dart
@@ -11,6 +11,7 @@ class UpdatePrintResponse with _$UpdatePrintResponse {
     required int kioskEventId,
     required PrintedStatus status,
     required int printedPhotoCardId,
+    int? cardCurrentCount,
   }) = _UpdatePrintResponse;
 
   factory UpdatePrintResponse.fromJson(Map<String, dynamic> json) => _$UpdatePrintResponseFromJson(json);

--- a/lib/core/data/repositories/kiosk_repository.dart
+++ b/lib/core/data/repositories/kiosk_repository.dart
@@ -2,13 +2,13 @@ import 'dart:convert';
 import 'dart:developer';
 
 import 'package:dio/dio.dart';
-import 'package:http_parser/http_parser.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_snaptag_kiosk/core/data/models/request/unique_key_request.dart';
 import 'package:flutter_snaptag_kiosk/core/data/models/request/update_back_photo_request.dart';
 import 'package:flutter_snaptag_kiosk/lib.dart';
 import 'package:flutter_snaptag_kiosk/presentation/core/card_count_provider.dart';
 import 'package:flutter_snaptag_kiosk/presentation/print/luca/state/printer_log.dart';
+import 'package:http_parser/http_parser.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
 
 part 'kiosk_repository.g.dart';
@@ -98,6 +98,22 @@ class _KioskRepository {
   Future<KioskMachineInfo> getKioskMachineInfoByKey(String uniqueKey) async {
     try {
       return await _apiClient.getKioskMachineInfoByKey(uniqueKey: uniqueKey);
+    } catch (e) {
+      rethrow;
+    }
+  }
+
+  Future<CardStockResponse> setCardStock(CardStockSetRequest request) async {
+    try {
+      return await _apiClient.setCardStock(body: request.toJson());
+    } catch (e) {
+      rethrow;
+    }
+  }
+
+  Future<CardStockResponse> getCardStock({required int machineId}) async {
+    try {
+      return await _apiClient.getCardStock(machineId: machineId);
     } catch (e) {
       rethrow;
     }

--- a/lib/core/ui/widget/dialog_helper.dart
+++ b/lib/core/ui/widget/dialog_helper.dart
@@ -768,8 +768,8 @@ class _RefundCardInsertDialogWidgetState extends State<_RefundCardInsertDialogWi
                 children: [
                   Expanded(
                     child: OutlinedButton(
-                      onPressed: () async {
-                        await SoundManager().playSound();
+                      onPressed: () {
+                        unawaited(SoundManager().playSound());
                         if (mounted) Navigator.of(context, rootNavigator: true).pop(false);
                       },
                       style: context.refundDialogCancelButtonStyle,
@@ -779,8 +779,8 @@ class _RefundCardInsertDialogWidgetState extends State<_RefundCardInsertDialogWi
                   SizedBox(width: 12.w),
                   Expanded(
                     child: ElevatedButton(
-                      onPressed: () async {
-                        await SoundManager().playSound();
+                      onPressed: () {
+                        unawaited(SoundManager().playSound());
                         if (mounted) Navigator.of(context, rootNavigator: true).pop(true);
                       },
                       style: context.dialogKioskStyle,

--- a/lib/core/ui/widget/dialog_helper.dart
+++ b/lib/core/ui/widget/dialog_helper.dart
@@ -145,7 +145,7 @@ class DialogHelper {
       context: context,
       barrierDismissible: barrierDismissible,
       builder: (BuildContext dialogContext) {
-        final isHwe = context.isHwe;
+        final isHwe = dialogContext.isHwe;
 
         return _AutoCloseScope(
           // 타이머를 다이얼로그 라이프사이클에 바인딩한다. 사용자가 먼저 닫으면
@@ -153,7 +153,7 @@ class DialogHelper {
           duration: autoCloseDuration,
           child: DefaultTextStyle(
             style: TextStyle(
-              fontFamily: context.locale.languageCode == 'ja' ? 'MPLUSRounded' : 'Cafe24Ssurround2',
+              fontFamily: dialogContext.locale.languageCode == 'ja' ? 'MPLUSRounded' : 'Cafe24Ssurround2',
             ),
             child: Dialog(
               backgroundColor: Colors.white,
@@ -171,7 +171,7 @@ class DialogHelper {
                       child: Text(
                         title,
                         textAlign: TextAlign.center,
-                        style: context.typography.kioskAlert1B.copyWith(
+                        style: dialogContext.typography.kioskAlert1B.copyWith(
                           fontFamily: isHwe ? 'Hanwha' : 'Pretendard',
                           color: Colors.black,
                           fontSize: isHwe ? 52.sp : 42.sp,
@@ -185,7 +185,7 @@ class DialogHelper {
                       child: Text(
                         content,
                         textAlign: TextAlign.center,
-                        style: context.typography.kioskAlert2M.copyWith(
+                        style: dialogContext.typography.kioskAlert2M.copyWith(
                           color: Colors.black,
                           fontFamily: 'Pretendard',
                         ),
@@ -197,7 +197,7 @@ class DialogHelper {
                       child: Text(
                         subContent,
                         textAlign: TextAlign.center,
-                        style: context.typography.kioskAlert2M.copyWith(
+                        style: dialogContext.typography.kioskAlert2M.copyWith(
                           color: const Color(0xFFFF333F),
                           fontFamily: 'Pretendard',
                           fontWeight: FontWeight.w700,
@@ -211,8 +211,8 @@ class DialogHelper {
                         if (showCancelButton)
                           Expanded(
                             child: OutlinedButton(
-                              onPressed: () async {
-                                await SoundManager().playSound();
+                              onPressed: () {
+                                unawaited(SoundManager().playSound());
                                 Navigator.of(dialogContext).pop(false);
                               },
                               style: cancelButtonStyle,
@@ -222,8 +222,8 @@ class DialogHelper {
                         if (showCancelButton) SizedBox(width: 12.w),
                         Expanded(
                           child: ElevatedButton(
-                            onPressed: () async {
-                              await SoundManager().playSound();
+                            onPressed: () {
+                              unawaited(SoundManager().playSound());
                               Navigator.of(dialogContext).pop(true);
                             },
                             style: confirmButtonStyle,
@@ -658,8 +658,8 @@ class _TimeoutDialogWidgetState extends State<_TimeoutDialogWidget> {
                   children: [
                     Expanded(
                       child: OutlinedButton(
-                        onPressed: () async {
-                          await SoundManager().playSound();
+                        onPressed: () {
+                          unawaited(SoundManager().playSound());
                           Navigator.of(context).pop(false);
                         },
                         style: context.refundDialogCancelButtonStyle,
@@ -669,8 +669,8 @@ class _TimeoutDialogWidgetState extends State<_TimeoutDialogWidget> {
                     SizedBox(width: 12.w),
                     Expanded(
                       child: ElevatedButton(
-                        onPressed: () async {
-                          await SoundManager().playSound();
+                        onPressed: () {
+                          unawaited(SoundManager().playSound());
                           Navigator.of(context).pop(true);
                         },
                         style: widget.confirmButtonStyle ?? context.refundDialogConfirmButtonStyle,

--- a/lib/presentation/core/card_count_provider.dart
+++ b/lib/presentation/core/card_count_provider.dart
@@ -1,24 +1,29 @@
-import 'package:riverpod_annotation/riverpod_annotation.dart';
 import 'package:flutter_snaptag_kiosk/core/data/datasources/local/id_writer.dart';
+import 'package:riverpod_annotation/riverpod_annotation.dart';
 
 part 'card_count_provider.g.dart';
 
 class CardCountState {
   final int initialCount; // 처음 설정(기준) 수량
   final int currentCount; // 현재 수량
+  final bool isSynced;
 
   const CardCountState({
     required this.initialCount,
     required this.currentCount,
+    this.isSynced = false,
   });
 
   int get usedCount => (initialCount - currentCount).clamp(0, initialCount);
   int get remaining => currentCount;
 
-  CardCountState copyWith({int? initialCount, int? currentCount}) {
+  String get displayCount => isSynced ? '$currentCount' : '-';
+
+  CardCountState copyWith({int? initialCount, int? currentCount, bool? isSynced}) {
     return CardCountState(
       initialCount: initialCount ?? this.initialCount,
       currentCount: currentCount ?? this.currentCount,
+      isSynced: isSynced ?? this.isSynced,
     );
   }
 
@@ -37,11 +42,16 @@ class CardCount extends _$CardCount {
   }
 
   void updateCurrent(int newCount) {
-    state = state.copyWith(currentCount: newCount);
+    state = state.copyWith(currentCount: newCount, isSynced: true);
   }
 
   void update(int value) {
-    state = state.copyWith(initialCount: value, currentCount: value);
+    state = state.copyWith(initialCount: value, currentCount: value, isSynced: true);
+  }
+
+  void markSynced() {
+    if (state.isSynced) return;
+    state = state.copyWith(isSynced: true);
   }
 
   Future<void> increase([int step = 1]) async {

--- a/lib/presentation/kiosk_shell/kiosk_info_service.dart
+++ b/lib/presentation/kiosk_shell/kiosk_info_service.dart
@@ -96,33 +96,32 @@ class KioskInfoService extends _$KioskInfoService {
     } catch (e) {
       _getInfoByKey = false;
       _isLoading = false;
-      // 조회까지 가지 못했더라도 수량 표시가 '-'에 갇히면 안 된다.
       ref.read(cardCountProvider.notifier).markSynced();
       return null;
     }
   }
 
-  /// 기기당 1회만 복원한다 — 운영 중 재조회하면 낡은 서버 값이 관리자가 방금 입력한 값을 덮는다.
   Future<void> _restoreCardStock(int machineId) async {
-    // machineId 0은 가드를 소진시키지 않는다. 이후 유효한 기기번호로 등록되면 복원돼야 한다.
     if (machineId == 0 || _cardStockRestoredMachineId == machineId) {
       ref.read(cardCountProvider.notifier).markSynced();
       return;
     }
+    final isMachineSwitch = _cardStockRestoredMachineId != null;
     _cardStockRestoredMachineId = machineId;
 
     try {
       final stock = await ref.read(kioskRepositoryProvider).getCardStock(machineId: machineId);
+      ref.read(cardCountProvider.notifier).update(stock.cardCurrentCount);
       if (stock.cardCurrentCount > 0) {
-        ref.read(cardCountProvider.notifier).update(stock.cardCurrentCount);
-        // 관리자 조작이 아니라 상태 복원이므로 인쇄모드 전환 Slack 알림은 보내지 않는다.
         ref.read(pagePrintProvider.notifier).set(PagePrintType.single);
       }
     } catch (e) {
       _cardStockRestoredMachineId = null;
+      if (isMachineSwitch) {
+        ref.read(cardCountProvider.notifier).update(0);
+      }
       SlackLogService().sendLogToSlack('단면 카드 잔량 복원 실패 (machineId: $machineId): $e');
     } finally {
-      // 복원 성공·이력 없음·조회 실패 모두 '조회 끝'이다.
       ref.read(cardCountProvider.notifier).markSynced();
     }
   }
@@ -149,7 +148,6 @@ class KioskInfoService extends _$KioskInfoService {
       _cachedMachineId = machineId;
       _cachedKioskEventId = response.kioskEventId;
 
-      // 첫 생존보고가 복원된 잔량을 싣도록 타이머 시작 전에 수행한다.
       await _restoreCardStock(machineId);
 
       // 응답을 받은 후 10분마다 실행되는 타이머 시작

--- a/lib/presentation/kiosk_shell/kiosk_info_service.dart
+++ b/lib/presentation/kiosk_shell/kiosk_info_service.dart
@@ -119,6 +119,7 @@ class KioskInfoService extends _$KioskInfoService {
         ref.read(pagePrintProvider.notifier).set(PagePrintType.single);
       }
     } catch (e) {
+      _cardStockRestoredMachineId = null;
       SlackLogService().sendLogToSlack('단면 카드 잔량 복원 실패 (machineId: $machineId): $e');
     } finally {
       // 복원 성공·이력 없음·조회 실패 모두 '조회 끝'이다.

--- a/lib/presentation/kiosk_shell/kiosk_info_service.dart
+++ b/lib/presentation/kiosk_shell/kiosk_info_service.dart
@@ -6,6 +6,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_snaptag_kiosk/lib.dart';
 import 'package:flutter_snaptag_kiosk/presentation/core/card_count_provider.dart';
 import 'package:flutter_snaptag_kiosk/presentation/setup/front_photo_list.dart';
+import 'package:flutter_snaptag_kiosk/presentation/setup/page_print_provider.dart';
 import 'package:flutter_snaptag_kiosk/presentation/setup/uuid_provider.dart';
 import 'package:path/path.dart' as p;
 import 'package:riverpod_annotation/riverpod_annotation.dart';
@@ -21,6 +22,7 @@ class KioskInfoService extends _$KioskInfoService {
   int? _cachedKioskEventId;
   bool _getInfoByKey = true;
   bool _isLoading = false;
+  int? _cardStockRestoredMachineId;
 
   bool get getInfoByKey => _getInfoByKey;
 
@@ -56,6 +58,7 @@ class KioskInfoService extends _$KioskInfoService {
         _cachedMachineId = cached.kioskMachineId;
         _cachedKioskEventId = cached.kioskEventId;
         ref.read(frontPhotoListProvider.notifier).fetch();
+        await _restoreCardStock(cached.kioskMachineId);
         await _startPeriodicTimer();
         _getInfoByKey = true;
         _isLoading = false;
@@ -81,6 +84,8 @@ class KioskInfoService extends _$KioskInfoService {
       _cachedMachineId = response.kioskMachineId;
       _cachedKioskEventId = response.kioskEventId;
 
+      await _restoreCardStock(response.kioskMachineId);
+
       // 응답을 받은 후 10분마다 실행되는 타이머 시작
       await _startPeriodicTimer();
 
@@ -91,7 +96,33 @@ class KioskInfoService extends _$KioskInfoService {
     } catch (e) {
       _getInfoByKey = false;
       _isLoading = false;
+      // 조회까지 가지 못했더라도 수량 표시가 '-'에 갇히면 안 된다.
+      ref.read(cardCountProvider.notifier).markSynced();
       return null;
+    }
+  }
+
+  /// 기기당 1회만 복원한다 — 운영 중 재조회하면 낡은 서버 값이 관리자가 방금 입력한 값을 덮는다.
+  Future<void> _restoreCardStock(int machineId) async {
+    // machineId 0은 가드를 소진시키지 않는다. 이후 유효한 기기번호로 등록되면 복원돼야 한다.
+    if (machineId == 0 || _cardStockRestoredMachineId == machineId) {
+      ref.read(cardCountProvider.notifier).markSynced();
+      return;
+    }
+    _cardStockRestoredMachineId = machineId;
+
+    try {
+      final stock = await ref.read(kioskRepositoryProvider).getCardStock(machineId: machineId);
+      if (stock.cardCurrentCount > 0) {
+        ref.read(cardCountProvider.notifier).update(stock.cardCurrentCount);
+        // 관리자 조작이 아니라 상태 복원이므로 인쇄모드 전환 Slack 알림은 보내지 않는다.
+        ref.read(pagePrintProvider.notifier).set(PagePrintType.single);
+      }
+    } catch (e) {
+      SlackLogService().sendLogToSlack('단면 카드 잔량 복원 실패 (machineId: $machineId): $e');
+    } finally {
+      // 복원 성공·이력 없음·조회 실패 모두 '조회 끝'이다.
+      ref.read(cardCountProvider.notifier).markSynced();
     }
   }
 
@@ -116,6 +147,9 @@ class KioskInfoService extends _$KioskInfoService {
       // 캐시된 값들 업데이트
       _cachedMachineId = machineId;
       _cachedKioskEventId = response.kioskEventId;
+
+      // 첫 생존보고가 복원된 잔량을 싣도록 타이머 시작 전에 수행한다.
+      await _restoreCardStock(machineId);
 
       // 응답을 받은 후 10분마다 실행되는 타이머 시작
       await _startPeriodicTimer();

--- a/lib/presentation/payment/payment_service.dart
+++ b/lib/presentation/payment/payment_service.dart
@@ -150,7 +150,10 @@ class PaymentService extends _$PaymentService {
   /// 성공적인 결제 처리
   Future<void> _handleSuccessfulPayment() async {
     final response = await _updateOrder(isRefund: false);
-    await ref.read(cardCountProvider.notifier).decrease();
+    // 단면 카운터는 단면 모드일 때만 차감 — 양면 모드 결제는 단면 카드를 쓰지 않음
+    if (ref.read(pagePrintProvider) == PagePrintType.single) {
+      await ref.read(cardCountProvider.notifier).decrease();
+    }
     SlackLogService().sendLogToSlack("paymentResponse0000 : $response");
   }
 

--- a/lib/presentation/print/print_service.dart
+++ b/lib/presentation/print/print_service.dart
@@ -1,6 +1,7 @@
 import 'dart:io';
 
 import 'package:flutter_snaptag_kiosk/lib.dart';
+import 'package:flutter_snaptag_kiosk/presentation/core/card_count_provider.dart';
 import 'package:flutter_snaptag_kiosk/presentation/kiosk_shell/kiosk_info_service.dart';
 import 'package:flutter_snaptag_kiosk/presentation/payment/create_order_info_state.dart';
 import 'package:flutter_snaptag_kiosk/presentation/payment/payment_response_state.dart';
@@ -135,9 +136,15 @@ class PrintService extends _$PrintService {
           },
         );
 
-        await ref
+        final response = await ref
             .read(kioskRepositoryProvider)
             .updatePrintStatus(printedPhotoCardId: printedPhotoCardId, request: request);
+
+        // 서버는 단면(SINGLE) + COMPLETED 최초 전이에서만 차감하고, 그때만 잔량을 내려준다.
+        final serverCardCount = response.cardCurrentCount;
+        if (serverCardCount != null) {
+          ref.read(cardCountProvider.notifier).updateCurrent(serverCardCount);
+        }
         return;
       } catch (e) {
         attempt++;

--- a/lib/presentation/print/print_service.dart
+++ b/lib/presentation/print/print_service.dart
@@ -120,12 +120,19 @@ class PrintService extends _$PrintService {
     const maxRetries = 3;
     int attempt = 0;
 
+    final pagePrintType = ref.read(pagePrintProvider);
+
     while (attempt < maxRetries) {
       try {
         final request = UpdatePrintRequest(
           kioskMachineId: ref.read(kioskInfoServiceProvider)!.kioskMachineId,
           kioskEventId: ref.read(kioskInfoServiceProvider)!.kioskEventId,
           status: status,
+          printType: switch (pagePrintType) {
+            PagePrintType.single => PrintType.single,
+            PagePrintType.double => PrintType.double,
+            PagePrintType.none => null,
+          },
         );
 
         await ref

--- a/lib/presentation/print/print_service.dart
+++ b/lib/presentation/print/print_service.dart
@@ -140,7 +140,6 @@ class PrintService extends _$PrintService {
             .read(kioskRepositoryProvider)
             .updatePrintStatus(printedPhotoCardId: printedPhotoCardId, request: request);
 
-        // 서버는 단면(SINGLE) + COMPLETED 최초 전이에서만 차감하고, 그때만 잔량을 내려준다.
         final serverCardCount = response.cardCurrentCount;
         if (serverCardCount != null) {
           ref.read(cardCountProvider.notifier).updateCurrent(serverCardCount);

--- a/lib/presentation/setup/card_stock/card_stock_action.dart
+++ b/lib/presentation/setup/card_stock/card_stock_action.dart
@@ -15,10 +15,12 @@ class CardStockOutcome {
 }
 
 Future<CardStockOutcome?> showCardStockDialog(BuildContext context, WidgetRef ref) async {
+  final cardCount = ref.read(cardCountProvider.notifier);
+  final kioskRepository = ref.read(kioskRepositoryProvider);
+  final machineId = ref.read(kioskInfoServiceProvider)?.kioskMachineId ?? 0;
+
   final requestCount = await _promptCount(context);
   if (requestCount == null) return null;
-
-  final machineId = ref.read(kioskInfoServiceProvider)?.kioskMachineId ?? 0;
 
   int appliedCount = requestCount;
   bool recorded = false;
@@ -28,7 +30,9 @@ Future<CardStockOutcome?> showCardStockDialog(BuildContext context, WidgetRef re
     failureReason = '기기 정보를 불러오지 못했습니다.';
   } else {
     try {
-      final response = await _recordCardStock(ref, machineId: machineId, requestCount: requestCount);
+      final response = await kioskRepository.setCardStock(
+        CardStockSetRequest(machineId: machineId, requestCount: requestCount),
+      );
       appliedCount = response.cardCurrentCount;
       recorded = true;
     } catch (e) {
@@ -37,7 +41,7 @@ Future<CardStockOutcome?> showCardStockDialog(BuildContext context, WidgetRef re
     }
   }
 
-  ref.read(cardCountProvider.notifier).update(appliedCount);
+  cardCount.update(appliedCount);
 
   if (!recorded && context.mounted) {
     await DialogHelper.showSetupDialog(
@@ -48,16 +52,6 @@ Future<CardStockOutcome?> showCardStockDialog(BuildContext context, WidgetRef re
   }
 
   return CardStockOutcome(count: appliedCount, recordedOnServer: recorded);
-}
-
-Future<CardStockResponse> _recordCardStock(
-  WidgetRef ref, {
-  required int machineId,
-  required int requestCount,
-}) {
-  return ref.read(kioskRepositoryProvider).setCardStock(
-        CardStockSetRequest(machineId: machineId, requestCount: requestCount),
-      );
 }
 
 Future<int?> _promptCount(BuildContext context) async {

--- a/lib/presentation/setup/card_stock/card_stock_action.dart
+++ b/lib/presentation/setup/card_stock/card_stock_action.dart
@@ -1,0 +1,88 @@
+import 'package:dio/dio.dart';
+import 'package:flutter/widgets.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_snaptag_kiosk/core/ui/widget/dialog_helper.dart';
+import 'package:flutter_snaptag_kiosk/lib.dart';
+import 'package:flutter_snaptag_kiosk/presentation/core/card_count_provider.dart';
+import 'package:flutter_snaptag_kiosk/presentation/kiosk_shell/kiosk_info_service.dart';
+
+const int kCardStockMax = 300;
+
+class CardStockOutcome {
+  final int count;
+  final bool recordedOnServer;
+  const CardStockOutcome({required this.count, required this.recordedOnServer});
+}
+
+Future<CardStockOutcome?> showCardStockDialog(BuildContext context, WidgetRef ref) async {
+  final requestCount = await _promptCount(context);
+  if (requestCount == null) return null;
+
+  final machineId = ref.read(kioskInfoServiceProvider)?.kioskMachineId ?? 0;
+
+  int appliedCount = requestCount;
+  bool recorded = false;
+  String failureReason = '';
+
+  if (machineId == 0) {
+    failureReason = '기기 정보를 불러오지 못했습니다.';
+  } else {
+    try {
+      final response = await _recordCardStock(ref, machineId: machineId, requestCount: requestCount);
+      appliedCount = response.cardCurrentCount;
+      recorded = true;
+    } catch (e) {
+      failureReason = _describeFailure(e);
+      SlackLogService().sendErrorLogToSlack('*[MachineId : $machineId]* 카드 적재 기록 실패 (요청: $requestCount장): $e');
+    }
+  }
+
+  ref.read(cardCountProvider.notifier).update(appliedCount);
+
+  if (!recorded && context.mounted) {
+    await DialogHelper.showSetupDialog(
+      context,
+      title: '카드 수량 서버 기록 실패',
+      content: '$appliedCount장으로 이 기기에만 반영했습니다.\n$failureReason',
+    );
+  }
+
+  return CardStockOutcome(count: appliedCount, recordedOnServer: recorded);
+}
+
+Future<CardStockResponse> _recordCardStock(
+  WidgetRef ref, {
+  required int machineId,
+  required int requestCount,
+}) {
+  return ref.read(kioskRepositoryProvider).setCardStock(
+        CardStockSetRequest(machineId: machineId, requestCount: requestCount),
+      );
+}
+
+Future<int?> _promptCount(BuildContext context) async {
+  final value = await DialogHelper.showKeypadDialog(context, mode: ModeType.card);
+  if (value == null || value.isEmpty) return null;
+
+  final parsed = int.tryParse(value);
+  if (parsed == null || parsed < 0 || parsed > kCardStockMax) {
+    if (!context.mounted) return null;
+    await DialogHelper.showSetupDialog(
+      context,
+      title: '카드 수량을 확인해주세요.',
+      content: '0장 이상 $kCardStockMax장 이하로 입력해 주세요.',
+    );
+    return null;
+  }
+  return parsed;
+}
+
+String _describeFailure(Object error) {
+  if (error is DioException) {
+    final data = error.response?.data;
+    if (data is Map && data['message'] is String) {
+      return data['message'] as String;
+    }
+  }
+  return '네트워크 상태를 확인해 주세요.';
+}

--- a/lib/presentation/setup/payment_history_provider.dart
+++ b/lib/presentation/setup/payment_history_provider.dart
@@ -12,15 +12,18 @@ class OrdersPage extends _$OrdersPage {
   int get kioskMachineId => ref.read(kioskInfoServiceProvider)?.kioskMachineId ?? 0;
 
   @override
-  Future<OrderListResponse> build({int page = 1}) => _fetch(page);
+  Future<OrderListResponse> build({int page = 1}) {
+    final machineId = ref.watch(kioskInfoServiceProvider.select((info) => info?.kioskMachineId ?? 0));
+    return _fetch(page, machineId);
+  }
 
   Future<void> goToPage(int newPage) async {
     state = const AsyncLoading();
-    state = await AsyncValue.guard(() => _fetch(newPage));
+    state = await AsyncValue.guard(() => _fetch(newPage, kioskMachineId));
   }
 
-  Future<OrderListResponse> _fetch(int page) async {
-    if (kioskMachineId == 0) {
+  Future<OrderListResponse> _fetch(int page, int machineId) async {
+    if (machineId == 0) {
       return OrderListResponse(
         list: const [],
         paging: PagingEntity(totalCount: 0, pageSize: _pageSize, currentPage: page, canNext: false),

--- a/lib/presentation/setup/payment_history_provider.dart
+++ b/lib/presentation/setup/payment_history_provider.dart
@@ -12,7 +12,21 @@ class OrdersPage extends _$OrdersPage {
   int get kioskMachineId => ref.read(kioskInfoServiceProvider)?.kioskMachineId ?? 0;
 
   @override
-  Future<OrderListResponse> build({int page = 1}) async {
+  Future<OrderListResponse> build({int page = 1}) => _fetch(page);
+
+  Future<void> goToPage(int newPage) async {
+    state = const AsyncLoading();
+    state = await AsyncValue.guard(() => _fetch(newPage));
+  }
+
+  Future<OrderListResponse> _fetch(int page) async {
+    if (kioskMachineId == 0) {
+      return OrderListResponse(
+        list: const [],
+        paging: PagingEntity(totalCount: 0, pageSize: _pageSize, currentPage: page, canNext: false),
+      );
+    }
+
     final OrderListResponse response = await ref.read(kioskRepositoryProvider).getOrders(GetOrdersRequest(
           pageSize: _pageSize,
           currentPage: page,
@@ -20,14 +34,5 @@ class OrdersPage extends _$OrdersPage {
         ));
     logger.i('response: $response');
     return response;
-  }
-
-  Future<void> goToPage(int newPage) async {
-    state = const AsyncLoading();
-    state = await AsyncValue.guard(() => ref.read(kioskRepositoryProvider).getOrders(GetOrdersRequest(
-          pageSize: _pageSize,
-          currentPage: newPage,
-          kioskMachineId: kioskMachineId,
-        )));
   }
 }

--- a/lib/presentation/setup/payment_history_screen.dart
+++ b/lib/presentation/setup/payment_history_screen.dart
@@ -8,6 +8,7 @@ import 'package:flutter_snaptag_kiosk/core/common/sound/sound_manager.dart';
 import 'package:flutter_snaptag_kiosk/core/ui/widget/dialog_helper.dart';
 import 'package:flutter_snaptag_kiosk/core/ui/widget/general_error_widget.dart';
 import 'package:flutter_snaptag_kiosk/lib.dart';
+import 'package:flutter_snaptag_kiosk/presentation/kiosk_shell/kiosk_info_service.dart';
 import 'package:flutter_snaptag_kiosk/presentation/setup/payment_history_provider.dart';
 import 'package:flutter_snaptag_kiosk/presentation/setup/setup_refund_process_provider.dart';
 import 'package:flutter_svg/svg.dart';
@@ -44,6 +45,7 @@ class _PaymentHistoryScreenState extends ConsumerState<PaymentHistoryScreen> {
       );
     });
     final ordersPage = ref.watch(ordersPageProvider());
+    final machineId = ref.watch(kioskInfoServiceProvider)?.kioskMachineId ?? 0;
 
     return Theme(
       data: Theme.of(context).copyWith(
@@ -99,6 +101,15 @@ class _PaymentHistoryScreenState extends ConsumerState<PaymentHistoryScreen> {
           ),
           body: ordersPage.when(
             data: (response) {
+              if (machineId == 0) {
+                return Center(
+                  child: Text(
+                    '키오스크 기기번호가 없어\n출력 내역을 조회할 수 없습니다.',
+                    textAlign: TextAlign.center,
+                    style: TextStyle(fontSize: 36.sp, fontWeight: FontWeight.bold),
+                  ),
+                );
+              }
               return Column(
                 mainAxisAlignment: MainAxisAlignment.start,
                 children: [
@@ -212,7 +223,7 @@ class _PaymentHistoryScreenState extends ConsumerState<PaymentHistoryScreen> {
               ),
             ),
             error: (error, stack) => GeneralErrorWidget(
-              exception: error as Exception,
+              exception: error is Exception ? error : Exception(error.toString()),
               onRetry: () => ref.refresh(ordersPageProvider()),
             ),
           ),

--- a/lib/presentation/setup/payment_history_screen.dart
+++ b/lib/presentation/setup/payment_history_screen.dart
@@ -549,9 +549,10 @@ class PaginationControls extends StatelessWidget {
   Widget build(BuildContext context) {
     List<Widget> pageButtons() {
       List<Widget> buttons = [];
+      final safeTotalPages = totalPages < 1 ? 1 : totalPages;
       int startPage =
-          (currentPage - 5).clamp(1, totalPages > 10 ? totalPages - 9 : 1);
-      int endPage = (startPage + 9).clamp(startPage, totalPages);
+          (currentPage - 5).clamp(1, safeTotalPages > 10 ? safeTotalPages - 9 : 1);
+      int endPage = (startPage + 9).clamp(startPage, safeTotalPages);
 
       for (int i = startPage; i <= endPage; i++) {
         buttons.add(

--- a/lib/presentation/setup/setup_main_screen.dart
+++ b/lib/presentation/setup/setup_main_screen.dart
@@ -15,6 +15,7 @@ import 'package:flutter_snaptag_kiosk/presentation/kiosk_shell/kiosk_info_servic
 import 'package:flutter_snaptag_kiosk/presentation/print/card_printer.dart';
 import 'package:flutter_snaptag_kiosk/presentation/print/luca/state/printer_connect_state.dart';
 import 'package:flutter_snaptag_kiosk/presentation/setup/alert_definition_provider.dart';
+import 'package:flutter_snaptag_kiosk/presentation/setup/card_stock/card_stock_action.dart';
 import 'package:flutter_snaptag_kiosk/presentation/setup/page_print_provider.dart';
 import 'package:flutter_svg/flutter_svg.dart';
 
@@ -388,28 +389,24 @@ class _SetupMainScreenState extends ConsumerState<SetupMainScreen> {
                       borderRadius: const BorderRadius.all(Radius.circular(12)),
                       onTap: () async {
                         final isActive = ref.read(pagePrintProvider) == PagePrintType.single;
-                        if (isActive) {
-                          String? value = await DialogHelper.showKeypadDialog(context, mode: ModeType.card);
+                        if (!isActive) return;
 
-                          if (value == null || value.isEmpty) return; // 값이 없으면 종료
-                          int cardNumber = int.parse(value);
-                          ref.read(cardCountProvider.notifier).update(cardNumber);
-                          if (cardNumber <= 0) {
-                            ref.read(pagePrintProvider.notifier).set(PagePrintType.double);
-                          } else {
-                            ref.read(pagePrintProvider.notifier).set(PagePrintType.single);
-                            if (machineId != 0) {
-                              SlackLogService().sendBroadcastLogToSlackWithKey(InfoKey.cardPrintModeSwitchSingle.key);
-                            }
-                          }
+                        final outcome = await showCardStockDialog(context, ref);
+                        if (outcome == null) return;
+
+                        if (outcome.count <= 0) {
+                          ref.read(pagePrintProvider.notifier).set(PagePrintType.double);
                         } else {
-                          print('click when pagePringType not single');
+                          ref.read(pagePrintProvider.notifier).set(PagePrintType.single);
+                          if (machineId != 0) {
+                            SlackLogService().sendBroadcastLogToSlackWithKey(InfoKey.cardPrintModeSwitchSingle.key);
+                          }
                         }
                       },
                       child: Align(
                         alignment: Alignment.center,
                         child: Text(
-                          (cardCountState.currentCount).toString(),
+                          cardCountState.displayCount,
                           textAlign: TextAlign.center,
                           style: ref.watch(pagePrintProvider) != PagePrintType.single
                               ? context.typography.kioskBody2B.copyWith(color: Color(0xFFECEDEF))

--- a/lib/presentation/setup/setup_main_screen.dart
+++ b/lib/presentation/setup/setup_main_screen.dart
@@ -440,8 +440,8 @@ class _SetupMainScreenState extends ConsumerState<SetupMainScreen> {
                         child: SetupMainCard(
                           label: '이벤트\n미리보기',
                           assetName: SnaptagSvg.eventPreview,
-                          onTap: () async {
-                            await SoundManager().playSound();
+                          onTap: () {
+                            unawaited(SoundManager().playSound());
                             if (cardCountState.currentCount < 1) {
                               ref.read(pagePrintProvider.notifier).set(PagePrintType.double);
                             }
@@ -474,8 +474,8 @@ class _SetupMainScreenState extends ConsumerState<SetupMainScreen> {
                         child: SetupMainCard(
                           label: '출력 내역',
                           assetName: SnaptagSvg.payment,
-                          onTap: () async {
-                            await SoundManager().playSound();
+                          onTap: () {
+                            unawaited(SoundManager().playSound());
                             PaymentHistoryRouteData().go(context);
                           },
                         ),
@@ -490,8 +490,8 @@ class _SetupMainScreenState extends ConsumerState<SetupMainScreen> {
                         child: SetupMainCard(
                           label: '출력 내역',
                           assetName: SnaptagSvg.payment,
-                          onTap: () async {
-                            await SoundManager().playSound();
+                          onTap: () {
+                            unawaited(SoundManager().playSound());
                             PaymentHistoryRouteData().go(context);
                           },
                         ),
@@ -526,8 +526,8 @@ class _SetupMainScreenState extends ConsumerState<SetupMainScreen> {
                         height: 314.h,
                         child: SetupMainCard(
                             label: 'Unit Test',
-                            onTap: () async {
-                              await SoundManager().playSound();
+                            onTap: () {
+                              unawaited(SoundManager().playSound());
                               UnitTestRouteData().go(context);
                             }),
                       ),
@@ -539,8 +539,8 @@ class _SetupMainScreenState extends ConsumerState<SetupMainScreen> {
                         height: 314.h,
                         child: SetupMainCard(
                             label: 'Kiosk\nComponents',
-                            onTap: () async {
-                              await SoundManager().playSound();
+                            onTap: () {
+                              unawaited(SoundManager().playSound());
                               KioskComponentsRouteData().go(context);
                             }),
                       ),
@@ -610,9 +610,9 @@ class _SetupMainScreenState extends ConsumerState<SetupMainScreen> {
                       child: SetupMainCard(
                         label: '서비스 점검',
                         assetName: SnaptagSvg.maintenance,
-                        onTap: () async {
+                        onTap: () {
                           SlackLogService().sendBroadcastLogToSlackWithKey(InfoKey.serviceMaintenanceEnter.key);
-                          await SoundManager().playSound();
+                          unawaited(SoundManager().playSound());
                           MaintenanceRouteData().go(context);
                         },
                       ),

--- a/lib/presentation/setup/setup_main_screen.dart
+++ b/lib/presentation/setup/setup_main_screen.dart
@@ -388,16 +388,16 @@ class _SetupMainScreenState extends ConsumerState<SetupMainScreen> {
                     child: InkWell(
                       borderRadius: const BorderRadius.all(Radius.circular(12)),
                       onTap: () async {
-                        final isActive = ref.read(pagePrintProvider) == PagePrintType.single;
-                        if (!isActive) return;
+                        if (ref.read(pagePrintProvider) != PagePrintType.single) return;
 
+                        final pagePrint = ref.read(pagePrintProvider.notifier);
                         final outcome = await showCardStockDialog(context, ref);
                         if (outcome == null) return;
 
                         if (outcome.count <= 0) {
-                          ref.read(pagePrintProvider.notifier).set(PagePrintType.double);
+                          pagePrint.set(PagePrintType.double);
                         } else {
-                          ref.read(pagePrintProvider.notifier).set(PagePrintType.single);
+                          pagePrint.set(PagePrintType.single);
                           if (machineId != 0) {
                             SlackLogService().sendBroadcastLogToSlackWithKey(InfoKey.cardPrintModeSwitchSingle.key);
                           }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: flutter_snaptag_kiosk
 description: "A new Flutter project."
 publish_to: "none"
-version: 4.1.21
+version: 4.1.22
 
 environment:
   sdk: ^3.6.0


### PR DESCRIPTION
## v4.1.22

단면 카드 재고를 서버 원장과 연동합니다 (JKLI-254 / 2단계 클라). 작업 중 발견한 출력 내역·다이얼로그 크래시 3건도 함께 수정했습니다.

서버 변경(JKLI-253)은 전부 additive이며, **서버 미배포 상태에서도 현행과 동일하게 동작**합니다.

---

## 단면 카드 재고 서버 연동 (JKLI-254)

기존에는 단면 카드 잔량이 로컬 카운터 단독 관리라 매 부팅마다 0에서 시작했고, 현장 적재가 서버에 전혀 기록되지 않았습니다. 서버 원장과 연동해 물리/논리 재고 대사가 가능하도록 합니다.

| API | 용도 |
|---|---|
| `POST /v1/machine/card-stock/set` | 적재 — 절대값 설정 (0 = CLEAR) |
| `GET /v1/machine/card-stock` | 부팅 시 잔량 복원 |
| `PATCH /v1/print/{id}` | `printType` 동봉 → 서버 차감, 응답 `cardCurrentCount`로 로컬 보정 |

- **적재 단일 진입점 격리** — 다이얼로그·검증·API 호출·로컬 반영을 `card_stock_action.dart` 한 곳에. 가산(recharge) 방식으로 전환될 여지가 남아 있어 그때 이 파일만 교체하면 되도록 한 구조
- **부팅 복원** — 기기당 1회. 잔량이 있으면 단면 모드 자동 선택, 없으면 관리자 수동 입력 대기
- **자가 치유** — 로컬 차감 시점은 기존 그대로(결제 승인 시). 서버는 인쇄 COMPLETED에서 차감하고, 그 응답으로 로컬을 보정
- **단면 소진 → 양면 자동 전환 판정은 무변경** — 네트워크와 무관하게 동작해야 하므로 로컬 카운터가 계속 판정 주체
- 서버 조회 완료 전 수량 `-` 표시, 적재 입력 `0~300` 범위 검증

## 크래시·버그 수정

- **비활성 위젯 context 조회 크래시** — 확인 다이얼로그가 호출 화면의 context를 참조해, 화면 pop 후 닫히는 애니메이션 중 `Theme.of()`가 죽은 context를 조회. 출력 내역 → 관리자 모드 복귀에서 재현
- **빈 목록 페이지네이션 크래시** — `totalCount` 0이면 `clamp(1, 0)`이 `ArgumentError`. 출력 내역이 비어 있으면 항상 재현
- **기기번호 미등록 시 출력 내역** — `kioskMachineId` 0으로 조회하면 200에 빈 목록이 돌아와 '주문 없음'과 '기기 미등록'을 구분할 수 없던 문제
- **기기 전환 시 잔량 잔류** — 새 기기 이력이 0이면 이전 기기 잔량이 화면에 남아, 카드 없는 기기에서 단면 인쇄를 시도하던 문제

---

## 검증

- `flutter analyze lib/` 에러 0건
- 실기기 검증 **미완** — 배포 후 QA 필요

## QA 확인 필요

- **양면 인쇄 연속 3장** — 양면 응답엔 `cardCurrentCount`가 없습니다(NON_NULL 직렬화). 파싱 예외가 나면 모든 양면 인쇄가 실패합니다
- **이력 없는 신규 기기 부팅** — 배포 직후 전 기기의 상태입니다. 양면 강제 전환이 일어나면 안 됩니다
- **잔량 0에서 단면 인쇄** — 서버가 409가 아니라 200 + `cardCurrentCount: 0`으로 응답하는지
- **기기 전환** — 미리보기에서 기기번호를 바꿨을 때 이전 기기 잔량이 남지 않는지

## 서버팀 확인 필요 (JKLI-253)

- KIOSK 머신 `cardCapacity` 실기기 값 — 미설정이면 상한 검증이 0~300만 적용
- `cardCapacity` 초과 요청을 400으로 거부하는지 클램프하는지
- **서버 선배포 권장** — 앱이 먼저 배포되면 적재 시마다 "서버 기록 실패" 다이얼로그가 노출됩니다(동작 자체는 현행과 동일)

## 범위 외

오프라인 재전송 큐는 3단계(JKLI-255) 범위로 제외했습니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
